### PR TITLE
fix: correct timestamp calculation in dify instrumentation

### DIFF
--- a/instrumentation-loongsuite/loongsuite-instrumentation-dify/src/opentelemetry/instrumentation/dify/utils.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-dify/src/opentelemetry/instrumentation/dify/utils.py
@@ -5,11 +5,7 @@ from datetime import datetime
 def get_timestamp_from_datetime_attr(obj, attr_name):
     attr_value = getattr(obj, attr_name, None)
     if attr_value is not None and isinstance(attr_value, datetime):
-        timestamp = (
-            attr_value.timestamp() * 1_000_000_000
-            + attr_value.microsecond * 1_000
-        )
-        return int(timestamp)
+        return int(attr_value.timestamp() * 1_000_000_000)
     return time.time_ns()
 
 


### PR DESCRIPTION
# Description

Remove duplicate microsecond calculation. The `datetime.timestamp()` method already includes microseconds in its decimal portion.

<img width="1728" height="446" alt="Clipboard_Screenshot_1764649023" src="https://github.com/user-attachments/assets/7e02e8b0-5adc-4191-8bb9-df96162e22aa" />


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
