### PR TITLE
Fix: Update aiohttp version in docs-requirements

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -11,7 +11,7 @@ django>=2.2
 
 # Required by instrumentation and exporter packages
 aio_pika~=7.2.0
-aiohttp~=3.0
+aiohttp>=3.9.3,<4.0.0
 aiokafka~=0.11.0
 aiopg>=0.13.0,<1.3.0
 asyncpg>=0.12.0


### PR DESCRIPTION
I've updated the aiohttp dependency in `docs-requirements.txt` to `_GTE_3.9.3,<4.0.0`. This addresses a security vulnerability (CWE-770, CVE-2024-23334) present in earlier 3.x versions of aiohttp, specifically related to the proxy CONNECT request handler.

The previous specifier `aiohttp~=3.0` allowed the installation of vulnerable versions. This change ensures that a patched version of aiohttp is used when you install dependencies for documentation generation or other development purposes that utilize `docs-requirements.txt`.