### PR TITLE
Cherry-pick from a649408 - requirements: stick with older setuptools for packages still using pkg_resources

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -2,6 +2,9 @@ sphinx==7.1.2
 sphinx-rtd-theme==2.0.0rc4
 sphinx-autodoc-typehints==1.25.2
 
+# Required to avoid breakages for pyramid and cassandra packages
+setuptools<82.0.0
+
 # Required by opentelemetry-instrumentation
 fastapi>=0.65.2
 pymemcache~=1.3

--- a/instrumentation/opentelemetry-instrumentation-pyramid/test-requirements.txt
+++ b/instrumentation/opentelemetry-instrumentation-pyramid/test-requirements.txt
@@ -10,6 +10,7 @@ pluggy==1.5.0
 py-cpuinfo==9.0.0
 pyramid==2.0.2
 pytest==7.4.4
+setuptools==81.0.0
 tomli==2.0.1
 translationstring==1.4
 typing_extensions==4.12.2

--- a/test-constraints.txt
+++ b/test-constraints.txt
@@ -1,0 +1,3 @@
+# Source install of cassandra-driver requires pkg_resources, if
+# it's not found the install script is broken and fails to build
+setuptools<82.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -750,6 +750,8 @@ setenv =
   CORE_REPO_SHA={env:CORE_REPO_SHA:main}
   CORE_REPO=git+https://github.com/open-telemetry/opentelemetry-python.git@{env:CORE_REPO_SHA}
   UV_CONFIG_FILE={toxinidir}/tox-uv.toml
+  PIP_CONSTRAINTS={toxinidir}/test-constraints.txt
+  UV_BUILD_CONSTRAINT={toxinidir}/test-constraints.txt
 
 commands_pre =
 ; In order to get a health coverage report,


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
