### PR TITLE
bugfix: fix spell mistake in pyproject.toml.

### DIFF
--- a/instrumentation-genai/opentelemetry-instrumentation-agentscope/pyproject.toml
+++ b/instrumentation-genai/opentelemetry-instrumentation-agentscope/pyproject.toml
@@ -58,4 +58,4 @@ include = [
 packages = ["src/opentelemetry"]
 
 [project.entry-points.opentelemetry_instrumentor]
-agentscope = "opentelemetry.instrumentation.agengscope:AgentScopeInstrumentor"
+agentscope = "opentelemetry.instrumentation.agentscope:AgentScopeInstrumentor"


### PR DESCRIPTION
Fix a spell mistake in "pyproject.toml", which leads to zero-code instrumentation falied for agentscope.