### PR TITLE
feat(qwen-agent): add instrumentation for Qwen-Agent

### DIFF
--- a/.github/workflows/loongsuite_lint_0.yml
+++ b/.github/workflows/loongsuite_lint_0.yml
@@ -146,6 +146,25 @@ jobs:
       - name: Run tests
         run: tox -c tox-loongsuite.ini -e lint-loongsuite-instrumentation-langgraph
 
+  lint-loongsuite-instrumentation-qwen-agent:
+    name: LoongSuite loongsuite-instrumentation-qwen-agent
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install tox
+        run: pip install tox-uv
+
+      - name: Run tests
+        run: tox -c tox-loongsuite.ini -e lint-loongsuite-instrumentation-qwen-agent
+
   lint-loongsuite-instrumentation-mem0:
     name: LoongSuite loongsuite-instrumentation-mem0
     runs-on: ubuntu-latest

--- a/.github/workflows/loongsuite_test_0.yml
+++ b/.github/workflows/loongsuite_test_0.yml
@@ -1096,6 +1096,196 @@ jobs:
       - name: Run tests
         run: tox -c tox-loongsuite.ini -e py313-test-loongsuite-instrumentation-langgraph-latest -- -ra
 
+  py39-test-loongsuite-instrumentation-qwen-agent-oldest_ubuntu-latest:
+    name: LoongSuite loongsuite-instrumentation-qwen-agent-oldest 3.9 Ubuntu
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+
+      - name: Install tox
+        run: pip install tox-uv
+
+      - name: Run tests
+        run: tox -c tox-loongsuite.ini -e py39-test-loongsuite-instrumentation-qwen-agent-oldest -- -ra
+
+  py39-test-loongsuite-instrumentation-qwen-agent-latest_ubuntu-latest:
+    name: LoongSuite loongsuite-instrumentation-qwen-agent-latest 3.9 Ubuntu
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+
+      - name: Install tox
+        run: pip install tox-uv
+
+      - name: Run tests
+        run: tox -c tox-loongsuite.ini -e py39-test-loongsuite-instrumentation-qwen-agent-latest -- -ra
+
+  py310-test-loongsuite-instrumentation-qwen-agent-oldest_ubuntu-latest:
+    name: LoongSuite loongsuite-instrumentation-qwen-agent-oldest 3.10 Ubuntu
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install tox
+        run: pip install tox-uv
+
+      - name: Run tests
+        run: tox -c tox-loongsuite.ini -e py310-test-loongsuite-instrumentation-qwen-agent-oldest -- -ra
+
+  py310-test-loongsuite-instrumentation-qwen-agent-latest_ubuntu-latest:
+    name: LoongSuite loongsuite-instrumentation-qwen-agent-latest 3.10 Ubuntu
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install tox
+        run: pip install tox-uv
+
+      - name: Run tests
+        run: tox -c tox-loongsuite.ini -e py310-test-loongsuite-instrumentation-qwen-agent-latest -- -ra
+
+  py311-test-loongsuite-instrumentation-qwen-agent-oldest_ubuntu-latest:
+    name: LoongSuite loongsuite-instrumentation-qwen-agent-oldest 3.11 Ubuntu
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install tox
+        run: pip install tox-uv
+
+      - name: Run tests
+        run: tox -c tox-loongsuite.ini -e py311-test-loongsuite-instrumentation-qwen-agent-oldest -- -ra
+
+  py311-test-loongsuite-instrumentation-qwen-agent-latest_ubuntu-latest:
+    name: LoongSuite loongsuite-instrumentation-qwen-agent-latest 3.11 Ubuntu
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install tox
+        run: pip install tox-uv
+
+      - name: Run tests
+        run: tox -c tox-loongsuite.ini -e py311-test-loongsuite-instrumentation-qwen-agent-latest -- -ra
+
+  py312-test-loongsuite-instrumentation-qwen-agent-oldest_ubuntu-latest:
+    name: LoongSuite loongsuite-instrumentation-qwen-agent-oldest 3.12 Ubuntu
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install tox
+        run: pip install tox-uv
+
+      - name: Run tests
+        run: tox -c tox-loongsuite.ini -e py312-test-loongsuite-instrumentation-qwen-agent-oldest -- -ra
+
+  py312-test-loongsuite-instrumentation-qwen-agent-latest_ubuntu-latest:
+    name: LoongSuite loongsuite-instrumentation-qwen-agent-latest 3.12 Ubuntu
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install tox
+        run: pip install tox-uv
+
+      - name: Run tests
+        run: tox -c tox-loongsuite.ini -e py312-test-loongsuite-instrumentation-qwen-agent-latest -- -ra
+
+  py313-test-loongsuite-instrumentation-qwen-agent-oldest_ubuntu-latest:
+    name: LoongSuite loongsuite-instrumentation-qwen-agent-oldest 3.13 Ubuntu
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install tox
+        run: pip install tox-uv
+
+      - name: Run tests
+        run: tox -c tox-loongsuite.ini -e py313-test-loongsuite-instrumentation-qwen-agent-oldest -- -ra
+
+  py313-test-loongsuite-instrumentation-qwen-agent-latest_ubuntu-latest:
+    name: LoongSuite loongsuite-instrumentation-qwen-agent-latest 3.13 Ubuntu
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install tox
+        run: pip install tox-uv
+
+      - name: Run tests
+        run: tox -c tox-loongsuite.ini -e py313-test-loongsuite-instrumentation-qwen-agent-latest -- -ra
+
   py310-test-loongsuite-instrumentation-mem0-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-mem0-oldest 3.10 Ubuntu
     runs-on: ubuntu-latest

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/CHANGELOG.md
@@ -1,13 +1,15 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
 ## Unreleased
+
+## Version 0.4.0.dev
 
 ### Added
 
-- Initial release of `loongsuite-instrumentation-qwen-agent`
-- Instrumentation for `Agent.run()` (invoke_agent spans; `run_nonstream()` is covered via its internal `run()` call — no duplicate span)
-- Instrumentation for `BaseChatModel.chat()` (LLM spans)
-- Instrumentation for `Agent._call_tool()` (execute_tool spans)
-- Support for streaming and non-streaming LLM responses
-- Message conversion from qwen-agent types to GenAI semantic conventions
-- Provider detection for DashScope, OpenAI, and Azure backends
+- Initial implementation of Qwen-Agent instrumentation
+  ([#154](https://github.com/alibaba/loongsuite-python-agent/pull/154))

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## Unreleased
+
+### Added
+
+- Initial release of `loongsuite-instrumentation-qwen-agent`
+- Instrumentation for `Agent.run()` (invoke_agent spans; `run_nonstream()` is covered via its internal `run()` call — no duplicate span)
+- Instrumentation for `BaseChatModel.chat()` (LLM spans)
+- Instrumentation for `Agent._call_tool()` (execute_tool spans)
+- Support for streaming and non-streaming LLM responses
+- Message conversion from qwen-agent types to GenAI semantic conventions
+- Provider detection for DashScope, OpenAI, and Azure backends

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/README.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/README.md
@@ -10,11 +10,10 @@ opentelemetry-bootstrap -a install
 
 pip install "qwen-agent >= 0.0.20"
 
+pip install ./util/opentelemetry-util-genai
+
 # Install this instrumentation (from the LoongSuite repo)
 pip install ./instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent
-
-# Required: GenAI utilities used by the instrumentation
-pip install ./util/opentelemetry-util-genai
 ```
 
 Published package name:

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/README.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/README.md
@@ -1,0 +1,109 @@
+# OpenTelemetry Qwen-Agent Instrumentation
+
+OpenTelemetry instrumentation for the [Qwen-Agent](https://github.com/QwenLM/Qwen-Agent) framework.
+
+## Installation
+
+```bash
+pip install opentelemetry-distro opentelemetry-exporter-otlp
+opentelemetry-bootstrap -a install
+
+pip install "qwen-agent >= 0.0.20"
+
+# Install this instrumentation (from the LoongSuite repo)
+pip install ./instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent
+
+# Required: GenAI utilities used by the instrumentation
+pip install ./util/opentelemetry-util-genai
+```
+
+Published package name:
+
+```bash
+pip install loongsuite-instrumentation-qwen-agent
+```
+
+## Usage
+
+### Auto-instrumentation
+
+With `loongsuite-instrumentation-qwen-agent` installed, the `opentelemetry_instrumentor` entry point `qwen_agent` is registered for use with the OpenTelemetry distro.
+
+```bash
+opentelemetry-instrument \
+    --traces_exporter console \
+    python your_qwen_agent_app.py
+```
+
+### Manual instrumentation
+
+```python
+from opentelemetry.instrumentation.qwen_agent import QwenAgentInstrumentor
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+from qwen_agent.agents import Assistant
+
+provider = TracerProvider()
+provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+
+QwenAgentInstrumentor().instrument(tracer_provider=provider)
+
+bot = Assistant(
+    llm={"model": "qwen-max", "model_type": "qwen_dashscope"},
+    name="my-assistant",
+)
+for _ in bot.run([{"role": "user", "content": "Hello!"}]):
+    pass
+
+QwenAgentInstrumentor().uninstrument()
+```
+
+## Configuration
+
+### Export to an OTLP backend
+
+```bash
+export OTEL_SERVICE_NAME=my-qwen-agent-app
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=<trace_endpoint>
+# Optional: metrics / logs if you configure exporters globally
+export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=<metrics_endpoint>
+
+opentelemetry-instrument python your_app.py
+```
+
+### GenAI semantic conventions and content capture
+
+```bash
+# Enable experimental GenAI semantic conventions (recommended for this instrumentation)
+export OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental
+
+# Message content capture (same env vars as other GenAI instrumentations in this repo)
+export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=SPAN_ONLY
+# EVENT_ONLY | SPAN_AND_EVENT | NO_CONTENT
+```
+
+## Supported components
+
+| Area | Instrumented API | Span / operation |
+|------|------------------|------------------|
+| Agent | `Agent.run` | `invoke_agent` |
+| LLM | `BaseChatModel.chat` | `chat` |
+| ReAct | `Agent._call_llm` | `react step` (agents with tools) |
+| Tools | `Agent._call_tool` | `execute_tool` |
+
+`Agent.run_nonstream()` is not wrapped separately; it calls `run()` internally, so you still get a single `invoke_agent` span per run.
+
+**Model backends** (inferred from `model_type` / class name): DashScope, OpenAI-compatible APIs, Azure OpenAI, and other Qwen-Agent–supported backends.
+
+## Visualization
+
+Export telemetry to:
+
+- [Alibaba Cloud ARMS / Managed Service for OpenTelemetry](https://www.aliyun.com/product/xtrace)
+- [AgentScope Studio](https://github.com/agentscope-ai/agentscope-studio) or any OTLP-compatible collector
+- Any OpenTelemetry-compatible backend (Jaeger, Zipkin, etc.)
+
+## License
+
+Apache License 2.0

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/pyproject.toml
@@ -5,12 +5,13 @@ build-backend = "hatchling.build"
 [project]
 name = "loongsuite-instrumentation-qwen-agent"
 dynamic = ["version"]
-description = "OpenTelemetry Qwen-Agent Instrumentation"
+description = "LoongSuite Qwen-Agent Instrumentation"
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.9"
 authors = [
-    { name = "LoongSuite Python Agent Authors", email = "qp467389@alibaba-inc.com" },
+    { name = "LoongSuite Python Agent Authors", email = "caishipeng.csp@alibaba-inc.com" },
+    { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -49,7 +50,7 @@ test = [
 qwen_agent = "opentelemetry.instrumentation.qwen_agent:QwenAgentInstrumentor"
 
 [project.urls]
-Homepage = "https://github.com/alibaba/loongsuite-python-agent"
+Homepage = "https://github.com/alibaba/loongsuite-python-agent/tree/main/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent"
 Repository = "https://github.com/alibaba/loongsuite-python-agent"
 
 [tool.hatch.version]

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/pyproject.toml
@@ -1,0 +1,65 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "loongsuite-instrumentation-qwen-agent"
+dynamic = ["version"]
+description = "OpenTelemetry Qwen-Agent Instrumentation"
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.9"
+authors = [
+    { name = "LoongSuite Python Agent Authors", email = "qp467389@alibaba-inc.com" },
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+]
+dependencies = [
+    "opentelemetry-api ~= 1.37",
+    "opentelemetry-instrumentation >= 0.58b0",
+    "opentelemetry-semantic-conventions >= 0.58b0",
+    "opentelemetry-util-genai",
+    "wrapt",
+]
+
+[project.optional-dependencies]
+instruments = [
+    "qwen-agent >= 0.0.20",
+]
+
+test = [
+    "pytest ~= 8.0",
+    "pytest-cov ~= 4.1.0",
+    "qwen-agent >= 0.0.20",
+    "vcrpy",
+    "pytest-vcr",
+]
+
+[project.entry-points.opentelemetry_instrumentor]
+qwen_agent = "opentelemetry.instrumentation.qwen_agent:QwenAgentInstrumentor"
+
+[project.urls]
+Homepage = "https://github.com/alibaba/loongsuite-python-agent"
+Repository = "https://github.com/alibaba/loongsuite-python-agent"
+
+[tool.hatch.version]
+path = "src/opentelemetry/instrumentation/qwen_agent/version.py"
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "/src",
+    "/tests",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/opentelemetry"]

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/__init__.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/__init__.py
@@ -1,0 +1,191 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Qwen-Agent instrumentation supporting `qwen-agent >= 0.0.20`.
+
+Usage
+-----
+.. code:: python
+
+    from opentelemetry.instrumentation.qwen_agent import QwenAgentInstrumentor
+    from qwen_agent.agents import Assistant
+
+    QwenAgentInstrumentor().instrument()
+
+    bot = Assistant(
+        llm={'model': 'qwen-max', 'model_type': 'qwen_dashscope'},
+        name='my-assistant',
+        system_message='You are a helpful assistant.',
+    )
+
+    messages = [{'role': 'user', 'content': 'Hello!'}]
+    for responses in bot.run(messages):
+        pass
+
+    QwenAgentInstrumentor().uninstrument()
+
+API
+---
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Collection
+
+from wrapt import wrap_function_wrapper
+
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.qwen_agent.package import _instruments
+from opentelemetry.instrumentation.qwen_agent.patch import (
+    wrap_agent_call_llm,
+    wrap_agent_call_tool,
+    wrap_agent_run,
+    wrap_chat_model_chat,
+)
+from opentelemetry.instrumentation.qwen_agent.version import __version__
+from opentelemetry.instrumentation.utils import unwrap
+from opentelemetry.util.genai.extended_handler import ExtendedTelemetryHandler
+
+logger = logging.getLogger(__name__)
+
+_AGENT_MODULE = "qwen_agent.agent"
+_LLM_MODULE = "qwen_agent.llm.base"
+
+__all__ = ["QwenAgentInstrumentor", "__version__"]
+
+
+class QwenAgentInstrumentor(BaseInstrumentor):
+    """OpenTelemetry instrumentor for Qwen-Agent framework.
+
+    Instruments the following components:
+    - Agent.run(): Agent execution spans (invoke_agent)
+      (run_nonstream is NOT wrapped separately — it calls run() internally,
+       so the invoke_agent span is created once by the run() wrapper.)
+    - Agent._call_llm(): ReAct step spans (only for agents with tools)
+    - BaseChatModel.chat(): LLM call spans (chat)
+    - Agent._call_tool(): Tool execution spans (execute_tool)
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._handler = None
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
+
+    def _instrument(self, **kwargs: Any) -> None:
+        """Enable Qwen-Agent instrumentation."""
+        tracer_provider = kwargs.get("tracer_provider")
+        meter_provider = kwargs.get("meter_provider")
+        logger_provider = kwargs.get("logger_provider")
+
+        self._handler = ExtendedTelemetryHandler(
+            tracer_provider=tracer_provider,
+            meter_provider=meter_provider,
+            logger_provider=logger_provider,
+        )
+
+        # Instrument Agent.run() - agent execution entry point (generator)
+        try:
+            wrap_function_wrapper(
+                module=_AGENT_MODULE,
+                name="Agent.run",
+                wrapper=lambda wrapped, instance, args, kwargs: wrap_agent_run(
+                    wrapped, instance, args, kwargs, handler=self._handler
+                ),
+            )
+            logger.debug("Instrumented Agent.run")
+        except Exception as e:
+            logger.warning(f"Failed to instrument Agent.run: {e}")
+
+        # Note: Agent.run_nonstream() is NOT wrapped separately.
+        # It internally calls self.run(), which is already instrumented above,
+        # so a single invoke_agent span is created per agent execution.
+
+        # Instrument BaseChatModel.chat() - LLM calls
+        try:
+            wrap_function_wrapper(
+                module=_LLM_MODULE,
+                name="BaseChatModel.chat",
+                wrapper=lambda wrapped, instance, args, kwargs: wrap_chat_model_chat(
+                    wrapped, instance, args, kwargs, handler=self._handler
+                ),
+            )
+            logger.debug("Instrumented BaseChatModel.chat")
+        except Exception as e:
+            logger.warning(f"Failed to instrument BaseChatModel.chat: {e}")
+
+        # Instrument Agent._call_llm() - ReAct step tracking (only fires for agents with tools)
+        try:
+            wrap_function_wrapper(
+                module=_AGENT_MODULE,
+                name="Agent._call_llm",
+                wrapper=lambda wrapped, instance, args, kwargs: wrap_agent_call_llm(
+                    wrapped, instance, args, kwargs, handler=self._handler
+                ),
+            )
+            logger.debug("Instrumented Agent._call_llm")
+        except Exception as e:
+            logger.warning(f"Failed to instrument Agent._call_llm: {e}")
+
+        # Instrument Agent._call_tool() - tool execution
+        try:
+            wrap_function_wrapper(
+                module=_AGENT_MODULE,
+                name="Agent._call_tool",
+                wrapper=lambda wrapped, instance, args, kwargs: wrap_agent_call_tool(
+                    wrapped, instance, args, kwargs, handler=self._handler
+                ),
+            )
+            logger.debug("Instrumented Agent._call_tool")
+        except Exception as e:
+            logger.warning(f"Failed to instrument Agent._call_tool: {e}")
+
+    def _uninstrument(self, **kwargs: Any) -> None:
+        """Disable Qwen-Agent instrumentation."""
+        try:
+            import qwen_agent.agent  # noqa: PLC0415
+
+            unwrap(qwen_agent.agent.Agent, "run")
+            logger.debug("Uninstrumented Agent.run")
+        except Exception as e:
+            logger.warning(f"Failed to uninstrument Agent.run: {e}")
+
+        try:
+            import qwen_agent.llm.base  # noqa: PLC0415
+
+            unwrap(qwen_agent.llm.base.BaseChatModel, "chat")
+            logger.debug("Uninstrumented BaseChatModel.chat")
+        except Exception as e:
+            logger.warning(f"Failed to uninstrument BaseChatModel.chat: {e}")
+
+        try:
+            import qwen_agent.agent  # noqa: PLC0415
+
+            unwrap(qwen_agent.agent.Agent, "_call_llm")
+            logger.debug("Uninstrumented Agent._call_llm")
+        except Exception as e:
+            logger.warning(f"Failed to uninstrument Agent._call_llm: {e}")
+
+        try:
+            import qwen_agent.agent  # noqa: PLC0415
+
+            unwrap(qwen_agent.agent.Agent, "_call_tool")
+            logger.debug("Uninstrumented Agent._call_tool")
+        except Exception as e:
+            logger.warning(f"Failed to uninstrument Agent._call_tool: {e}")
+
+        self._handler = None

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/__init__.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/__init__.py
@@ -120,8 +120,10 @@ class QwenAgentInstrumentor(BaseInstrumentor):
             wrap_function_wrapper(
                 module=_LLM_MODULE,
                 name="BaseChatModel.chat",
-                wrapper=lambda wrapped, instance, args, kwargs: wrap_chat_model_chat(
-                    wrapped, instance, args, kwargs, handler=self._handler
+                wrapper=lambda wrapped, instance, args, kwargs: (
+                    wrap_chat_model_chat(
+                        wrapped, instance, args, kwargs, handler=self._handler
+                    )
                 ),
             )
             logger.debug("Instrumented BaseChatModel.chat")
@@ -133,8 +135,10 @@ class QwenAgentInstrumentor(BaseInstrumentor):
             wrap_function_wrapper(
                 module=_AGENT_MODULE,
                 name="Agent._call_llm",
-                wrapper=lambda wrapped, instance, args, kwargs: wrap_agent_call_llm(
-                    wrapped, instance, args, kwargs, handler=self._handler
+                wrapper=lambda wrapped, instance, args, kwargs: (
+                    wrap_agent_call_llm(
+                        wrapped, instance, args, kwargs, handler=self._handler
+                    )
                 ),
             )
             logger.debug("Instrumented Agent._call_llm")
@@ -146,8 +150,10 @@ class QwenAgentInstrumentor(BaseInstrumentor):
             wrap_function_wrapper(
                 module=_AGENT_MODULE,
                 name="Agent._call_tool",
-                wrapper=lambda wrapped, instance, args, kwargs: wrap_agent_call_tool(
-                    wrapped, instance, args, kwargs, handler=self._handler
+                wrapper=lambda wrapped, instance, args, kwargs: (
+                    wrap_agent_call_tool(
+                        wrapped, instance, args, kwargs, handler=self._handler
+                    )
                 ),
             )
             logger.debug("Instrumented Agent._call_tool")

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/package.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/package.py
@@ -1,0 +1,17 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+_instruments = ("qwen-agent >= 0.0.20",)
+
+_supports_metrics = False

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/patch.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/patch.py
@@ -30,10 +30,10 @@ import timeit
 from contextvars import ContextVar
 from typing import Any, Iterator, Optional
 
-from opentelemetry.util.genai._extended_common.common_types import (
+from opentelemetry.util.genai.extended_handler import ExtendedTelemetryHandler
+from opentelemetry.util.genai.extended_types import (
     ReactStepInvocation,
 )
-from opentelemetry.util.genai.extended_handler import ExtendedTelemetryHandler
 from opentelemetry.util.genai.types import Error
 
 from .utils import (
@@ -59,9 +59,13 @@ _react_step_counter: ContextVar[int] = ContextVar(
 
 # Reentrancy guards to prevent duplicate spans when Agent/BaseChatModel
 # are abstract classes and subclass calls super() (Proxy/Wrapper scenarios).
-_in_agent_run: ContextVar[bool] = ContextVar("_qwen_in_agent_run", default=False)
+_in_agent_run: ContextVar[bool] = ContextVar(
+    "_qwen_in_agent_run", default=False
+)
 _in_chat: ContextVar[bool] = ContextVar("_qwen_in_chat", default=False)
-_in_call_tool: ContextVar[bool] = ContextVar("_qwen_in_call_tool", default=False)
+_in_call_tool: ContextVar[bool] = ContextVar(
+    "_qwen_in_call_tool", default=False
+)
 
 
 def _close_active_react_step(handler: ExtendedTelemetryHandler) -> None:
@@ -196,7 +200,9 @@ def wrap_chat_model_chat(
                 and not isinstance(result, list)
             ):
                 # Streaming: wrap the iterator
-                return _wrap_streaming_llm_response(result, invocation, handler)
+                return _wrap_streaming_llm_response(
+                    result, invocation, handler
+                )
             else:
                 # Non-streaming: result is List[Message]
                 if result:
@@ -332,7 +338,9 @@ def wrap_agent_call_tool(
     tool_guard_token = _in_call_tool.set(True)
 
     try:
-        tool_name = args[0] if args else kwargs.get("tool_name", "unknown_tool")
+        tool_name = (
+            args[0] if args else kwargs.get("tool_name", "unknown_tool")
+        )
         tool_args = args[1] if len(args) > 1 else kwargs.get("tool_args", "{}")
 
         # Get tool instance for description

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/patch.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/patch.py
@@ -1,0 +1,304 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Patch functions for Qwen-Agent instrumentation.
+
+Wraps key qwen-agent methods to generate OpenTelemetry spans:
+- Agent.run() -> invoke_agent spans
+  (Agent.run_nonstream() is NOT wrapped separately; it calls self.run()
+   internally, so a single invoke_agent span is produced by this wrapper.)
+- BaseChatModel.chat() -> LLM spans
+- Agent._call_tool() -> execute_tool spans
+- Agent._call_llm() -> react step spans (only for ReAct agents with tools)
+"""
+
+from __future__ import annotations
+
+import logging
+import timeit
+from contextvars import ContextVar
+from typing import Any, Iterator, Optional
+
+from opentelemetry.util.genai._extended_common.common_types import (
+    ReactStepInvocation,
+)
+from opentelemetry.util.genai.extended_handler import ExtendedTelemetryHandler
+from opentelemetry.util.genai.types import Error
+
+from .utils import (
+    convert_qwen_messages_to_output_messages,
+    create_agent_invocation,
+    create_llm_invocation,
+    create_tool_invocation,
+)
+
+logger = logging.getLogger(__name__)
+
+# ContextVar guards for ReAct step tracking.
+# _react_mode: True when the current agent run has tools (ReAct-capable).
+# _react_step_invocation: the currently active (open) ReactStepInvocation.
+# _react_step_counter: 1-based step counter within the current agent run.
+_react_mode: ContextVar[bool] = ContextVar("qwen_react_mode", default=False)
+_react_step_invocation: ContextVar[Optional[ReactStepInvocation]] = ContextVar(
+    "qwen_react_step_invocation", default=None
+)
+_react_step_counter: ContextVar[int] = ContextVar(
+    "qwen_react_step_counter", default=0
+)
+
+
+def _close_active_react_step(handler: ExtendedTelemetryHandler) -> None:
+    """Close the currently active react_step span, if any."""
+    prev = _react_step_invocation.get()
+    if prev is not None:
+        try:
+            handler.stop_react_step(prev)
+        except Exception as e:
+            logger.debug(f"Failed to close react step: {e}")
+        _react_step_invocation.set(None)
+
+
+def wrap_agent_run(wrapped, instance, args, kwargs, handler: ExtendedTelemetryHandler):
+    """Wrapper for Agent.run() to create invoke_agent spans.
+
+    Agent.run() is a generator that yields List[Message].
+    We wrap it to create an agent span covering the full execution.
+
+    Also sets up the ReAct mode guard: if the agent has tools in its
+    function_map, _react_mode is set to True so that wrap_agent_call_llm
+    will create react_step spans for each ReAct iteration.
+    """
+    messages = args[0] if args else kwargs.get("messages", [])
+
+    try:
+        invocation = create_agent_invocation(instance, messages)
+    except Exception as e:
+        logger.debug(f"Failed to create agent invocation: {e}")
+        yield from wrapped(*args, **kwargs)
+        return
+
+    # Set up ReAct mode guard: only agents with tools get react_step spans.
+    is_react = bool(getattr(instance, "function_map", {}))
+    mode_token = _react_mode.set(is_react)
+    counter_token = _react_step_counter.set(0)
+    step_token = _react_step_invocation.set(None)
+
+    handler.start_invoke_agent(invocation)
+
+    try:
+        last_response = None
+        for response in wrapped(*args, **kwargs):
+            last_response = response
+            yield response
+
+        # Extract output from last yielded response
+        if last_response:
+            invocation.output_messages = convert_qwen_messages_to_output_messages(
+                last_response
+            )
+
+        # Close the last react_step span before closing invoke_agent.
+        _close_active_react_step(handler)
+
+        handler.stop_invoke_agent(invocation)
+
+    except Exception as e:
+        # Close any open react_step on error path too.
+        _close_active_react_step(handler)
+        handler.fail_invoke_agent(
+            invocation, Error(message=str(e), type=type(e))
+        )
+        raise
+    finally:
+        # Restore ContextVars to pre-run state.
+        _react_step_counter.reset(counter_token)
+        _react_step_invocation.reset(step_token)
+        _react_mode.reset(mode_token)
+
+
+def wrap_chat_model_chat(
+    wrapped, instance, args, kwargs, handler: ExtendedTelemetryHandler
+):
+    """Wrapper for BaseChatModel.chat() to create LLM spans.
+
+    chat() can return:
+    - List[Message] (non-stream)
+    - Iterator[List[Message]] (stream)
+    """
+    messages = args[0] if args else kwargs.get("messages", [])
+    functions = kwargs.get("functions") if len(args) < 2 else (args[1] if len(args) > 1 else None)
+    stream = kwargs.get("stream", True)
+    extra_generate_cfg = kwargs.get("extra_generate_cfg")
+
+    try:
+        invocation = create_llm_invocation(
+            instance, messages, functions, stream, extra_generate_cfg
+        )
+    except Exception as e:
+        logger.debug(f"Failed to create LLM invocation: {e}")
+        return wrapped(*args, **kwargs)
+
+    handler.start_llm(invocation)
+
+    try:
+        result = wrapped(*args, **kwargs)
+
+        if stream and hasattr(result, "__iter__") and not isinstance(result, list):
+            # Streaming: wrap the iterator
+            return _wrap_streaming_llm_response(result, invocation, handler)
+        else:
+            # Non-streaming: result is List[Message]
+            if result:
+                invocation.output_messages = convert_qwen_messages_to_output_messages(
+                    result
+                )
+                invocation.response_model_name = invocation.request_model
+                invocation.finish_reasons = ["stop"]
+
+                # Check for function calls in output
+                for msg in result:
+                    fc = msg.function_call if hasattr(msg, "function_call") else msg.get("function_call") if isinstance(msg, dict) else None
+                    if fc:
+                        invocation.finish_reasons = ["tool_calls"]
+                        break
+
+            handler.stop_llm(invocation)
+            return result
+
+    except Exception as e:
+        handler.fail_llm(invocation, Error(message=str(e), type=type(e)))
+        raise
+
+
+def _wrap_streaming_llm_response(
+    response_iter: Iterator, invocation: Any, handler: ExtendedTelemetryHandler
+) -> Iterator:
+    """Wrap a streaming LLM response iterator to capture output on completion."""
+    try:
+        last_response = None
+        first_token = True
+        for response in response_iter:
+            if first_token:
+                invocation.monotonic_first_token_s = timeit.default_timer()
+                first_token = False
+            last_response = response
+            yield response
+
+        if last_response:
+            invocation.output_messages = convert_qwen_messages_to_output_messages(
+                last_response
+            )
+            invocation.response_model_name = invocation.request_model
+            invocation.finish_reasons = ["stop"]
+
+            # Check for function calls
+            for msg in last_response:
+                fc = msg.function_call if hasattr(msg, "function_call") else msg.get("function_call") if isinstance(msg, dict) else None
+                if fc:
+                    invocation.finish_reasons = ["tool_calls"]
+                    break
+
+        handler.stop_llm(invocation)
+
+    except Exception as e:
+        handler.fail_llm(invocation, Error(message=str(e), type=type(e)))
+        raise
+
+
+def wrap_agent_call_llm(
+    wrapped, instance, args, kwargs, handler: ExtendedTelemetryHandler
+):
+    """Wrapper for Agent._call_llm() to create react_step spans.
+
+    Only creates react_step spans when _react_mode is True (i.e. the
+    current agent has tools in its function_map).  This ensures that
+    simple agents (no tools) are completely unaffected.
+
+    Each call to _call_llm corresponds to one iteration of the ReAct
+    while-loop.  The react_step span is NOT closed here — it stays
+    open so that subsequent _call_tool invocations become children of
+    this react_step.  The span is closed either:
+    - by the next wrap_agent_call_llm call (start of next iteration), or
+    - by wrap_agent_run when the agent run finishes.
+    """
+    if not _react_mode.get():
+        # Not a ReAct agent — transparent pass-through.
+        return wrapped(*args, **kwargs)
+
+    # Close the previous react_step (if any) before starting a new one.
+    _close_active_react_step(handler)
+
+    # Increment step counter (1-based).
+    step_num = _react_step_counter.get() + 1
+    _react_step_counter.set(step_num)
+
+    step_invocation = ReactStepInvocation(round=step_num)
+
+    try:
+        handler.start_react_step(step_invocation)
+    except Exception as e:
+        logger.debug(f"Failed to start react step: {e}")
+        return wrapped(*args, **kwargs)
+
+    _react_step_invocation.set(step_invocation)
+
+    # Call original _call_llm — its return value is a generator (or list).
+    # The chat span created inside will be a child of this react_step
+    # because start_react_step attached it to the current context.
+    return wrapped(*args, **kwargs)
+
+
+def wrap_agent_call_tool(
+    wrapped, instance, args, kwargs, handler: ExtendedTelemetryHandler
+):
+    """Wrapper for Agent._call_tool() to create execute_tool spans.
+
+    _call_tool(tool_name, tool_args, **kwargs) -> str | List[ContentItem]
+    """
+    tool_name = args[0] if args else kwargs.get("tool_name", "unknown_tool")
+    tool_args = args[1] if len(args) > 1 else kwargs.get("tool_args", "{}")
+
+    # Get tool instance for description
+    tool_instance = None
+    if hasattr(instance, "function_map"):
+        tool_instance = instance.function_map.get(tool_name)
+
+    try:
+        invocation = create_tool_invocation(tool_name, tool_args, tool_instance)
+    except Exception as e:
+        logger.debug(f"Failed to create tool invocation: {e}")
+        return wrapped(*args, **kwargs)
+
+    handler.start_execute_tool(invocation)
+
+    try:
+        result = wrapped(*args, **kwargs)
+
+        # Set tool result
+        if isinstance(result, str):
+            invocation.tool_call_result = result
+        elif isinstance(result, list):
+            # List[ContentItem] - serialize to string
+            invocation.tool_call_result = str(result)
+        else:
+            invocation.tool_call_result = str(result) if result else None
+
+        handler.stop_execute_tool(invocation)
+        return result
+
+    except Exception as e:
+        handler.fail_execute_tool(
+            invocation, Error(message=str(e), type=type(e))
+        )
+        raise

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/patch.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/patch.py
@@ -37,10 +37,10 @@ from opentelemetry.util.genai.extended_handler import ExtendedTelemetryHandler
 from opentelemetry.util.genai.types import Error
 
 from .utils import (
-    convert_qwen_messages_to_output_messages,
-    create_agent_invocation,
-    create_llm_invocation,
-    create_tool_invocation,
+    _convert_qwen_messages_to_output_messages,
+    _create_agent_invocation,
+    _create_llm_invocation,
+    _create_tool_invocation,
 )
 
 logger = logging.getLogger(__name__)
@@ -56,6 +56,12 @@ _react_step_invocation: ContextVar[Optional[ReactStepInvocation]] = ContextVar(
 _react_step_counter: ContextVar[int] = ContextVar(
     "qwen_react_step_counter", default=0
 )
+
+# Reentrancy guards to prevent duplicate spans when Agent/BaseChatModel
+# are abstract classes and subclass calls super() (Proxy/Wrapper scenarios).
+_in_agent_run: ContextVar[bool] = ContextVar("_qwen_in_agent_run", default=False)
+_in_chat: ContextVar[bool] = ContextVar("_qwen_in_chat", default=False)
+_in_call_tool: ContextVar[bool] = ContextVar("_qwen_in_call_tool", default=False)
 
 
 def _close_active_react_step(handler: ExtendedTelemetryHandler) -> None:
@@ -81,12 +87,20 @@ def wrap_agent_run(
     function_map, _react_mode is set to True so that wrap_agent_call_llm
     will create react_step spans for each ReAct iteration.
     """
+    # Reentrancy guard: prevent duplicate spans in Proxy/Wrapper scenarios
+    # where a subclass calls super().run().
+    if _in_agent_run.get():
+        yield from wrapped(*args, **kwargs)
+        return
+    run_token = _in_agent_run.set(True)
+
     messages = args[0] if args else kwargs.get("messages", [])
 
     try:
-        invocation = create_agent_invocation(instance, messages)
+        invocation = _create_agent_invocation(instance, messages)
     except Exception as e:
         logger.debug(f"Failed to create agent invocation: {e}")
+        _in_agent_run.reset(run_token)
         yield from wrapped(*args, **kwargs)
         return
 
@@ -107,7 +121,7 @@ def wrap_agent_run(
         # Extract output from last yielded response
         if last_response:
             invocation.output_messages = (
-                convert_qwen_messages_to_output_messages(last_response)
+                _convert_qwen_messages_to_output_messages(last_response)
             )
 
         # Close the last react_step span before closing invoke_agent.
@@ -115,6 +129,14 @@ def wrap_agent_run(
 
         handler.stop_invoke_agent(invocation)
 
+    except GeneratorExit as e:
+        # Generator was closed early (e.g., consumer stopped iterating).
+        # Ensure any open react_step and the invoke_agent span are finalized.
+        _close_active_react_step(handler)
+        handler.fail_invoke_agent(
+            invocation, Error(message=str(e), type=type(e))
+        )
+        raise
     except Exception as e:
         # Close any open react_step on error path too.
         _close_active_react_step(handler)
@@ -127,6 +149,7 @@ def wrap_agent_run(
         _react_step_counter.reset(counter_token)
         _react_step_invocation.reset(step_token)
         _react_mode.reset(mode_token)
+        _in_agent_run.reset(run_token)
 
 
 def wrap_chat_model_chat(
@@ -138,63 +161,72 @@ def wrap_chat_model_chat(
     - List[Message] (non-stream)
     - Iterator[List[Message]] (stream)
     """
-    messages = args[0] if args else kwargs.get("messages", [])
-    functions = (
-        kwargs.get("functions")
-        if len(args) < 2
-        else (args[1] if len(args) > 1 else None)
-    )
-    stream = kwargs.get("stream", True)
-    extra_generate_cfg = kwargs.get("extra_generate_cfg")
-
-    try:
-        invocation = create_llm_invocation(
-            instance, messages, functions, stream, extra_generate_cfg
-        )
-    except Exception as e:
-        logger.debug(f"Failed to create LLM invocation: {e}")
+    # Reentrancy guard: prevent duplicate spans in Proxy/Wrapper scenarios
+    # where a subclass calls super().chat().
+    if _in_chat.get():
         return wrapped(*args, **kwargs)
-
-    handler.start_llm(invocation)
+    chat_token = _in_chat.set(True)
 
     try:
-        result = wrapped(*args, **kwargs)
+        messages = args[0] if args else kwargs.get("messages", [])
+        functions = (
+            kwargs.get("functions")
+            if len(args) < 2
+            else (args[1] if len(args) > 1 else None)
+        )
+        stream = kwargs.get("stream", True)
+        extra_generate_cfg = kwargs.get("extra_generate_cfg")
 
-        if (
-            stream
-            and hasattr(result, "__iter__")
-            and not isinstance(result, list)
-        ):
-            # Streaming: wrap the iterator
-            return _wrap_streaming_llm_response(result, invocation, handler)
-        else:
-            # Non-streaming: result is List[Message]
-            if result:
-                invocation.output_messages = (
-                    convert_qwen_messages_to_output_messages(result)
-                )
-                invocation.response_model_name = invocation.request_model
-                invocation.finish_reasons = ["stop"]
+        try:
+            invocation = _create_llm_invocation(
+                instance, messages, functions, stream, extra_generate_cfg
+            )
+        except Exception as e:
+            logger.debug(f"Failed to create LLM invocation: {e}")
+            return wrapped(*args, **kwargs)
 
-                # Check for function calls in output
-                for msg in result:
-                    fc = (
-                        msg.function_call
-                        if hasattr(msg, "function_call")
-                        else msg.get("function_call")
-                        if isinstance(msg, dict)
-                        else None
+        handler.start_llm(invocation)
+
+        try:
+            result = wrapped(*args, **kwargs)
+
+            if (
+                stream
+                and hasattr(result, "__iter__")
+                and not isinstance(result, list)
+            ):
+                # Streaming: wrap the iterator
+                return _wrap_streaming_llm_response(result, invocation, handler)
+            else:
+                # Non-streaming: result is List[Message]
+                if result:
+                    invocation.output_messages = (
+                        _convert_qwen_messages_to_output_messages(result)
                     )
-                    if fc:
-                        invocation.finish_reasons = ["tool_calls"]
-                        break
+                    invocation.response_model_name = invocation.request_model
+                    invocation.finish_reasons = ["stop"]
 
-            handler.stop_llm(invocation)
-            return result
+                    # Check for function calls in output
+                    for msg in result:
+                        fc = (
+                            msg.function_call
+                            if hasattr(msg, "function_call")
+                            else msg.get("function_call")
+                            if isinstance(msg, dict)
+                            else None
+                        )
+                        if fc:
+                            invocation.finish_reasons = ["tool_calls"]
+                            break
 
-    except Exception as e:
-        handler.fail_llm(invocation, Error(message=str(e), type=type(e)))
-        raise
+                handler.stop_llm(invocation)
+                return result
+
+        except Exception as e:
+            handler.fail_llm(invocation, Error(message=str(e), type=type(e)))
+            raise
+    finally:
+        _in_chat.reset(chat_token)
 
 
 def _wrap_streaming_llm_response(
@@ -213,7 +245,7 @@ def _wrap_streaming_llm_response(
 
         if last_response:
             invocation.output_messages = (
-                convert_qwen_messages_to_output_messages(last_response)
+                _convert_qwen_messages_to_output_messages(last_response)
             )
             invocation.response_model_name = invocation.request_model
             invocation.finish_reasons = ["stop"]
@@ -233,6 +265,11 @@ def _wrap_streaming_llm_response(
 
         handler.stop_llm(invocation)
 
+    except GeneratorExit as e:
+        # Stream was closed early (e.g., consumer stopped iterating).
+        # Ensure the LLM span is finalized.
+        handler.fail_llm(invocation, Error(message=str(e), type=type(e)))
+        raise
     except Exception as e:
         handler.fail_llm(invocation, Error(message=str(e), type=type(e)))
         raise
@@ -288,41 +325,50 @@ def wrap_agent_call_tool(
 
     _call_tool(tool_name, tool_args, **kwargs) -> str | List[ContentItem]
     """
-    tool_name = args[0] if args else kwargs.get("tool_name", "unknown_tool")
-    tool_args = args[1] if len(args) > 1 else kwargs.get("tool_args", "{}")
-
-    # Get tool instance for description
-    tool_instance = None
-    if hasattr(instance, "function_map"):
-        tool_instance = instance.function_map.get(tool_name)
-
-    try:
-        invocation = create_tool_invocation(
-            tool_name, tool_args, tool_instance
-        )
-    except Exception as e:
-        logger.debug(f"Failed to create tool invocation: {e}")
+    # Reentrancy guard: prevent duplicate spans in Proxy/Wrapper scenarios
+    # where a subclass calls super()._call_tool().
+    if _in_call_tool.get():
         return wrapped(*args, **kwargs)
-
-    handler.start_execute_tool(invocation)
+    tool_guard_token = _in_call_tool.set(True)
 
     try:
-        result = wrapped(*args, **kwargs)
+        tool_name = args[0] if args else kwargs.get("tool_name", "unknown_tool")
+        tool_args = args[1] if len(args) > 1 else kwargs.get("tool_args", "{}")
 
-        # Set tool result
-        if isinstance(result, str):
-            invocation.tool_call_result = result
-        elif isinstance(result, list):
-            # List[ContentItem] - serialize to string
-            invocation.tool_call_result = str(result)
-        else:
-            invocation.tool_call_result = str(result) if result else None
+        # Get tool instance for description
+        tool_instance = None
+        if hasattr(instance, "function_map"):
+            tool_instance = instance.function_map.get(tool_name)
 
-        handler.stop_execute_tool(invocation)
-        return result
+        try:
+            invocation = _create_tool_invocation(
+                tool_name, tool_args, tool_instance
+            )
+        except Exception as e:
+            logger.debug(f"Failed to create tool invocation: {e}")
+            return wrapped(*args, **kwargs)
 
-    except Exception as e:
-        handler.fail_execute_tool(
-            invocation, Error(message=str(e), type=type(e))
-        )
-        raise
+        handler.start_execute_tool(invocation)
+
+        try:
+            result = wrapped(*args, **kwargs)
+
+            # Set tool result
+            if isinstance(result, str):
+                invocation.tool_call_result = result
+            elif isinstance(result, list):
+                # List[ContentItem] - serialize to string
+                invocation.tool_call_result = str(result)
+            else:
+                invocation.tool_call_result = str(result) if result else None
+
+            handler.stop_execute_tool(invocation)
+            return result
+
+        except Exception as e:
+            handler.fail_execute_tool(
+                invocation, Error(message=str(e), type=type(e))
+            )
+            raise
+    finally:
+        _in_call_tool.reset(tool_guard_token)

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/patch.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/patch.py
@@ -69,7 +69,9 @@ def _close_active_react_step(handler: ExtendedTelemetryHandler) -> None:
         _react_step_invocation.set(None)
 
 
-def wrap_agent_run(wrapped, instance, args, kwargs, handler: ExtendedTelemetryHandler):
+def wrap_agent_run(
+    wrapped, instance, args, kwargs, handler: ExtendedTelemetryHandler
+):
     """Wrapper for Agent.run() to create invoke_agent spans.
 
     Agent.run() is a generator that yields List[Message].
@@ -104,8 +106,8 @@ def wrap_agent_run(wrapped, instance, args, kwargs, handler: ExtendedTelemetryHa
 
         # Extract output from last yielded response
         if last_response:
-            invocation.output_messages = convert_qwen_messages_to_output_messages(
-                last_response
+            invocation.output_messages = (
+                convert_qwen_messages_to_output_messages(last_response)
             )
 
         # Close the last react_step span before closing invoke_agent.
@@ -137,7 +139,11 @@ def wrap_chat_model_chat(
     - Iterator[List[Message]] (stream)
     """
     messages = args[0] if args else kwargs.get("messages", [])
-    functions = kwargs.get("functions") if len(args) < 2 else (args[1] if len(args) > 1 else None)
+    functions = (
+        kwargs.get("functions")
+        if len(args) < 2
+        else (args[1] if len(args) > 1 else None)
+    )
     stream = kwargs.get("stream", True)
     extra_generate_cfg = kwargs.get("extra_generate_cfg")
 
@@ -154,21 +160,31 @@ def wrap_chat_model_chat(
     try:
         result = wrapped(*args, **kwargs)
 
-        if stream and hasattr(result, "__iter__") and not isinstance(result, list):
+        if (
+            stream
+            and hasattr(result, "__iter__")
+            and not isinstance(result, list)
+        ):
             # Streaming: wrap the iterator
             return _wrap_streaming_llm_response(result, invocation, handler)
         else:
             # Non-streaming: result is List[Message]
             if result:
-                invocation.output_messages = convert_qwen_messages_to_output_messages(
-                    result
+                invocation.output_messages = (
+                    convert_qwen_messages_to_output_messages(result)
                 )
                 invocation.response_model_name = invocation.request_model
                 invocation.finish_reasons = ["stop"]
 
                 # Check for function calls in output
                 for msg in result:
-                    fc = msg.function_call if hasattr(msg, "function_call") else msg.get("function_call") if isinstance(msg, dict) else None
+                    fc = (
+                        msg.function_call
+                        if hasattr(msg, "function_call")
+                        else msg.get("function_call")
+                        if isinstance(msg, dict)
+                        else None
+                    )
                     if fc:
                         invocation.finish_reasons = ["tool_calls"]
                         break
@@ -196,15 +212,21 @@ def _wrap_streaming_llm_response(
             yield response
 
         if last_response:
-            invocation.output_messages = convert_qwen_messages_to_output_messages(
-                last_response
+            invocation.output_messages = (
+                convert_qwen_messages_to_output_messages(last_response)
             )
             invocation.response_model_name = invocation.request_model
             invocation.finish_reasons = ["stop"]
 
             # Check for function calls
             for msg in last_response:
-                fc = msg.function_call if hasattr(msg, "function_call") else msg.get("function_call") if isinstance(msg, dict) else None
+                fc = (
+                    msg.function_call
+                    if hasattr(msg, "function_call")
+                    else msg.get("function_call")
+                    if isinstance(msg, dict)
+                    else None
+                )
                 if fc:
                     invocation.finish_reasons = ["tool_calls"]
                     break
@@ -275,7 +297,9 @@ def wrap_agent_call_tool(
         tool_instance = instance.function_map.get(tool_name)
 
     try:
-        invocation = create_tool_invocation(tool_name, tool_args, tool_instance)
+        invocation = create_tool_invocation(
+            tool_name, tool_args, tool_instance
+        )
     except Exception as e:
         logger.debug(f"Failed to create tool invocation: {e}")
         return wrapped(*args, **kwargs)

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/utils.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/utils.py
@@ -127,10 +127,18 @@ def convert_qwen_messages_to_input_messages(
     input_messages = []
     for msg in messages:
         try:
-            role = msg.role if hasattr(msg, "role") else msg.get("role", "user")
-            content = msg.content if hasattr(msg, "content") else msg.get("content", "")
+            role = (
+                msg.role if hasattr(msg, "role") else msg.get("role", "user")
+            )
+            content = (
+                msg.content
+                if hasattr(msg, "content")
+                else msg.get("content", "")
+            )
             function_call = (
-                msg.function_call if hasattr(msg, "function_call") else msg.get("function_call")
+                msg.function_call
+                if hasattr(msg, "function_call")
+                else msg.get("function_call")
             )
             name = msg.name if hasattr(msg, "name") else msg.get("name")
 
@@ -154,7 +162,9 @@ def convert_qwen_messages_to_input_messages(
                         fc_args = json.loads(fc_args)
                     except (json.JSONDecodeError, ValueError):
                         pass
-                parts.append(ToolCall(name=fc_name, arguments=fc_args, id=None))
+                parts.append(
+                    ToolCall(name=fc_name, arguments=fc_args, id=None)
+                )
 
             # Handle function role (tool response)
             if role == "function" and content:
@@ -200,9 +210,15 @@ def convert_qwen_messages_to_output_messages(
     output_messages = []
     for msg in messages:
         try:
-            content = msg.content if hasattr(msg, "content") else msg.get("content", "")
+            content = (
+                msg.content
+                if hasattr(msg, "content")
+                else msg.get("content", "")
+            )
             function_call = (
-                msg.function_call if hasattr(msg, "function_call") else msg.get("function_call")
+                msg.function_call
+                if hasattr(msg, "function_call")
+                else msg.get("function_call")
             )
 
             parts = []
@@ -224,7 +240,9 @@ def convert_qwen_messages_to_output_messages(
                         fc_args = json.loads(fc_args)
                     except (json.JSONDecodeError, ValueError):
                         pass
-                parts.append(ToolCall(name=fc_name, arguments=fc_args, id=None))
+                parts.append(
+                    ToolCall(name=fc_name, arguments=fc_args, id=None)
+                )
                 finish_reason = "tool_calls"
 
             if content:
@@ -250,7 +268,9 @@ def convert_qwen_messages_to_output_messages(
     return output_messages
 
 
-def get_tool_definitions(functions: Optional[List[Dict]]) -> Optional[List[FunctionToolDefinition]]:
+def get_tool_definitions(
+    functions: Optional[List[Dict]],
+) -> Optional[List[FunctionToolDefinition]]:
     """Extract tool definitions for tracing as FunctionToolDefinition objects.
 
     Args:
@@ -355,7 +375,9 @@ def create_agent_invocation(
 
     input_messages = convert_qwen_messages_to_input_messages(messages)
 
-    agent_name = getattr(agent_instance, "name", None) or type(agent_instance).__name__
+    agent_name = (
+        getattr(agent_instance, "name", None) or type(agent_instance).__name__
+    )
     agent_description = getattr(agent_instance, "description", None) or ""
 
     invocation = InvokeAgentInvocation(
@@ -367,8 +389,13 @@ def create_agent_invocation(
     )
 
     # Set system instruction if available
-    if hasattr(agent_instance, "system_message") and agent_instance.system_message:
-        invocation.system_instruction = [Text(content=agent_instance.system_message)]
+    if (
+        hasattr(agent_instance, "system_message")
+        and agent_instance.system_message
+    ):
+        invocation.system_instruction = [
+            Text(content=agent_instance.system_message)
+        ]
 
     return invocation
 

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/utils.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/utils.py
@@ -1,0 +1,410 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utility functions for Qwen-Agent instrumentation.
+
+Handles conversion between qwen-agent Message types and
+OpenTelemetry GenAI semantic convention types.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAIAttributes,
+)
+from opentelemetry.util.genai.extended_types import (
+    ExecuteToolInvocation,
+    InvokeAgentInvocation,
+)
+from opentelemetry.util.genai.types import (
+    FunctionToolDefinition,
+    InputMessage,
+    LLMInvocation,
+    OutputMessage,
+    Text,
+    ToolCall,
+    ToolCallResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class QwenAgentProviderName(str, Enum):
+    """Provider names for qwen-agent LLM backends."""
+
+    DASHSCOPE = "dashscope"
+    QWEN = "qwen"
+
+
+# Map qwen-agent model_type to provider name
+_MODEL_TYPE_PROVIDER_MAP = {
+    "qwen_dashscope": QwenAgentProviderName.DASHSCOPE.value,
+    "qwenvl_dashscope": QwenAgentProviderName.DASHSCOPE.value,
+    "qwenaudio_dashscope": QwenAgentProviderName.DASHSCOPE.value,
+    "oai": GenAIAttributes.GenAiProviderNameValues.OPENAI.value,
+    "azure": GenAIAttributes.GenAiProviderNameValues.OPENAI.value,
+    "qwenvl_oai": GenAIAttributes.GenAiProviderNameValues.OPENAI.value,
+    "qwenomni_oai": GenAIAttributes.GenAiProviderNameValues.OPENAI.value,
+}
+
+
+def get_provider_name(llm_instance: Any) -> str:
+    """Extract provider name from a qwen-agent LLM instance.
+
+    Args:
+        llm_instance: A BaseChatModel instance from qwen-agent.
+
+    Returns:
+        Provider name string.
+    """
+    model_type = getattr(llm_instance, "model_type", "")
+    if model_type in _MODEL_TYPE_PROVIDER_MAP:
+        return _MODEL_TYPE_PROVIDER_MAP[model_type]
+
+    # Fallback: infer from class name
+    class_name = type(llm_instance).__name__.lower()
+    if "dashscope" in class_name:
+        return QwenAgentProviderName.DASHSCOPE.value
+    if "openai" in class_name or "oai" in class_name or "azure" in class_name:
+        return GenAIAttributes.GenAiProviderNameValues.OPENAI.value
+
+    return "qwen_agent"
+
+
+def _extract_content_text(content: Any) -> str:
+    """Extract text from qwen-agent Message content field.
+
+    Content can be str or List[ContentItem].
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        texts = []
+        for item in content:
+            if hasattr(item, "text") and item.text is not None:
+                texts.append(item.text)
+            elif hasattr(item, "get_type_and_value"):
+                t, v = item.get_type_and_value()
+                if t == "text":
+                    texts.append(v)
+        return "\n".join(texts)
+    return str(content) if content else ""
+
+
+def convert_qwen_messages_to_input_messages(
+    messages: Any,
+) -> List[InputMessage]:
+    """Convert qwen-agent Message list to GenAI InputMessage format.
+
+    Args:
+        messages: List of qwen-agent Message objects or dicts.
+
+    Returns:
+        List of InputMessage objects for ExtendedTelemetryHandler.
+    """
+    if not messages:
+        return []
+
+    if not isinstance(messages, list):
+        messages = [messages]
+
+    input_messages = []
+    for msg in messages:
+        try:
+            role = msg.role if hasattr(msg, "role") else msg.get("role", "user")
+            content = msg.content if hasattr(msg, "content") else msg.get("content", "")
+            function_call = (
+                msg.function_call if hasattr(msg, "function_call") else msg.get("function_call")
+            )
+            name = msg.name if hasattr(msg, "name") else msg.get("name")
+
+            parts = []
+
+            # Handle function_call (tool call from assistant)
+            if function_call:
+                fc_name = (
+                    function_call.name
+                    if hasattr(function_call, "name")
+                    else function_call.get("name", "")
+                )
+                fc_args = (
+                    function_call.arguments
+                    if hasattr(function_call, "arguments")
+                    else function_call.get("arguments", "{}")
+                )
+                # Parse arguments if string
+                if isinstance(fc_args, str):
+                    try:
+                        fc_args = json.loads(fc_args)
+                    except (json.JSONDecodeError, ValueError):
+                        pass
+                parts.append(ToolCall(name=fc_name, arguments=fc_args, id=None))
+
+            # Handle function role (tool response)
+            if role == "function" and content:
+                text = _extract_content_text(content)
+                parts.append(
+                    ToolCallResponse(
+                        id=name or "",
+                        response=text,
+                    )
+                )
+            elif content:
+                text = _extract_content_text(content)
+                if text:
+                    parts.append(Text(content=text))
+
+            if parts:
+                input_messages.append(InputMessage(role=role, parts=parts))
+
+        except Exception as e:
+            logger.debug(f"Error converting message: {e}")
+            continue
+
+    return input_messages
+
+
+def convert_qwen_messages_to_output_messages(
+    messages: Any,
+) -> List[OutputMessage]:
+    """Convert qwen-agent response messages to GenAI OutputMessage format.
+
+    Args:
+        messages: List of qwen-agent Message objects (LLM output).
+
+    Returns:
+        List of OutputMessage objects.
+    """
+    if not messages:
+        return []
+
+    if not isinstance(messages, list):
+        messages = [messages]
+
+    output_messages = []
+    for msg in messages:
+        try:
+            content = msg.content if hasattr(msg, "content") else msg.get("content", "")
+            function_call = (
+                msg.function_call if hasattr(msg, "function_call") else msg.get("function_call")
+            )
+
+            parts = []
+            finish_reason = "stop"
+
+            if function_call:
+                fc_name = (
+                    function_call.name
+                    if hasattr(function_call, "name")
+                    else function_call.get("name", "")
+                )
+                fc_args = (
+                    function_call.arguments
+                    if hasattr(function_call, "arguments")
+                    else function_call.get("arguments", "{}")
+                )
+                if isinstance(fc_args, str):
+                    try:
+                        fc_args = json.loads(fc_args)
+                    except (json.JSONDecodeError, ValueError):
+                        pass
+                parts.append(ToolCall(name=fc_name, arguments=fc_args, id=None))
+                finish_reason = "tool_calls"
+
+            if content:
+                text = _extract_content_text(content)
+                if text:
+                    parts.append(Text(content=text))
+
+            if not parts:
+                parts.append(Text(content=""))
+
+            output_messages.append(
+                OutputMessage(
+                    role="assistant",
+                    parts=parts,
+                    finish_reason=finish_reason,
+                )
+            )
+
+        except Exception as e:
+            logger.debug(f"Error converting output message: {e}")
+            continue
+
+    return output_messages
+
+
+def get_tool_definitions(functions: Optional[List[Dict]]) -> Optional[List[FunctionToolDefinition]]:
+    """Extract tool definitions for tracing as FunctionToolDefinition objects.
+
+    Args:
+        functions: List of function dicts in qwen-agent format
+                   (each with 'name', 'description', 'parameters').
+
+    Returns:
+        List of FunctionToolDefinition objects, or None.
+    """
+    if not functions:
+        return None
+
+    try:
+        tool_defs = []
+        for func in functions:
+            if not isinstance(func, dict):
+                continue
+            name = func.get("name")
+            if not name:
+                continue
+            tool_defs.append(
+                FunctionToolDefinition(
+                    name=name,
+                    description=func.get("description"),
+                    parameters=func.get("parameters"),
+                )
+            )
+        if tool_defs:
+            return tool_defs
+    except Exception:
+        pass
+
+    return None
+
+
+def create_llm_invocation(
+    llm_instance: Any,
+    messages: Any,
+    functions: Optional[List[Dict]] = None,
+    stream: bool = True,
+    extra_generate_cfg: Optional[Dict] = None,
+) -> LLMInvocation:
+    """Create LLMInvocation from qwen-agent BaseChatModel.chat() parameters.
+
+    Args:
+        llm_instance: The BaseChatModel instance.
+        messages: Input messages.
+        functions: Tool function definitions.
+        stream: Whether streaming.
+        extra_generate_cfg: Extra generation config.
+
+    Returns:
+        LLMInvocation for ExtendedTelemetryHandler.
+    """
+    provider_name = get_provider_name(llm_instance)
+    request_model = getattr(llm_instance, "model", "unknown_model")
+
+    input_messages = convert_qwen_messages_to_input_messages(messages)
+
+    invocation = LLMInvocation(
+        request_model=request_model,
+        provider=provider_name,
+        input_messages=input_messages,
+    )
+
+    # Set generation parameters
+    if extra_generate_cfg:
+        if extra_generate_cfg.get("max_tokens"):
+            invocation.max_tokens = extra_generate_cfg["max_tokens"]
+        if extra_generate_cfg.get("temperature"):
+            invocation.temperature = extra_generate_cfg["temperature"]
+        if extra_generate_cfg.get("top_p"):
+            invocation.top_p = extra_generate_cfg["top_p"]
+
+    # Set tool definitions
+    tool_definitions = get_tool_definitions(functions)
+    if tool_definitions:
+        invocation.tool_definitions = tool_definitions
+
+    return invocation
+
+
+def create_agent_invocation(
+    agent_instance: Any,
+    messages: Any,
+) -> InvokeAgentInvocation:
+    """Create InvokeAgentInvocation from qwen-agent Agent.run() parameters.
+
+    Args:
+        agent_instance: The Agent instance.
+        messages: Input messages.
+
+    Returns:
+        InvokeAgentInvocation for ExtendedTelemetryHandler.
+    """
+    # Get provider and model from agent's LLM
+    provider_name = None
+    request_model = None
+    if hasattr(agent_instance, "llm") and agent_instance.llm:
+        provider_name = get_provider_name(agent_instance.llm)
+        request_model = getattr(agent_instance.llm, "model", None)
+
+    input_messages = convert_qwen_messages_to_input_messages(messages)
+
+    agent_name = getattr(agent_instance, "name", None) or type(agent_instance).__name__
+    agent_description = getattr(agent_instance, "description", None) or ""
+
+    invocation = InvokeAgentInvocation(
+        provider=provider_name,
+        agent_name=agent_name,
+        agent_description=agent_description,
+        request_model=request_model,
+        input_messages=input_messages,
+    )
+
+    # Set system instruction if available
+    if hasattr(agent_instance, "system_message") and agent_instance.system_message:
+        invocation.system_instruction = [Text(content=agent_instance.system_message)]
+
+    return invocation
+
+
+def create_tool_invocation(
+    tool_name: str,
+    tool_args: Any = None,
+    tool_instance: Any = None,
+) -> ExecuteToolInvocation:
+    """Create ExecuteToolInvocation from qwen-agent tool call parameters.
+
+    Args:
+        tool_name: Name of the tool.
+        tool_args: Tool arguments (str or dict).
+        tool_instance: The BaseTool instance, if available.
+
+    Returns:
+        ExecuteToolInvocation for ExtendedTelemetryHandler.
+    """
+    # Parse tool_args
+    if isinstance(tool_args, str):
+        try:
+            parsed_args = json.loads(tool_args)
+        except (json.JSONDecodeError, ValueError):
+            parsed_args = {"raw_args": tool_args}
+    elif isinstance(tool_args, dict):
+        parsed_args = tool_args
+    else:
+        parsed_args = {}
+
+    tool_description = None
+    if tool_instance:
+        tool_description = getattr(tool_instance, "description", None)
+
+    return ExecuteToolInvocation(
+        tool_name=tool_name,
+        tool_call_arguments=parsed_args,
+        tool_description=tool_description,
+    )

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/utils.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/utils.py
@@ -25,7 +25,7 @@ from typing import Any, Dict, List, Optional
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
 )
-from opentelemetry.util.genai._extended_semconv.gen_ai_extended_attributes import (
+from opentelemetry.util.genai.extended_semconv.gen_ai_extended_attributes import (
     GenAiExtendedProviderNameValues,
 )
 from opentelemetry.util.genai.extended_types import (
@@ -55,6 +55,7 @@ _MODEL_TYPE_PROVIDER_MAP = {
     "qwenvl_oai": GenAIAttributes.GenAiProviderNameValues.OPENAI.value,
     "qwenomni_oai": GenAIAttributes.GenAiProviderNameValues.OPENAI.value,
 }
+
 
 def _get_provider_name(llm_instance: Any) -> str:
     """Extract provider name from a qwen-agent LLM instance.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/utils.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/utils.py
@@ -18,15 +18,15 @@ Handles conversion between qwen-agent Message types and
 OpenTelemetry GenAI semantic convention types.
 """
 
-from __future__ import annotations
-
 import json
 import logging
-from enum import Enum
 from typing import Any, Dict, List, Optional
 
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
+)
+from opentelemetry.util.genai._extended_semconv.gen_ai_extended_attributes import (
+    GenAiExtendedProviderNameValues,
 )
 from opentelemetry.util.genai.extended_types import (
     ExecuteToolInvocation,
@@ -44,27 +44,19 @@ from opentelemetry.util.genai.types import (
 
 logger = logging.getLogger(__name__)
 
-
-class QwenAgentProviderName(str, Enum):
-    """Provider names for qwen-agent LLM backends."""
-
-    DASHSCOPE = "dashscope"
-    QWEN = "qwen"
-
-
-# Map qwen-agent model_type to provider name
+# Map qwen-agent model_type to provider name.
 _MODEL_TYPE_PROVIDER_MAP = {
-    "qwen_dashscope": QwenAgentProviderName.DASHSCOPE.value,
-    "qwenvl_dashscope": QwenAgentProviderName.DASHSCOPE.value,
-    "qwenaudio_dashscope": QwenAgentProviderName.DASHSCOPE.value,
+    "qwen_dashscope": GenAiExtendedProviderNameValues.DASHSCOPE.value,
+    "qwenvl_dashscope": GenAiExtendedProviderNameValues.DASHSCOPE.value,
+    "qwenaudio_dashscope": GenAiExtendedProviderNameValues.DASHSCOPE.value,
+    "qwenvlo_dashscope": GenAiExtendedProviderNameValues.DASHSCOPE.value,
     "oai": GenAIAttributes.GenAiProviderNameValues.OPENAI.value,
-    "azure": GenAIAttributes.GenAiProviderNameValues.OPENAI.value,
+    "azure": GenAIAttributes.GenAiProviderNameValues.AZURE_AI_OPENAI.value,
     "qwenvl_oai": GenAIAttributes.GenAiProviderNameValues.OPENAI.value,
     "qwenomni_oai": GenAIAttributes.GenAiProviderNameValues.OPENAI.value,
 }
 
-
-def get_provider_name(llm_instance: Any) -> str:
+def _get_provider_name(llm_instance: Any) -> str:
     """Extract provider name from a qwen-agent LLM instance.
 
     Args:
@@ -80,11 +72,13 @@ def get_provider_name(llm_instance: Any) -> str:
     # Fallback: infer from class name
     class_name = type(llm_instance).__name__.lower()
     if "dashscope" in class_name:
-        return QwenAgentProviderName.DASHSCOPE.value
-    if "openai" in class_name or "oai" in class_name or "azure" in class_name:
+        return GenAiExtendedProviderNameValues.DASHSCOPE.value
+    if "openai" in class_name or "oai" in class_name:
         return GenAIAttributes.GenAiProviderNameValues.OPENAI.value
+    if "azure" in class_name:
+        return GenAIAttributes.GenAiProviderNameValues.AZURE_AI_OPENAI.value
 
-    return "qwen_agent"
+    return GenAiExtendedProviderNameValues.DASHSCOPE.value
 
 
 def _extract_content_text(content: Any) -> str:
@@ -107,7 +101,7 @@ def _extract_content_text(content: Any) -> str:
     return str(content) if content else ""
 
 
-def convert_qwen_messages_to_input_messages(
+def _convert_qwen_messages_to_input_messages(
     messages: Any,
 ) -> List[InputMessage]:
     """Convert qwen-agent Message list to GenAI InputMessage format.
@@ -166,12 +160,40 @@ def convert_qwen_messages_to_input_messages(
                     ToolCall(name=fc_name, arguments=fc_args, id=None)
                 )
 
-            # Handle function role (tool response)
-            if role == "function" and content:
+            # Handle function/tool role (tool response).
+            # qwen-agent uses role="function" internally, but DashScope API
+            # converts it to role="tool" (see base.py:445). Handle both.
+            if role in ("function", "tool") and content:
                 text = _extract_content_text(content)
+
+                # Extract tool_call_id: prefer msg.id, then msg.extra.function_id,
+                # then fall back to tool name.
+                tool_call_id: str = ""
+                if hasattr(msg, "id"):
+                    tool_call_id = getattr(msg, "id", "") or ""
+                elif isinstance(msg, dict):
+                    tool_call_id = msg.get("id") or ""
+
+                if not tool_call_id:
+                    extra = (
+                        getattr(msg, "extra", None)
+                        if not isinstance(msg, dict)
+                        else msg.get("extra")
+                    )
+                    if extra is not None:
+                        if isinstance(extra, dict):
+                            tool_call_id = extra.get("function_id") or ""
+                        else:
+                            tool_call_id = (
+                                getattr(extra, "function_id", "") or ""
+                            )
+
+                if not tool_call_id:
+                    tool_call_id = name or ""
+
                 parts.append(
                     ToolCallResponse(
-                        id=name or "",
+                        id=tool_call_id,
                         response=text,
                     )
                 )
@@ -190,7 +212,7 @@ def convert_qwen_messages_to_input_messages(
     return input_messages
 
 
-def convert_qwen_messages_to_output_messages(
+def _convert_qwen_messages_to_output_messages(
     messages: Any,
 ) -> List[OutputMessage]:
     """Convert qwen-agent response messages to GenAI OutputMessage format.
@@ -268,7 +290,7 @@ def convert_qwen_messages_to_output_messages(
     return output_messages
 
 
-def get_tool_definitions(
+def _get_tool_definitions(
     functions: Optional[List[Dict]],
 ) -> Optional[List[FunctionToolDefinition]]:
     """Extract tool definitions for tracing as FunctionToolDefinition objects.
@@ -306,7 +328,7 @@ def get_tool_definitions(
     return None
 
 
-def create_llm_invocation(
+def _create_llm_invocation(
     llm_instance: Any,
     messages: Any,
     functions: Optional[List[Dict]] = None,
@@ -325,10 +347,10 @@ def create_llm_invocation(
     Returns:
         LLMInvocation for ExtendedTelemetryHandler.
     """
-    provider_name = get_provider_name(llm_instance)
+    provider_name = _get_provider_name(llm_instance)
     request_model = getattr(llm_instance, "model", "unknown_model")
 
-    input_messages = convert_qwen_messages_to_input_messages(messages)
+    input_messages = _convert_qwen_messages_to_input_messages(messages)
 
     invocation = LLMInvocation(
         request_model=request_model,
@@ -346,14 +368,14 @@ def create_llm_invocation(
             invocation.top_p = extra_generate_cfg["top_p"]
 
     # Set tool definitions
-    tool_definitions = get_tool_definitions(functions)
+    tool_definitions = _get_tool_definitions(functions)
     if tool_definitions:
         invocation.tool_definitions = tool_definitions
 
     return invocation
 
 
-def create_agent_invocation(
+def _create_agent_invocation(
     agent_instance: Any,
     messages: Any,
 ) -> InvokeAgentInvocation:
@@ -370,10 +392,10 @@ def create_agent_invocation(
     provider_name = None
     request_model = None
     if hasattr(agent_instance, "llm") and agent_instance.llm:
-        provider_name = get_provider_name(agent_instance.llm)
+        provider_name = _get_provider_name(agent_instance.llm)
         request_model = getattr(agent_instance.llm, "model", None)
 
-    input_messages = convert_qwen_messages_to_input_messages(messages)
+    input_messages = _convert_qwen_messages_to_input_messages(messages)
 
     agent_name = (
         getattr(agent_instance, "name", None) or type(agent_instance).__name__
@@ -388,7 +410,14 @@ def create_agent_invocation(
         input_messages=input_messages,
     )
 
-    # Set system instruction if available
+    # Set system instruction if available.
+    # Qwen-Agent's Agent.system_message is a plain string (Optional[str])
+    # that serves as the system prompt prepended to messages (see agent.py:113).
+    # This conforms to the gen_ai.system_instructions semantic convention:
+    # "The full system instructions (also known as system prompt)".
+    # Note: agent.py:117 may concatenate system_message with an existing
+    # system message in the input, but we capture the original system_message
+    # as the agent's configured instruction.
     if (
         hasattr(agent_instance, "system_message")
         and agent_instance.system_message
@@ -400,7 +429,7 @@ def create_agent_invocation(
     return invocation
 
 
-def create_tool_invocation(
+def _create_tool_invocation(
     tool_name: str,
     tool_args: Any = None,
     tool_instance: Any = None,

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/version.py
@@ -1,0 +1,15 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__version__ = "0.1.0"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.1.0"
+__version__ = "0.4.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/__init__.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/__init__.py
@@ -1,0 +1,13 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/cassettes/test_agent_run_nonstream.yaml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/cassettes/test_agent_run_nonstream.yaml
@@ -1,0 +1,85 @@
+interactions:
+- request:
+    body: |-
+      {
+        "model": "qwen-max",
+        "parameters": {
+          "result_format": "message",
+          "incremental_output": true,
+          "seed": 993050835
+        },
+        "input": {
+          "messages": [
+            {
+              "role": "user",
+              "content": "Say 'OK' and nothing else."
+            }
+          ]
+        }
+      }
+    headers:
+      Accept:
+      - text/event-stream
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '196'
+      Content-Type:
+      - application/json
+      X-Accel-Buffering:
+      - 'no'
+      X-DashScope-SSE:
+      - enable
+      authorization:
+      - Bearer test_dashscope_api_key
+      user-agent:
+      - dashscope/1.25.2; python/3.12.10; platform/macOS-15.1.1-arm64-arm-64bit; processor/arm;
+        incremental_to_full/0
+    method: POST
+    uri: https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation
+  response:
+    body:
+      string: |+
+        id:1
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":"OK","role":"assistant"},"finish_reason":"null"}]},"usage":{"total_tokens":17,"output_tokens":1,"input_tokens":16,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"81fdbf28-1e5f-4c23-964c-0568e8684665"}
+
+        id:2
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":"","role":"assistant"},"finish_reason":"stop"}]},"usage":{"total_tokens":17,"output_tokens":1,"input_tokens":16,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"81fdbf28-1e5f-4c23-964c-0568e8684665"}
+
+    headers:
+      content-type:
+      - text/event-stream;charset=UTF-8
+      date:
+      - Fri, 20 Mar 2026 02:22:37 GMT
+      req-arrive-time:
+      - '1773973357553'
+      req-cost-time:
+      - '523'
+      resp-start-time:
+      - '1773973358076'
+      server:
+      - istio-envoy
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin,Access-Control-Request-Method,Access-Control-Request-Headers
+      x-dashscope-call-gateway:
+      - 'true'
+      x-dashscope-finished:
+      - 'false'
+      x-dashscope-timeout:
+      - '298'
+      x-envoy-upstream-service-time:
+      - '515'
+      x-request-id:
+      - 81fdbf28-1e5f-4c23-964c-0568e8684665
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/cassettes/test_multi_turn_conversation.yaml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/cassettes/test_multi_turn_conversation.yaml
@@ -1,0 +1,103 @@
+interactions:
+- request:
+    body: |-
+      {
+        "model": "qwen-max",
+        "parameters": {
+          "result_format": "message",
+          "incremental_output": true,
+          "seed": 260755724
+        },
+        "input": {
+          "messages": [
+            {
+              "role": "user",
+              "content": "My name is Alice."
+            },
+            {
+              "role": "assistant",
+              "content": "Nice to meet you, Alice!"
+            },
+            {
+              "role": "user",
+              "content": "What is my name?"
+            }
+          ]
+        }
+      }
+    headers:
+      Accept:
+      - text/event-stream
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '298'
+      Content-Type:
+      - application/json
+      X-Accel-Buffering:
+      - 'no'
+      X-DashScope-SSE:
+      - enable
+      authorization:
+      - Bearer test_dashscope_api_key
+      user-agent:
+      - dashscope/1.25.2; python/3.12.10; platform/macOS-15.1.1-arm64-arm-64bit; processor/arm;
+        incremental_to_full/0
+    method: POST
+    uri: https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation
+  response:
+    body:
+      string: |+
+        id:1
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":"Your","role":"assistant"},"finish_reason":"null"}]},"usage":{"total_tokens":36,"output_tokens":1,"input_tokens":35,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"fd5a3067-858a-4604-ab8e-8b9e40796e99"}
+
+        id:2
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":" name is Alice","role":"assistant"},"finish_reason":"null"}]},"usage":{"total_tokens":39,"output_tokens":4,"input_tokens":35,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"fd5a3067-858a-4604-ab8e-8b9e40796e99"}
+
+        id:3
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":".","role":"assistant"},"finish_reason":"null"}]},"usage":{"total_tokens":40,"output_tokens":5,"input_tokens":35,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"fd5a3067-858a-4604-ab8e-8b9e40796e99"}
+
+        id:4
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":"","role":"assistant"},"finish_reason":"stop"}]},"usage":{"total_tokens":40,"output_tokens":5,"input_tokens":35,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"fd5a3067-858a-4604-ab8e-8b9e40796e99"}
+
+    headers:
+      content-type:
+      - text/event-stream;charset=UTF-8
+      date:
+      - Fri, 20 Mar 2026 02:22:38 GMT
+      req-arrive-time:
+      - '1773973358381'
+      req-cost-time:
+      - '260'
+      resp-start-time:
+      - '1773973358642'
+      server:
+      - istio-envoy
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin,Access-Control-Request-Method,Access-Control-Request-Headers
+      x-dashscope-call-gateway:
+      - 'true'
+      x-dashscope-finished:
+      - 'false'
+      x-dashscope-timeout:
+      - '298'
+      x-envoy-upstream-service-time:
+      - '254'
+      x-request-id:
+      - fd5a3067-858a-4604-ab8e-8b9e40796e99
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/cassettes/test_non_stream_chat.yaml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/cassettes/test_non_stream_chat.yaml
@@ -1,0 +1,94 @@
+interactions:
+- request:
+    body: |-
+      {
+        "model": "qwen-max",
+        "parameters": {
+          "result_format": "message",
+          "seed": 935360180
+        },
+        "input": {
+          "messages": [
+            {
+              "role": "user",
+              "content": "What is 2+2? Answer with just the number."
+            }
+          ]
+        }
+      }
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '183'
+      Content-Type:
+      - application/json
+      authorization:
+      - Bearer test_dashscope_api_key
+      user-agent:
+      - dashscope/1.25.2; python/3.12.10; platform/macOS-15.1.1-arm64-arm-64bit; processor/arm;
+        incremental_to_full/0
+    method: POST
+    uri: https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation
+  response:
+    body:
+      string: |-
+        {
+          "output": {
+            "choices": [
+              {
+                "finish_reason": "stop",
+                "message": {
+                  "content": "4",
+                  "role": "assistant"
+                }
+              }
+            ]
+          },
+          "usage": {
+            "input_tokens": 21,
+            "output_tokens": 1,
+            "prompt_tokens_details": {
+              "cached_tokens": 0
+            },
+            "total_tokens": 22
+          },
+          "request_id": "c5f380ae-1f7e-423b-803a-9d38fe7f448c"
+        }
+    headers:
+      content-length:
+      - '254'
+      content-type:
+      - application/json
+      date:
+      - Fri, 20 Mar 2026 02:31:41 GMT
+      req-arrive-time:
+      - '1773973901239'
+      req-cost-time:
+      - '679'
+      resp-start-time:
+      - '1773973901919'
+      server:
+      - istio-envoy
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin,Access-Control-Request-Method,Access-Control-Request-Headers, Accept-Encoding
+      x-dashscope-call-gateway:
+      - 'true'
+      x-dashscope-finished:
+      - 'true'
+      x-dashscope-timeout:
+      - '298'
+      x-envoy-upstream-service-time:
+      - '673'
+      x-request-id:
+      - c5f380ae-1f7e-423b-803a-9d38fe7f448c
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/cassettes/test_qwen_agent_basic_run.yaml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/cassettes/test_qwen_agent_basic_run.yaml
@@ -1,0 +1,105 @@
+interactions:
+- request:
+    body: |-
+      {
+        "model": "qwen-max",
+        "parameters": {
+          "result_format": "message",
+          "incremental_output": true,
+          "seed": 289569634
+        },
+        "input": {
+          "messages": [
+            {
+              "role": "user",
+              "content": "Hello, what is 1+1?"
+            }
+          ]
+        }
+      }
+    headers:
+      Accept:
+      - text/event-stream
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '189'
+      Content-Type:
+      - application/json
+      X-Accel-Buffering:
+      - 'no'
+      X-DashScope-SSE:
+      - enable
+      authorization:
+      - Bearer test_dashscope_api_key
+      user-agent:
+      - dashscope/1.25.2; python/3.12.10; platform/macOS-15.1.1-arm64-arm-64bit; processor/arm;
+        incremental_to_full/0
+    method: POST
+    uri: https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation
+  response:
+    body:
+      string: |+
+        id:1
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":"Hello","role":"assistant"},"finish_reason":"null"}]},"usage":{"total_tokens":18,"output_tokens":1,"input_tokens":17,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"f0a08fc8-84cd-4884-a742-f8f94d014c2a"}
+
+        id:2
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":"! ","role":"assistant"},"finish_reason":"null"}]},"usage":{"total_tokens":20,"output_tokens":3,"input_tokens":17,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"f0a08fc8-84cd-4884-a742-f8f94d014c2a"}
+
+        id:3
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":"1+1","role":"assistant"},"finish_reason":"null"}]},"usage":{"total_tokens":23,"output_tokens":6,"input_tokens":17,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"f0a08fc8-84cd-4884-a742-f8f94d014c2a"}
+
+        id:4
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":" equals 2","role":"assistant"},"finish_reason":"null"}]},"usage":{"total_tokens":26,"output_tokens":9,"input_tokens":17,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"f0a08fc8-84cd-4884-a742-f8f94d014c2a"}
+
+        id:5
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":".","role":"assistant"},"finish_reason":"null"}]},"usage":{"total_tokens":27,"output_tokens":10,"input_tokens":17,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"f0a08fc8-84cd-4884-a742-f8f94d014c2a"}
+
+        id:6
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":"","role":"assistant"},"finish_reason":"stop"}]},"usage":{"total_tokens":27,"output_tokens":10,"input_tokens":17,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"f0a08fc8-84cd-4884-a742-f8f94d014c2a"}
+
+    headers:
+      content-type:
+      - text/event-stream;charset=UTF-8
+      date:
+      - Thu, 19 Mar 2026 08:14:35 GMT
+      req-arrive-time:
+      - '1773908075696'
+      req-cost-time:
+      - '235'
+      resp-start-time:
+      - '1773908075932'
+      server:
+      - istio-envoy
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin,Access-Control-Request-Method,Access-Control-Request-Headers
+      x-dashscope-call-gateway:
+      - 'true'
+      x-dashscope-finished:
+      - 'false'
+      x-dashscope-timeout:
+      - '298'
+      x-envoy-upstream-service-time:
+      - '228'
+      x-request-id:
+      - f0a08fc8-84cd-4884-a742-f8f94d014c2a
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/cassettes/test_qwen_agent_stream_llm_with_ttft.yaml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/cassettes/test_qwen_agent_stream_llm_with_ttft.yaml
@@ -1,0 +1,85 @@
+interactions:
+- request:
+    body: |-
+      {
+        "model": "qwen-max",
+        "parameters": {
+          "result_format": "message",
+          "incremental_output": true,
+          "seed": 200802247
+        },
+        "input": {
+          "messages": [
+            {
+              "role": "user",
+              "content": "Say hello in one word."
+            }
+          ]
+        }
+      }
+    headers:
+      Accept:
+      - text/event-stream
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '192'
+      Content-Type:
+      - application/json
+      X-Accel-Buffering:
+      - 'no'
+      X-DashScope-SSE:
+      - enable
+      authorization:
+      - Bearer test_dashscope_api_key
+      user-agent:
+      - dashscope/1.25.2; python/3.12.10; platform/macOS-15.1.1-arm64-arm-64bit; processor/arm;
+        incremental_to_full/0
+    method: POST
+    uri: https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation
+  response:
+    body:
+      string: |+
+        id:1
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":"Hello","role":"assistant"},"finish_reason":"null"}]},"usage":{"total_tokens":15,"output_tokens":1,"input_tokens":14,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"280f9f0f-6f8b-4d48-b646-aceda50fe87c"}
+
+        id:2
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":"","role":"assistant"},"finish_reason":"stop"}]},"usage":{"total_tokens":15,"output_tokens":1,"input_tokens":14,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"280f9f0f-6f8b-4d48-b646-aceda50fe87c"}
+
+    headers:
+      content-type:
+      - text/event-stream;charset=UTF-8
+      date:
+      - Thu, 19 Mar 2026 08:14:36 GMT
+      req-arrive-time:
+      - '1773908076883'
+      req-cost-time:
+      - '264'
+      resp-start-time:
+      - '1773908077147'
+      server:
+      - istio-envoy
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin,Access-Control-Request-Method,Access-Control-Request-Headers
+      x-dashscope-call-gateway:
+      - 'true'
+      x-dashscope-finished:
+      - 'false'
+      x-dashscope-timeout:
+      - '298'
+      x-envoy-upstream-service-time:
+      - '259'
+      x-request-id:
+      - 280f9f0f-6f8b-4d48-b646-aceda50fe87c
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/cassettes/test_qwen_agent_with_tool_call.yaml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/cassettes/test_qwen_agent_with_tool_call.yaml
@@ -151,7 +151,7 @@ interactions:
             },
             {
               "role": "tool",
-              "content": "An error occurred when calling tool `get_current_weather_test`:\nAttributeError: 'str' object has no attribute 'get'\nTraceback:\n  File \"/Users/sipercai/miniforge3/lib/python3.12/site-packages/qwen_agent/agent.py\", line 192, in _call_tool\n    tool_result = tool.call(tool_args, **kwargs)\n                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/sipercai/project/pyins/team-work/loongsuite-python-agent/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/test_real_api.py\", line 204, in call\n    city = params.get(\"city\", \"unknown\")\n           ^^^^^^^^^^\n",
+              "content": "The weather in Beijing is sunny and 22 degrees Celsius.",
               "name": "get_current_weather_test",
               "extra": {
                 "function_id": "call_355b7a9ccc024c71a743ab"
@@ -298,7 +298,7 @@ interactions:
             },
             {
               "role": "tool",
-              "content": "An error occurred when calling tool `get_current_weather_test`:\nAttributeError: 'str' object has no attribute 'get'\nTraceback:\n  File \"/Users/sipercai/miniforge3/lib/python3.12/site-packages/qwen_agent/agent.py\", line 192, in _call_tool\n    tool_result = tool.call(tool_args, **kwargs)\n                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/sipercai/project/pyins/team-work/loongsuite-python-agent/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/test_real_api.py\", line 204, in call\n    city = params.get(\"city\", \"unknown\")\n           ^^^^^^^^^^\n",
+              "content": "The weather in Beijing is sunny and 22 degrees Celsius.",
               "name": "get_current_weather_test",
               "extra": {
                 "function_id": "call_355b7a9ccc024c71a743ab"
@@ -321,7 +321,7 @@ interactions:
             },
             {
               "role": "tool",
-              "content": "An error occurred when calling tool `get_current_weather_test`:\nAttributeError: 'str' object has no attribute 'get'\nTraceback:\n  File \"/Users/sipercai/miniforge3/lib/python3.12/site-packages/qwen_agent/agent.py\", line 192, in _call_tool\n    tool_result = tool.call(tool_args, **kwargs)\n                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/sipercai/project/pyins/team-work/loongsuite-python-agent/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/test_real_api.py\", line 204, in call\n    city = params.get(\"city\", \"unknown\")\n           ^^^^^^^^^^\n",
+              "content": "The weather in Beijing is sunny and 22 degrees Celsius.",
               "name": "get_current_weather_test",
               "extra": {
                 "function_id": "call_cbd8e5262b69466a8f8fdc"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/cassettes/test_qwen_agent_with_tool_call.yaml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/cassettes/test_qwen_agent_with_tool_call.yaml
@@ -1,0 +1,444 @@
+interactions:
+- request:
+    body: |-
+      {
+        "model": "qwen-max",
+        "parameters": {
+          "result_format": "message",
+          "incremental_output": true,
+          "seed": 1031217577,
+          "tools": [
+            {
+              "type": "function",
+              "function": {
+                "name": "get_current_weather_test",
+                "description": "Get the current weather for a given city.",
+                "parameters": [
+                  {
+                    "name": "city",
+                    "type": "string",
+                    "description": "The city name to get weather for.",
+                    "required": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "input": {
+          "messages": [
+            {
+              "role": "user",
+              "content": "What is the weather in Beijing right now?"
+            }
+          ]
+        }
+      }
+    headers:
+      Accept:
+      - text/event-stream
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '477'
+      Content-Type:
+      - application/json
+      X-Accel-Buffering:
+      - 'no'
+      X-DashScope-SSE:
+      - enable
+      authorization:
+      - Bearer test_dashscope_api_key
+      user-agent:
+      - dashscope/1.25.2; python/3.12.10; platform/macOS-15.1.1-arm64-arm-64bit; processor/arm;
+        incremental_to_full/0
+    method: POST
+    uri: https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation
+  response:
+    body:
+      string: |+
+        id:1
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":"","tool_calls":[{"index":0,"id":"call_355b7a9ccc024c71a743ab","type":"function","function":{"name":"get_current_weather_test","arguments":"{\"city\":"}}],"role":"assistant"},"index":0,"finish_reason":"null"}]},"usage":{"total_tokens":268,"output_tokens":16,"input_tokens":252,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"2b71822d-e756-4991-b683-0593ac350383"}
+
+        id:2
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":"","tool_calls":[{"index":0,"id":"","type":"function","function":{"arguments":" \"Beijing\"}"}}],"role":"assistant"},"index":0,"finish_reason":"null"}]},"usage":{"total_tokens":272,"output_tokens":20,"input_tokens":252,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"2b71822d-e756-4991-b683-0593ac350383"}
+
+        id:3
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":"","tool_calls":[{"index":0,"id":"","type":"function","function":{}}],"role":"assistant"},"index":0,"finish_reason":"tool_calls"}]},"usage":{"total_tokens":272,"output_tokens":20,"input_tokens":252,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"2b71822d-e756-4991-b683-0593ac350383"}
+
+    headers:
+      content-type:
+      - text/event-stream;charset=UTF-8
+      date:
+      - Thu, 19 Mar 2026 08:30:15 GMT
+      req-arrive-time:
+      - '1773909014615'
+      req-cost-time:
+      - '710'
+      resp-start-time:
+      - '1773909015325'
+      server:
+      - istio-envoy
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin,Access-Control-Request-Method,Access-Control-Request-Headers
+      x-dashscope-call-gateway:
+      - 'true'
+      x-dashscope-finished:
+      - 'false'
+      x-dashscope-timeout:
+      - '298'
+      x-envoy-upstream-service-time:
+      - '704'
+      x-request-id:
+      - 2b71822d-e756-4991-b683-0593ac350383
+    status:
+      code: 200
+      message: OK
+- request:
+    body: |-
+      {
+        "model": "qwen-max",
+        "parameters": {
+          "result_format": "message",
+          "incremental_output": true,
+          "seed": 751403280,
+          "tools": [
+            {
+              "type": "function",
+              "function": {
+                "name": "get_current_weather_test",
+                "description": "Get the current weather for a given city.",
+                "parameters": [
+                  {
+                    "name": "city",
+                    "type": "string",
+                    "description": "The city name to get weather for.",
+                    "required": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "input": {
+          "messages": [
+            {
+              "role": "user",
+              "content": "What is the weather in Beijing right now?"
+            },
+            {
+              "role": "assistant",
+              "tool_calls": [
+                {
+                  "id": "call_355b7a9ccc024c71a743ab",
+                  "type": "function",
+                  "function": {
+                    "name": "get_current_weather_test",
+                    "arguments": "{\"city\": \"Beijing\"}"
+                  }
+                }
+              ]
+            },
+            {
+              "role": "tool",
+              "content": "An error occurred when calling tool `get_current_weather_test`:\nAttributeError: 'str' object has no attribute 'get'\nTraceback:\n  File \"/Users/sipercai/miniforge3/lib/python3.12/site-packages/qwen_agent/agent.py\", line 192, in _call_tool\n    tool_result = tool.call(tool_args, **kwargs)\n                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/sipercai/project/pyins/team-work/loongsuite-python-agent/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/test_real_api.py\", line 204, in call\n    city = params.get(\"city\", \"unknown\")\n           ^^^^^^^^^^\n",
+              "name": "get_current_weather_test",
+              "extra": {
+                "function_id": "call_355b7a9ccc024c71a743ab"
+              },
+              "id": "call_355b7a9ccc024c71a743ab"
+            }
+          ]
+        }
+      }
+    headers:
+      Accept:
+      - text/event-stream
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '1422'
+      Content-Type:
+      - application/json
+      X-Accel-Buffering:
+      - 'no'
+      X-DashScope-SSE:
+      - enable
+      authorization:
+      - Bearer test_dashscope_api_key
+      user-agent:
+      - dashscope/1.25.2; python/3.12.10; platform/macOS-15.1.1-arm64-arm-64bit; processor/arm;
+        incremental_to_full/0
+    method: POST
+    uri: https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation
+  response:
+    body:
+      string: |+
+        id:1
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":"It","role":"assistant"},"index":0,"finish_reason":"null"}]},"usage":{"total_tokens":436,"output_tokens":2,"input_tokens":434,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"3b4ff815-8227-4f6b-bb55-4d2822e621d8"}
+
+        id:2
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":" seems there was","role":"assistant"},"index":0,"finish_reason":"null"}]},"usage":{"total_tokens":439,"output_tokens":5,"input_tokens":434,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"3b4ff815-8227-4f6b-bb55-4d2822e621d8"}
+
+        id:3
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":" an error retrieving","role":"assistant"},"index":0,"finish_reason":"null"}]},"usage":{"total_tokens":442,"output_tokens":8,"input_tokens":434,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"3b4ff815-8227-4f6b-bb55-4d2822e621d8"}
+
+        id:4
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":" the current weather for Beijing","role":"assistant"},"index":0,"finish_reason":"null"}]},"usage":{"total_tokens":447,"output_tokens":13,"input_tokens":434,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"3b4ff815-8227-4f6b-bb55-4d2822e621d8"}
+
+        id:5
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":". Let's try again.","role":"assistant"},"index":0,"finish_reason":"null"}]},"usage":{"total_tokens":453,"output_tokens":19,"input_tokens":434,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"3b4ff815-8227-4f6b-bb55-4d2822e621d8"}
+
+        id:6
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":"","tool_calls":[{"index":0,"id":"call_cbd8e5262b69466a8f8fdc","type":"function","function":{"name":"get_current_weather_test","arguments":"{\"city\": \"Be"}}],"role":"assistant"},"index":0,"finish_reason":"null"}]},"usage":{"total_tokens":471,"output_tokens":37,"input_tokens":434,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"3b4ff815-8227-4f6b-bb55-4d2822e621d8"}
+
+        id:7
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":"","tool_calls":[{"index":0,"id":"","type":"function","function":{"arguments":"ijing\"}"}}],"role":"assistant"},"index":0,"finish_reason":"tool_calls"}]},"usage":{"total_tokens":473,"output_tokens":39,"input_tokens":434,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"3b4ff815-8227-4f6b-bb55-4d2822e621d8"}
+
+    headers:
+      content-type:
+      - text/event-stream;charset=UTF-8
+      date:
+      - Thu, 19 Mar 2026 08:30:18 GMT
+      req-arrive-time:
+      - '1773909017561'
+      req-cost-time:
+      - '545'
+      resp-start-time:
+      - '1773909018107'
+      server:
+      - istio-envoy
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin,Access-Control-Request-Method,Access-Control-Request-Headers
+      x-dashscope-call-gateway:
+      - 'true'
+      x-dashscope-finished:
+      - 'false'
+      x-dashscope-timeout:
+      - '298'
+      x-envoy-upstream-service-time:
+      - '540'
+      x-request-id:
+      - 3b4ff815-8227-4f6b-bb55-4d2822e621d8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: |-
+      {
+        "model": "qwen-max",
+        "parameters": {
+          "result_format": "message",
+          "incremental_output": true,
+          "seed": 159133726,
+          "tools": [
+            {
+              "type": "function",
+              "function": {
+                "name": "get_current_weather_test",
+                "description": "Get the current weather for a given city.",
+                "parameters": [
+                  {
+                    "name": "city",
+                    "type": "string",
+                    "description": "The city name to get weather for.",
+                    "required": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "input": {
+          "messages": [
+            {
+              "role": "user",
+              "content": "What is the weather in Beijing right now?"
+            },
+            {
+              "role": "assistant",
+              "tool_calls": [
+                {
+                  "id": "call_355b7a9ccc024c71a743ab",
+                  "type": "function",
+                  "function": {
+                    "name": "get_current_weather_test",
+                    "arguments": "{\"city\": \"Beijing\"}"
+                  }
+                }
+              ]
+            },
+            {
+              "role": "tool",
+              "content": "An error occurred when calling tool `get_current_weather_test`:\nAttributeError: 'str' object has no attribute 'get'\nTraceback:\n  File \"/Users/sipercai/miniforge3/lib/python3.12/site-packages/qwen_agent/agent.py\", line 192, in _call_tool\n    tool_result = tool.call(tool_args, **kwargs)\n                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/sipercai/project/pyins/team-work/loongsuite-python-agent/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/test_real_api.py\", line 204, in call\n    city = params.get(\"city\", \"unknown\")\n           ^^^^^^^^^^\n",
+              "name": "get_current_weather_test",
+              "extra": {
+                "function_id": "call_355b7a9ccc024c71a743ab"
+              },
+              "id": "call_355b7a9ccc024c71a743ab"
+            },
+            {
+              "role": "assistant",
+              "content": "It seems there was an error retrieving the current weather for Beijing. Let's try again.",
+              "tool_calls": [
+                {
+                  "id": "call_cbd8e5262b69466a8f8fdc",
+                  "type": "function",
+                  "function": {
+                    "name": "get_current_weather_test",
+                    "arguments": "{\"city\": \"Beijing\"}"
+                  }
+                }
+              ]
+            },
+            {
+              "role": "tool",
+              "content": "An error occurred when calling tool `get_current_weather_test`:\nAttributeError: 'str' object has no attribute 'get'\nTraceback:\n  File \"/Users/sipercai/miniforge3/lib/python3.12/site-packages/qwen_agent/agent.py\", line 192, in _call_tool\n    tool_result = tool.call(tool_args, **kwargs)\n                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/sipercai/project/pyins/team-work/loongsuite-python-agent/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/test_real_api.py\", line 204, in call\n    city = params.get(\"city\", \"unknown\")\n           ^^^^^^^^^^\n",
+              "name": "get_current_weather_test",
+              "extra": {
+                "function_id": "call_cbd8e5262b69466a8f8fdc"
+              },
+              "id": "call_cbd8e5262b69466a8f8fdc"
+            }
+          ]
+        }
+      }
+    headers:
+      Accept:
+      - text/event-stream
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '2471'
+      Content-Type:
+      - application/json
+      X-Accel-Buffering:
+      - 'no'
+      X-DashScope-SSE:
+      - enable
+      authorization:
+      - Bearer test_dashscope_api_key
+      user-agent:
+      - dashscope/1.25.2; python/3.12.10; platform/macOS-15.1.1-arm64-arm-64bit; processor/arm;
+        incremental_to_full/0
+    method: POST
+    uri: https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation
+  response:
+    body:
+      string: |+
+        id:1
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":"I","role":"assistant"},"index":0,"finish_reason":"null"}]},"usage":{"total_tokens":637,"output_tokens":2,"input_tokens":635,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"f5412765-6e4e-457a-abe6-ef0eca865a38"}
+
+        id:2
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":"'m encountering","role":"assistant"},"index":0,"finish_reason":"null"}]},"usage":{"total_tokens":639,"output_tokens":4,"input_tokens":635,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"f5412765-6e4e-457a-abe6-ef0eca865a38"}
+
+        id:3
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":" a","role":"assistant"},"index":0,"finish_reason":"null"}]},"usage":{"total_tokens":640,"output_tokens":5,"input_tokens":635,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"f5412765-6e4e-457a-abe6-ef0eca865a38"}
+
+        id:4
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":" technical issue while trying","role":"assistant"},"index":0,"finish_reason":"null"}]},"usage":{"total_tokens":644,"output_tokens":9,"input_tokens":635,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"f5412765-6e4e-457a-abe6-ef0eca865a38"}
+
+        id:5
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":" to fetch the current weather","role":"assistant"},"index":0,"finish_reason":"null"}]},"usage":{"total_tokens":649,"output_tokens":14,"input_tokens":635,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"f5412765-6e4e-457a-abe6-ef0eca865a38"}
+
+        id:6
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":" for Beijing. Please","role":"assistant"},"index":0,"finish_reason":"null"}]},"usage":{"total_tokens":653,"output_tokens":18,"input_tokens":635,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"f5412765-6e4e-457a-abe6-ef0eca865a38"}
+
+        id:7
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":" try again later or","role":"assistant"},"index":0,"finish_reason":"null"}]},"usage":{"total_tokens":657,"output_tokens":22,"input_tokens":635,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"f5412765-6e4e-457a-abe6-ef0eca865a38"}
+
+        id:8
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":" check the weather through","role":"assistant"},"index":0,"finish_reason":"null"}]},"usage":{"total_tokens":661,"output_tokens":26,"input_tokens":635,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"f5412765-6e4e-457a-abe6-ef0eca865a38"}
+
+        id:9
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":" an alternative method. Ap","role":"assistant"},"index":0,"finish_reason":"null"}]},"usage":{"total_tokens":666,"output_tokens":31,"input_tokens":635,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"f5412765-6e4e-457a-abe6-ef0eca865a38"}
+
+        id:10
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":"ologies for the inconvenience.","role":"assistant"},"index":0,"finish_reason":"null"}]},"usage":{"total_tokens":671,"output_tokens":36,"input_tokens":635,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"f5412765-6e4e-457a-abe6-ef0eca865a38"}
+
+        id:11
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":"","role":"assistant"},"index":0,"finish_reason":"stop"}]},"usage":{"total_tokens":671,"output_tokens":36,"input_tokens":635,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"f5412765-6e4e-457a-abe6-ef0eca865a38"}
+
+    headers:
+      content-type:
+      - text/event-stream;charset=UTF-8
+      date:
+      - Thu, 19 Mar 2026 08:30:20 GMT
+      req-arrive-time:
+      - '1773909019683'
+      req-cost-time:
+      - '820'
+      resp-start-time:
+      - '1773909020504'
+      server:
+      - istio-envoy
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin,Access-Control-Request-Method,Access-Control-Request-Headers
+      x-dashscope-call-gateway:
+      - 'true'
+      x-dashscope-finished:
+      - 'false'
+      x-dashscope-timeout:
+      - '298'
+      x-envoy-upstream-service-time:
+      - '814'
+      x-request-id:
+      - f5412765-6e4e-457a-abe6-ef0eca865a38
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/cassettes/test_react_multi_round.yaml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/cassettes/test_react_multi_round.yaml
@@ -1,0 +1,244 @@
+interactions:
+- request:
+    body: |-
+      {
+        "model": "qwen-max",
+        "parameters": {
+          "result_format": "message",
+          "incremental_output": true,
+          "seed": 700291534,
+          "tools": [
+            {
+              "type": "function",
+              "function": {
+                "name": "calculator_react_test",
+                "description": "Evaluate a simple arithmetic expression and return the numeric result.",
+                "parameters": [
+                  {
+                    "name": "expression",
+                    "type": "string",
+                    "description": "The arithmetic expression to evaluate, e.g. '3 * 7'.",
+                    "required": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "input": {
+          "messages": [
+            {
+              "role": "user",
+              "content": "What is 6 multiplied by 7?"
+            }
+          ]
+        }
+      }
+    headers:
+      Accept:
+      - text/event-stream
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '512'
+      Content-Type:
+      - application/json
+      X-Accel-Buffering:
+      - 'no'
+      X-DashScope-SSE:
+      - enable
+      authorization:
+      - Bearer test_dashscope_api_key
+      user-agent:
+      - dashscope/1.25.2; python/3.12.10; platform/macOS-15.1.1-arm64-arm-64bit; processor/arm;
+        incremental_to_full/0
+    method: POST
+    uri: https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation
+  response:
+    body:
+      string: |+
+        id:1
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":"","tool_calls":[{"index":0,"id":"call_3f06405749c34b749ac694","type":"function","function":{"name":"calculator_react_test","arguments":"{\"expression\":"}}],"role":"assistant"},"index":0,"finish_reason":"null"}]},"usage":{"total_tokens":278,"output_tokens":16,"input_tokens":262,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"9e265eb0-eee3-4b65-87ce-9ebb6cae2d0c"}
+
+        id:2
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":"","tool_calls":[{"index":0,"id":"","type":"function","function":{"arguments":" \"6 * 7\"}"}}],"role":"assistant"},"index":0,"finish_reason":"null"}]},"usage":{"total_tokens":284,"output_tokens":22,"input_tokens":262,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"9e265eb0-eee3-4b65-87ce-9ebb6cae2d0c"}
+
+        id:3
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":"","tool_calls":[{"index":0,"id":"","type":"function","function":{}}],"role":"assistant"},"index":0,"finish_reason":"tool_calls"}]},"usage":{"total_tokens":284,"output_tokens":22,"input_tokens":262,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"9e265eb0-eee3-4b65-87ce-9ebb6cae2d0c"}
+
+    headers:
+      content-type:
+      - text/event-stream;charset=UTF-8
+      date:
+      - Fri, 20 Mar 2026 02:22:39 GMT
+      req-arrive-time:
+      - '1773973359070'
+      req-cost-time:
+      - '850'
+      resp-start-time:
+      - '1773973359920'
+      server:
+      - istio-envoy
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin,Access-Control-Request-Method,Access-Control-Request-Headers
+      x-dashscope-call-gateway:
+      - 'true'
+      x-dashscope-finished:
+      - 'false'
+      x-dashscope-timeout:
+      - '298'
+      x-envoy-upstream-service-time:
+      - '842'
+      x-request-id:
+      - 9e265eb0-eee3-4b65-87ce-9ebb6cae2d0c
+    status:
+      code: 200
+      message: OK
+- request:
+    body: |-
+      {
+        "model": "qwen-max",
+        "parameters": {
+          "result_format": "message",
+          "incremental_output": true,
+          "seed": 40957755,
+          "tools": [
+            {
+              "type": "function",
+              "function": {
+                "name": "calculator_react_test",
+                "description": "Evaluate a simple arithmetic expression and return the numeric result.",
+                "parameters": [
+                  {
+                    "name": "expression",
+                    "type": "string",
+                    "description": "The arithmetic expression to evaluate, e.g. '3 * 7'.",
+                    "required": true
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "input": {
+          "messages": [
+            {
+              "role": "user",
+              "content": "What is 6 multiplied by 7?"
+            },
+            {
+              "role": "assistant",
+              "tool_calls": [
+                {
+                  "id": "call_3f06405749c34b749ac694",
+                  "type": "function",
+                  "function": {
+                    "name": "calculator_react_test",
+                    "arguments": "{\"expression\": \"6 * 7\"}"
+                  }
+                }
+              ]
+            },
+            {
+              "role": "tool",
+              "content": "42",
+              "name": "calculator_react_test",
+              "extra": {
+                "function_id": "call_3f06405749c34b749ac694"
+              },
+              "id": "call_3f06405749c34b749ac694"
+            }
+          ]
+        }
+      }
+    headers:
+      Accept:
+      - text/event-stream
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '862'
+      Content-Type:
+      - application/json
+      X-Accel-Buffering:
+      - 'no'
+      X-DashScope-SSE:
+      - enable
+      authorization:
+      - Bearer test_dashscope_api_key
+      user-agent:
+      - dashscope/1.25.2; python/3.12.10; platform/macOS-15.1.1-arm64-arm-64bit; processor/arm;
+        incremental_to_full/0
+    method: POST
+    uri: https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation
+  response:
+    body:
+      string: |+
+        id:1
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":"The result of","role":"assistant"},"index":0,"finish_reason":"null"}]},"usage":{"total_tokens":299,"output_tokens":4,"input_tokens":295,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"144bde91-158f-46e9-ac9c-49249e330cbc"}
+
+        id:2
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":" 6 multiplied","role":"assistant"},"index":0,"finish_reason":"null"}]},"usage":{"total_tokens":302,"output_tokens":7,"input_tokens":295,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"144bde91-158f-46e9-ac9c-49249e330cbc"}
+
+        id:3
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":" by 7","role":"assistant"},"index":0,"finish_reason":"null"}]},"usage":{"total_tokens":305,"output_tokens":10,"input_tokens":295,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"144bde91-158f-46e9-ac9c-49249e330cbc"}
+
+        id:4
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":" is 42.","role":"assistant"},"index":0,"finish_reason":"null"}]},"usage":{"total_tokens":310,"output_tokens":15,"input_tokens":295,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"144bde91-158f-46e9-ac9c-49249e330cbc"}
+
+        id:5
+        event:result
+        :HTTP_STATUS/200
+        data:{"output":{"choices":[{"message":{"content":"","role":"assistant"},"index":0,"finish_reason":"stop"}]},"usage":{"total_tokens":310,"output_tokens":15,"input_tokens":295,"prompt_tokens_details":{"cached_tokens":0}},"request_id":"144bde91-158f-46e9-ac9c-49249e330cbc"}
+
+    headers:
+      content-type:
+      - text/event-stream;charset=UTF-8
+      date:
+      - Fri, 20 Mar 2026 02:22:41 GMT
+      req-arrive-time:
+      - '1773973360868'
+      req-cost-time:
+      - '447'
+      resp-start-time:
+      - '1773973361315'
+      server:
+      - istio-envoy
+      transfer-encoding:
+      - chunked
+      vary:
+      - Origin,Access-Control-Request-Method,Access-Control-Request-Headers
+      x-dashscope-call-gateway:
+      - 'true'
+      x-dashscope-finished:
+      - 'false'
+      x-dashscope-timeout:
+      - '298'
+      x-envoy-upstream-service-time:
+      - '439'
+      x-request-id:
+      - 144bde91-158f-46e9-ac9c-49249e330cbc
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/conftest.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/conftest.py
@@ -1,0 +1,205 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test configuration for Qwen-Agent instrumentation tests."""
+
+import json
+import os
+
+import pytest
+import yaml
+from vcr.stubs import VCRHTTPResponse
+
+# Set DASHSCOPE_API_KEY before any dashscope/qwen-agent imports
+# dashscope SDK reads environment variables at module import time
+if "DASHSCOPE_API_KEY" not in os.environ:
+    os.environ["DASHSCOPE_API_KEY"] = "test_dashscope_api_key"
+
+from opentelemetry.instrumentation.qwen_agent import QwenAgentInstrumentor
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import (
+    InMemoryLogExporter,
+    SimpleLogRecordProcessor,
+)
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+
+
+def pytest_configure(config: pytest.Config):
+    os.environ["OTEL_SEMCONV_STABILITY_OPT_IN"] = "gen_ai_latest_experimental"
+
+
+# ==================== Exporters ====================
+
+
+@pytest.fixture(scope="function", name="span_exporter")
+def fixture_span_exporter():
+    exporter = InMemorySpanExporter()
+    yield exporter
+
+
+@pytest.fixture(scope="function", name="log_exporter")
+def fixture_log_exporter():
+    exporter = InMemoryLogExporter()
+    yield exporter
+
+
+@pytest.fixture(scope="function", name="metric_reader")
+def fixture_metric_reader():
+    reader = InMemoryMetricReader()
+    yield reader
+
+
+# ==================== Providers ====================
+
+
+@pytest.fixture(scope="function", name="tracer_provider")
+def fixture_tracer_provider(span_exporter):
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+    return provider
+
+
+@pytest.fixture(scope="function", name="logger_provider")
+def fixture_logger_provider(log_exporter):
+    provider = LoggerProvider()
+    provider.add_log_record_processor(SimpleLogRecordProcessor(log_exporter))
+    return provider
+
+
+@pytest.fixture(scope="function", name="meter_provider")
+def fixture_meter_provider(metric_reader):
+    meter_provider = MeterProvider(
+        metric_readers=[metric_reader],
+    )
+    return meter_provider
+
+
+# ==================== Instrumentation ====================
+
+
+@pytest.fixture(scope="function")
+def instrument(tracer_provider, logger_provider, meter_provider):
+    instrumentor = QwenAgentInstrumentor()
+    instrumentor.instrument(
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        skip_dep_check=True,
+    )
+    yield instrumentor
+    instrumentor.uninstrument()
+
+
+# ==================== VCR Support ====================
+
+
+def _patch_vcr_response():
+    """Patch VCRHTTPResponse to add missing version_string attribute.
+
+    Newer urllib3 requires version_string on HTTP responses, but VCR.py's
+    VCRHTTPResponse stub does not set it, causing AttributeError when dashscope
+    SDK streams SSE responses.
+    """
+    if not hasattr(VCRHTTPResponse, "version_string"):
+        VCRHTTPResponse.version_string = "HTTP/1.1"
+
+
+_patch_vcr_response()
+
+
+class LiteralBlockScalar(str):
+    """Formats the string as a literal block scalar."""
+
+
+def literal_block_scalar_presenter(dumper, data):
+    """Represents a scalar string as a literal block."""
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+
+
+yaml.add_representer(LiteralBlockScalar, literal_block_scalar_presenter)
+
+
+def process_string_value(string_value):
+    """Pretty-prints JSON or returns long strings as a LiteralBlockScalar."""
+    try:
+        json_data = json.loads(string_value)
+        return LiteralBlockScalar(json.dumps(json_data, indent=2))
+    except (ValueError, TypeError):
+        if len(string_value) > 80:
+            return LiteralBlockScalar(string_value)
+    return string_value
+
+
+def convert_body_to_literal(data):
+    """Searches the data for body strings, attempting to pretty-print JSON."""
+    if isinstance(data, dict):
+        for key, value in data.items():
+            if key == "body" and isinstance(value, dict) and "string" in value:
+                value["string"] = process_string_value(value["string"])
+            elif key == "body" and isinstance(value, str):
+                data[key] = process_string_value(value)
+            else:
+                convert_body_to_literal(value)
+    elif isinstance(data, list):
+        for idx, choice in enumerate(data):
+            data[idx] = convert_body_to_literal(choice)
+    return data
+
+
+class PrettyPrintJSONBody:
+    """Makes request and response body recordings more readable."""
+
+    @staticmethod
+    def serialize(cassette_dict):
+        cassette_dict = convert_body_to_literal(cassette_dict)
+        return yaml.dump(
+            cassette_dict, default_flow_style=False, allow_unicode=True
+        )
+
+    @staticmethod
+    def deserialize(cassette_string):
+        return yaml.load(cassette_string, Loader=yaml.Loader)
+
+
+def scrub_response_headers(response):
+    """Scrubs sensitive response headers."""
+    if "x-dashscope-request-id" in response.get("headers", {}):
+        response["headers"]["x-dashscope-request-id"] = "test_request_id"
+    return response
+
+
+@pytest.fixture(scope="module")
+def vcr_config():
+    """Configure VCR for recording/replaying HTTP interactions."""
+    return {
+        "filter_headers": [
+            ("authorization", "Bearer test_dashscope_api_key"),
+            ("x-dashscope-api-key", "test_dashscope_api_key"),
+        ],
+        "decode_compressed_response": True,
+        "before_record_response": scrub_response_headers,
+    }
+
+
+@pytest.fixture(scope="module", autouse=True)
+def fixture_vcr(vcr):
+    """Register custom VCR serializer."""
+    vcr.register_serializer("yaml", PrettyPrintJSONBody)
+    return vcr

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/requirements.latest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/requirements.latest.txt
@@ -1,0 +1,37 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ********************************
+# WARNING: NOT HERMETIC !!!!!!!!!!
+# ********************************
+#
+# Installed together with {[testenv]test_deps} from tox-loongsuite.ini
+# (opentelemetry-api/sdk/semantic-conventions from CORE_REPO).
+
+# Newest supported versions of external dependencies for qwen-agent tests.
+# numpy / soundfile / python-dateutil: see requirements.oldest.txt
+
+qwen-agent>=0.0.20
+numpy>=1.24.0
+soundfile>=0.12.0
+python-dateutil>=2.8.0
+pytest==7.4.4
+pytest-vcr==1.0.2
+vcrpy>=4.2.0
+pyyaml>=6.0
+wrapt==1.17.3
+
+-e opentelemetry-instrumentation
+-e instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent
+-e util/opentelemetry-util-genai

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/requirements.oldest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/requirements.oldest.txt
@@ -1,0 +1,35 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Oldest supported versions for loongsuite-instrumentation-qwen-agent tests.
+# numpy / soundfile / python-dateutil: not always declared by qwen-agent but
+# required at import time by current qwen_agent modules used in tests.
+
+qwen-agent>=0.0.20
+numpy>=1.24.0
+soundfile>=0.12.0
+python-dateutil>=2.8.0
+pytest==7.4.4
+pytest-vcr==1.0.2
+vcrpy>=4.2.0
+pyyaml>=6.0
+wrapt==1.17.3
+opentelemetry-exporter-otlp-proto-http~=1.30
+opentelemetry-api==1.37
+opentelemetry-sdk==1.37
+opentelemetry-semantic-conventions==0.58b0
+opentelemetry-instrumentation==0.58b0
+
+-e instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent
+-e util/opentelemetry-util-genai

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/test_instrumentor.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/test_instrumentor.py
@@ -31,7 +31,9 @@ from opentelemetry.util.genai.types import ToolCall
 class TestQwenAgentInstrumentor:
     """Test the instrumentor lifecycle."""
 
-    def test_instrument_and_uninstrument(self, tracer_provider, logger_provider, meter_provider):
+    def test_instrument_and_uninstrument(
+        self, tracer_provider, logger_provider, meter_provider
+    ):
         """Test that instrument/uninstrument works without errors."""
         instrumentor = QwenAgentInstrumentor()
         instrumentor.instrument(
@@ -109,7 +111,9 @@ class TestMessageConversion:
 
     def test_convert_function_response_message(self):
         """Test converting a function role message (tool result)."""
-        msg = Message(role="function", name="get_weather", content="Sunny, 25°C")
+        msg = Message(
+            role="function", name="get_weather", content="Sunny, 25°C"
+        )
         result = convert_qwen_messages_to_input_messages([msg])
         assert len(result) == 1
         assert result[0].role == "function"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/test_instrumentor.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/test_instrumentor.py
@@ -20,10 +20,10 @@ from qwen_agent.llm.schema import ContentItem, FunctionCall, Message
 
 from opentelemetry.instrumentation.qwen_agent import QwenAgentInstrumentor
 from opentelemetry.instrumentation.qwen_agent.utils import (
-    convert_qwen_messages_to_input_messages,
-    convert_qwen_messages_to_output_messages,
-    create_llm_invocation,
-    get_provider_name,
+    _convert_qwen_messages_to_input_messages,
+    _convert_qwen_messages_to_output_messages,
+    _create_llm_invocation,
+    _get_provider_name,
 )
 from opentelemetry.util.genai.types import ToolCall
 
@@ -59,24 +59,24 @@ class TestProviderName:
     def test_dashscope_model_type(self):
         llm = MagicMock()
         llm.model_type = "qwen_dashscope"
-        assert get_provider_name(llm) == "dashscope"
+        assert _get_provider_name(llm) == "dashscope"
 
     def test_oai_model_type(self):
         llm = MagicMock()
         llm.model_type = "oai"
-        assert get_provider_name(llm) == "openai"
+        assert _get_provider_name(llm) == "openai"
 
     def test_unknown_model_type(self):
         llm = MagicMock()
         llm.model_type = "unknown_custom"
         type(llm).__name__ = "CustomModel"
-        assert get_provider_name(llm) == "qwen_agent"
+        assert _get_provider_name(llm) == "dashscope"
 
     def test_class_name_fallback_dashscope(self):
         llm = MagicMock()
         llm.model_type = "custom"
         type(llm).__name__ = "QwenDashScopeChat"
-        assert get_provider_name(llm) == "dashscope"
+        assert _get_provider_name(llm) == "dashscope"
 
 
 class TestMessageConversion:
@@ -85,7 +85,7 @@ class TestMessageConversion:
     def test_convert_simple_user_message(self):
         """Test converting a simple user text message."""
         messages = [Message(role="user", content="Hello")]
-        result = convert_qwen_messages_to_input_messages(messages)
+        result = _convert_qwen_messages_to_input_messages(messages)
         assert len(result) == 1
         assert result[0].role == "user"
         assert len(result[0].parts) == 1
@@ -101,7 +101,7 @@ class TestMessageConversion:
                 arguments='{"city": "Beijing"}',
             ),
         )
-        result = convert_qwen_messages_to_output_messages([msg])
+        result = _convert_qwen_messages_to_output_messages([msg])
         assert len(result) == 1
         assert result[0].finish_reason == "tool_calls"
         # Should have a ToolCall part
@@ -114,13 +114,13 @@ class TestMessageConversion:
         msg = Message(
             role="function", name="get_weather", content="Sunny, 25°C"
         )
-        result = convert_qwen_messages_to_input_messages([msg])
+        result = _convert_qwen_messages_to_input_messages([msg])
         assert len(result) == 1
         assert result[0].role == "function"
 
     def test_convert_empty_messages(self):
         """Test converting empty message list."""
-        result = convert_qwen_messages_to_input_messages([])
+        result = _convert_qwen_messages_to_input_messages([])
         assert result == []
 
     def test_convert_multimodal_content(self):
@@ -129,7 +129,7 @@ class TestMessageConversion:
             role="user",
             content=[ContentItem(text="Describe this image")],
         )
-        result = convert_qwen_messages_to_input_messages([msg])
+        result = _convert_qwen_messages_to_input_messages([msg])
         assert len(result) == 1
         assert result[0].parts[0].content == "Describe this image"
 
@@ -144,7 +144,7 @@ class TestLLMInvocation:
         llm.model_type = "qwen_dashscope"
 
         messages = [Message(role="user", content="Hi")]
-        invocation = create_llm_invocation(llm, messages)
+        invocation = _create_llm_invocation(llm, messages)
 
         assert invocation.request_model == "qwen-max"
         assert invocation.provider == "dashscope"
@@ -164,7 +164,7 @@ class TestLLMInvocation:
                 "parameters": {"type": "object", "properties": {}},
             }
         ]
-        invocation = create_llm_invocation(llm, messages, functions=functions)
+        invocation = _create_llm_invocation(llm, messages, functions=functions)
 
         # P1 fix: tool_definitions are now FunctionToolDefinition objects on invocation.tool_definitions
         assert len(invocation.tool_definitions) == 1

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/test_instrumentor.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/test_instrumentor.py
@@ -1,0 +1,169 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for QwenAgentInstrumentor."""
+
+from unittest.mock import MagicMock
+
+from qwen_agent.llm.schema import ContentItem, FunctionCall, Message
+
+from opentelemetry.instrumentation.qwen_agent import QwenAgentInstrumentor
+from opentelemetry.instrumentation.qwen_agent.utils import (
+    convert_qwen_messages_to_input_messages,
+    convert_qwen_messages_to_output_messages,
+    create_llm_invocation,
+    get_provider_name,
+)
+from opentelemetry.util.genai.types import ToolCall
+
+
+class TestQwenAgentInstrumentor:
+    """Test the instrumentor lifecycle."""
+
+    def test_instrument_and_uninstrument(self, tracer_provider, logger_provider, meter_provider):
+        """Test that instrument/uninstrument works without errors."""
+        instrumentor = QwenAgentInstrumentor()
+        instrumentor.instrument(
+            tracer_provider=tracer_provider,
+            logger_provider=logger_provider,
+            meter_provider=meter_provider,
+            skip_dep_check=True,
+        )
+        assert instrumentor._handler is not None
+        instrumentor.uninstrument()
+        assert instrumentor._handler is None
+
+    def test_instrumentation_dependencies(self):
+        """Test that dependencies are correctly specified."""
+        instrumentor = QwenAgentInstrumentor()
+        deps = instrumentor.instrumentation_dependencies()
+        assert ("qwen-agent >= 0.0.20",) == deps
+
+
+class TestProviderName:
+    """Test provider name detection."""
+
+    def test_dashscope_model_type(self):
+        llm = MagicMock()
+        llm.model_type = "qwen_dashscope"
+        assert get_provider_name(llm) == "dashscope"
+
+    def test_oai_model_type(self):
+        llm = MagicMock()
+        llm.model_type = "oai"
+        assert get_provider_name(llm) == "openai"
+
+    def test_unknown_model_type(self):
+        llm = MagicMock()
+        llm.model_type = "unknown_custom"
+        type(llm).__name__ = "CustomModel"
+        assert get_provider_name(llm) == "qwen_agent"
+
+    def test_class_name_fallback_dashscope(self):
+        llm = MagicMock()
+        llm.model_type = "custom"
+        type(llm).__name__ = "QwenDashScopeChat"
+        assert get_provider_name(llm) == "dashscope"
+
+
+class TestMessageConversion:
+    """Test qwen-agent message to GenAI type conversion."""
+
+    def test_convert_simple_user_message(self):
+        """Test converting a simple user text message."""
+        messages = [Message(role="user", content="Hello")]
+        result = convert_qwen_messages_to_input_messages(messages)
+        assert len(result) == 1
+        assert result[0].role == "user"
+        assert len(result[0].parts) == 1
+        assert result[0].parts[0].content == "Hello"
+
+    def test_convert_function_call_message(self):
+        """Test converting a message with function_call."""
+        msg = Message(
+            role="assistant",
+            content="",
+            function_call=FunctionCall(
+                name="get_weather",
+                arguments='{"city": "Beijing"}',
+            ),
+        )
+        result = convert_qwen_messages_to_output_messages([msg])
+        assert len(result) == 1
+        assert result[0].finish_reason == "tool_calls"
+        # Should have a ToolCall part
+        tool_calls = [p for p in result[0].parts if isinstance(p, ToolCall)]
+        assert len(tool_calls) == 1
+        assert tool_calls[0].name == "get_weather"
+
+    def test_convert_function_response_message(self):
+        """Test converting a function role message (tool result)."""
+        msg = Message(role="function", name="get_weather", content="Sunny, 25°C")
+        result = convert_qwen_messages_to_input_messages([msg])
+        assert len(result) == 1
+        assert result[0].role == "function"
+
+    def test_convert_empty_messages(self):
+        """Test converting empty message list."""
+        result = convert_qwen_messages_to_input_messages([])
+        assert result == []
+
+    def test_convert_multimodal_content(self):
+        """Test converting message with ContentItem list."""
+        msg = Message(
+            role="user",
+            content=[ContentItem(text="Describe this image")],
+        )
+        result = convert_qwen_messages_to_input_messages([msg])
+        assert len(result) == 1
+        assert result[0].parts[0].content == "Describe this image"
+
+
+class TestLLMInvocation:
+    """Test LLM invocation creation."""
+
+    def test_create_basic_invocation(self):
+        """Test creating a basic LLM invocation."""
+        llm = MagicMock()
+        llm.model = "qwen-max"
+        llm.model_type = "qwen_dashscope"
+
+        messages = [Message(role="user", content="Hi")]
+        invocation = create_llm_invocation(llm, messages)
+
+        assert invocation.request_model == "qwen-max"
+        assert invocation.provider == "dashscope"
+        assert len(invocation.input_messages) == 1
+
+    def test_create_invocation_with_functions(self):
+        """Test creating invocation with tool definitions."""
+        llm = MagicMock()
+        llm.model = "qwen-max"
+        llm.model_type = "qwen_dashscope"
+
+        messages = [Message(role="user", content="What's the weather?")]
+        functions = [
+            {
+                "name": "get_weather",
+                "description": "Get weather info",
+                "parameters": {"type": "object", "properties": {}},
+            }
+        ]
+        invocation = create_llm_invocation(llm, messages, functions=functions)
+
+        # P1 fix: tool_definitions are now FunctionToolDefinition objects on invocation.tool_definitions
+        assert len(invocation.tool_definitions) == 1
+        tool_def = invocation.tool_definitions[0]
+        assert tool_def.name == "get_weather"
+        assert tool_def.description == "Get weather info"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/test_real_api.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/test_real_api.py
@@ -62,7 +62,13 @@ def _make_providers():
     metric_reader = InMemoryMetricReader()
     meter_provider = MeterProvider(metric_readers=[metric_reader])
 
-    return tracer_provider, span_exporter, logger_provider, log_exporter, meter_provider
+    return (
+        tracer_provider,
+        span_exporter,
+        logger_provider,
+        log_exporter,
+        meter_provider,
+    )
 
 
 @pytest.mark.vcr()
@@ -74,7 +80,13 @@ def test_qwen_agent_basic_run():
     - A chat (LLM) span is produced as a child
     - Both spans have the expected gen_ai.* attributes
     """
-    tracer_provider, span_exporter, logger_provider, log_exporter, meter_provider = _make_providers()
+    (
+        tracer_provider,
+        span_exporter,
+        logger_provider,
+        log_exporter,
+        meter_provider,
+    ) = _make_providers()
 
     instrumentor = QwenAgentInstrumentor()
     instrumentor.instrument(
@@ -96,31 +108,57 @@ def test_qwen_agent_basic_run():
         instrumentor.uninstrument()
 
     spans = span_exporter.get_finished_spans()
-    assert len(spans) >= 2, f"Expected at least 2 spans, got {len(spans)}: {[s.name for s in spans]}"
+    assert len(spans) >= 2, (
+        f"Expected at least 2 spans, got {len(spans)}: {[s.name for s in spans]}"
+    )
 
     # Find invoke_agent span
     agent_spans = [s for s in spans if "invoke_agent" in s.name]
-    assert len(agent_spans) >= 1, f"No invoke_agent span found in: {[s.name for s in spans]}"
+    assert len(agent_spans) >= 1, (
+        f"No invoke_agent span found in: {[s.name for s in spans]}"
+    )
     agent_span = agent_spans[0]
-    assert agent_span.attributes.get(GenAIAttributes.GEN_AI_OPERATION_NAME) == "invoke_agent"
+    assert (
+        agent_span.attributes.get(GenAIAttributes.GEN_AI_OPERATION_NAME)
+        == "invoke_agent"
+    )
 
     # Find chat/LLM span
     chat_spans = [s for s in spans if s.name.startswith("chat ")]
-    assert len(chat_spans) >= 1, f"No chat span found in: {[s.name for s in spans]}"
+    assert len(chat_spans) >= 1, (
+        f"No chat span found in: {[s.name for s in spans]}"
+    )
     chat_span = chat_spans[0]
 
     # Verify key span attributes on the chat span
-    assert chat_span.attributes.get(GenAIAttributes.GEN_AI_OPERATION_NAME) == "chat"
-    assert chat_span.attributes.get(GenAIAttributes.GEN_AI_PROVIDER_NAME) == "dashscope"
-    assert chat_span.attributes.get(GenAIAttributes.GEN_AI_REQUEST_MODEL) == "qwen-max"
+    assert (
+        chat_span.attributes.get(GenAIAttributes.GEN_AI_OPERATION_NAME)
+        == "chat"
+    )
+    assert (
+        chat_span.attributes.get(GenAIAttributes.GEN_AI_PROVIDER_NAME)
+        == "dashscope"
+    )
+    assert (
+        chat_span.attributes.get(GenAIAttributes.GEN_AI_REQUEST_MODEL)
+        == "qwen-max"
+    )
 
     # response_model_name fix: GEN_AI_RESPONSE_MODEL should now be populated
-    response_model = chat_span.attributes.get(GenAIAttributes.GEN_AI_RESPONSE_MODEL)
-    assert response_model is not None, "gen_ai.response.model should be set (P0 fix)"
+    response_model = chat_span.attributes.get(
+        GenAIAttributes.GEN_AI_RESPONSE_MODEL
+    )
+    assert response_model is not None, (
+        "gen_ai.response.model should be set (P0 fix)"
+    )
 
     # finish_reasons fix: GEN_AI_RESPONSE_FINISH_REASONS should be populated
-    finish_reasons = chat_span.attributes.get(GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS)
-    assert finish_reasons is not None, "gen_ai.response.finish_reasons should be set (P0 fix)"
+    finish_reasons = chat_span.attributes.get(
+        GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS
+    )
+    assert finish_reasons is not None, (
+        "gen_ai.response.finish_reasons should be set (P0 fix)"
+    )
 
 
 @pytest.mark.vcr()
@@ -130,7 +168,13 @@ def test_qwen_agent_stream_llm_with_ttft():
     Verifies that P2 fix (monotonic_first_token_s) is working:
     - gen_ai.response.time_to_first_token attribute is recorded when available
     """
-    tracer_provider, span_exporter, logger_provider, log_exporter, meter_provider = _make_providers()
+    (
+        tracer_provider,
+        span_exporter,
+        logger_provider,
+        log_exporter,
+        meter_provider,
+    ) = _make_providers()
 
     instrumentor = QwenAgentInstrumentor()
     instrumentor.instrument(
@@ -141,7 +185,9 @@ def test_qwen_agent_stream_llm_with_ttft():
     )
 
     try:
-        llm = get_chat_model({"model": "qwen-max", "model_type": "qwen_dashscope"})
+        llm = get_chat_model(
+            {"model": "qwen-max", "model_type": "qwen_dashscope"}
+        )
         messages = [{"role": "user", "content": "Say hello in one word."}]
         # stream=True is the default; consume the iterator
         list(llm.chat(messages=messages, stream=True))
@@ -150,18 +196,33 @@ def test_qwen_agent_stream_llm_with_ttft():
 
     spans = span_exporter.get_finished_spans()
     chat_spans = [s for s in spans if s.name.startswith("chat ")]
-    assert len(chat_spans) >= 1, f"No chat span found in: {[s.name for s in spans]}"
+    assert len(chat_spans) >= 1, (
+        f"No chat span found in: {[s.name for s in spans]}"
+    )
     chat_span = chat_spans[0]
 
     # Verify basic span attributes
-    assert chat_span.attributes.get(GenAIAttributes.GEN_AI_OPERATION_NAME) == "chat"
-    assert chat_span.attributes.get(GenAIAttributes.GEN_AI_PROVIDER_NAME) == "dashscope"
-    assert chat_span.attributes.get(GenAIAttributes.GEN_AI_REQUEST_MODEL) == "qwen-max"
+    assert (
+        chat_span.attributes.get(GenAIAttributes.GEN_AI_OPERATION_NAME)
+        == "chat"
+    )
+    assert (
+        chat_span.attributes.get(GenAIAttributes.GEN_AI_PROVIDER_NAME)
+        == "dashscope"
+    )
+    assert (
+        chat_span.attributes.get(GenAIAttributes.GEN_AI_REQUEST_MODEL)
+        == "qwen-max"
+    )
 
     # TTFT (gen_ai.response.time_to_first_token) may be None during cassette replay;
     # we assert finish_reasons to ensure the P2 code path ran.
-    finish_reasons = chat_span.attributes.get(GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS)
-    assert finish_reasons is not None, "gen_ai.response.finish_reasons should be set (P0 fix)"
+    finish_reasons = chat_span.attributes.get(
+        GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS
+    )
+    assert finish_reasons is not None, (
+        "gen_ai.response.finish_reasons should be set (P0 fix)"
+    )
 
 
 @pytest.mark.vcr()
@@ -173,7 +234,13 @@ def test_non_stream_chat():
     - response_model and finish_reasons are set (P0 fix)
     - no streaming wrapper is used
     """
-    tracer_provider, span_exporter, logger_provider, log_exporter, meter_provider = _make_providers()
+    (
+        tracer_provider,
+        span_exporter,
+        logger_provider,
+        log_exporter,
+        meter_provider,
+    ) = _make_providers()
 
     instrumentor = QwenAgentInstrumentor()
     instrumentor.instrument(
@@ -186,30 +253,56 @@ def test_non_stream_chat():
     try:
         # use_raw_api=False forces the non-streaming code path; newer qwen-agent
         # versions default use_raw_api=True for qwen_dashscope which only supports stream=True.
-        llm = get_chat_model({
-            "model": "qwen-max",
-            "model_type": "qwen_dashscope",
-            "generate_cfg": {"use_raw_api": False},
-        })
-        messages = [{"role": "user", "content": "What is 2+2? Answer with just the number."}]
+        llm = get_chat_model(
+            {
+                "model": "qwen-max",
+                "model_type": "qwen_dashscope",
+                "generate_cfg": {"use_raw_api": False},
+            }
+        )
+        messages = [
+            {
+                "role": "user",
+                "content": "What is 2+2? Answer with just the number.",
+            }
+        ]
         list(llm.chat(messages=messages, stream=False))
     finally:
         instrumentor.uninstrument()
 
     spans = span_exporter.get_finished_spans()
     chat_spans = [s for s in spans if s.name.startswith("chat ")]
-    assert len(chat_spans) >= 1, f"Expected at least 1 chat span, got: {[s.name for s in spans]}"
+    assert len(chat_spans) >= 1, (
+        f"Expected at least 1 chat span, got: {[s.name for s in spans]}"
+    )
     chat_span = chat_spans[0]
 
-    assert chat_span.attributes.get(GenAIAttributes.GEN_AI_OPERATION_NAME) == "chat"
-    assert chat_span.attributes.get(GenAIAttributes.GEN_AI_PROVIDER_NAME) == "dashscope"
-    assert chat_span.attributes.get(GenAIAttributes.GEN_AI_REQUEST_MODEL) == "qwen-max"
+    assert (
+        chat_span.attributes.get(GenAIAttributes.GEN_AI_OPERATION_NAME)
+        == "chat"
+    )
+    assert (
+        chat_span.attributes.get(GenAIAttributes.GEN_AI_PROVIDER_NAME)
+        == "dashscope"
+    )
+    assert (
+        chat_span.attributes.get(GenAIAttributes.GEN_AI_REQUEST_MODEL)
+        == "qwen-max"
+    )
 
-    response_model = chat_span.attributes.get(GenAIAttributes.GEN_AI_RESPONSE_MODEL)
-    assert response_model is not None, "gen_ai.response.model should be set for non-stream (P0 fix)"
+    response_model = chat_span.attributes.get(
+        GenAIAttributes.GEN_AI_RESPONSE_MODEL
+    )
+    assert response_model is not None, (
+        "gen_ai.response.model should be set for non-stream (P0 fix)"
+    )
 
-    finish_reasons = chat_span.attributes.get(GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS)
-    assert finish_reasons is not None, "gen_ai.response.finish_reasons should be set for non-stream (P0 fix)"
+    finish_reasons = chat_span.attributes.get(
+        GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS
+    )
+    assert finish_reasons is not None, (
+        "gen_ai.response.finish_reasons should be set for non-stream (P0 fix)"
+    )
 
 
 @pytest.mark.vcr()
@@ -220,7 +313,13 @@ def test_agent_run_nonstream():
     so the invoke_agent span is created once by the run() wrapper.
     Verifies there is no span duplication when using the non-streaming entry point.
     """
-    tracer_provider, span_exporter, logger_provider, log_exporter, meter_provider = _make_providers()
+    (
+        tracer_provider,
+        span_exporter,
+        logger_provider,
+        log_exporter,
+        meter_provider,
+    ) = _make_providers()
 
     instrumentor = QwenAgentInstrumentor()
     instrumentor.instrument(
@@ -243,13 +342,22 @@ def test_agent_run_nonstream():
     spans = span_exporter.get_finished_spans()
     # Assistant may spawn a Memory sub-agent producing extra invoke_agent spans;
     # filter to the target agent by name.
-    agent_spans = [s for s in spans if s.name == "invoke_agent NonStreamAssistant"]
-    assert len(agent_spans) >= 1, f"Expected invoke_agent NonStreamAssistant span, got: {[s.name for s in spans]}"
+    agent_spans = [
+        s for s in spans if s.name == "invoke_agent NonStreamAssistant"
+    ]
+    assert len(agent_spans) >= 1, (
+        f"Expected invoke_agent NonStreamAssistant span, got: {[s.name for s in spans]}"
+    )
     agent_span = agent_spans[0]
-    assert agent_span.attributes.get(GenAIAttributes.GEN_AI_OPERATION_NAME) == "invoke_agent"
+    assert (
+        agent_span.attributes.get(GenAIAttributes.GEN_AI_OPERATION_NAME)
+        == "invoke_agent"
+    )
 
     chat_spans = [s for s in spans if s.name.startswith("chat ")]
-    assert len(chat_spans) >= 1, f"No chat span found in: {[s.name for s in spans]}"
+    assert len(chat_spans) >= 1, (
+        f"No chat span found in: {[s.name for s in spans]}"
+    )
 
 
 @pytest.mark.vcr()
@@ -259,7 +367,13 @@ def test_multi_turn_conversation():
     Verifies that all input messages (user + assistant history) are correctly
     captured in the span event log, not just the last message.
     """
-    tracer_provider, span_exporter, logger_provider, log_exporter, meter_provider = _make_providers()
+    (
+        tracer_provider,
+        span_exporter,
+        logger_provider,
+        log_exporter,
+        meter_provider,
+    ) = _make_providers()
 
     instrumentor = QwenAgentInstrumentor()
     instrumentor.instrument(
@@ -286,16 +400,29 @@ def test_multi_turn_conversation():
 
     spans = span_exporter.get_finished_spans()
     # Filter to our specific agent; Assistant may produce extra Memory sub-agent spans.
-    agent_spans = [s for s in spans if s.name == "invoke_agent MultiTurnAssistant"]
-    assert len(agent_spans) >= 1, f"Expected invoke_agent MultiTurnAssistant span in: {[s.name for s in spans]}"
+    agent_spans = [
+        s for s in spans if s.name == "invoke_agent MultiTurnAssistant"
+    ]
+    assert len(agent_spans) >= 1, (
+        f"Expected invoke_agent MultiTurnAssistant span in: {[s.name for s in spans]}"
+    )
 
     chat_spans = [s for s in spans if s.name.startswith("chat ")]
-    assert len(chat_spans) >= 1, f"No chat span found in: {[s.name for s in spans]}"
+    assert len(chat_spans) >= 1, (
+        f"No chat span found in: {[s.name for s in spans]}"
+    )
     chat_span = chat_spans[0]
 
-    assert chat_span.attributes.get(GenAIAttributes.GEN_AI_REQUEST_MODEL) == "qwen-max"
-    finish_reasons = chat_span.attributes.get(GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS)
-    assert finish_reasons is not None, "gen_ai.response.finish_reasons should be set"
+    assert (
+        chat_span.attributes.get(GenAIAttributes.GEN_AI_REQUEST_MODEL)
+        == "qwen-max"
+    )
+    finish_reasons = chat_span.attributes.get(
+        GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS
+    )
+    assert finish_reasons is not None, (
+        "gen_ai.response.finish_reasons should be set"
+    )
 
 
 @pytest.mark.vcr()
@@ -307,7 +434,13 @@ def test_react_multi_round():
     - gen_ai.react.round attribute increments per iteration
     - chat and execute_tool spans are nested inside react_step
     """
-    tracer_provider, span_exporter, logger_provider, log_exporter, meter_provider = _make_providers()
+    (
+        tracer_provider,
+        span_exporter,
+        logger_provider,
+        log_exporter,
+        meter_provider,
+    ) = _make_providers()
 
     instrumentor = QwenAgentInstrumentor()
     instrumentor.instrument(
@@ -318,6 +451,7 @@ def test_react_multi_round():
     )
 
     try:
+
         @register_tool("calculator_react_test")
         class CalculatorTool(BaseTool):
             description = "Evaluate a simple arithmetic expression and return the numeric result."
@@ -357,7 +491,9 @@ def test_react_multi_round():
 
     # Filter to our specific agent; Assistant may produce extra Memory sub-agent spans.
     agent_spans = [s for s in spans if s.name == "invoke_agent ReactAgent"]
-    assert len(agent_spans) >= 1, f"Expected invoke_agent ReactAgent span in: {span_names}"
+    assert len(agent_spans) >= 1, (
+        f"Expected invoke_agent ReactAgent span in: {span_names}"
+    )
 
     # "react step" spans must appear (agent has tools → ReAct mode)
     react_spans = [s for s in spans if s.name == "react step"]
@@ -367,7 +503,9 @@ def test_react_multi_round():
 
     # gen_ai.react.round attribute must be set and start at 1
     rounds = [s.attributes.get("gen_ai.react.round") for s in react_spans]
-    assert 1 in rounds, f"Expected gen_ai.react.round=1 in react step spans, got rounds={rounds}"
+    assert 1 in rounds, (
+        f"Expected gen_ai.react.round=1 in react step spans, got rounds={rounds}"
+    )
 
     # chat spans must exist inside react step (nested via OTel context)
     chat_spans = [s for s in spans if s.name.startswith("chat ")]
@@ -382,7 +520,13 @@ def test_qwen_agent_with_tool_call():
     without TOOL_REGISTRY registration) to exercise the tool_definitions P1 fix
     and verify execute_tool spans are generated when the model calls a tool.
     """
-    tracer_provider, span_exporter, logger_provider, log_exporter, meter_provider = _make_providers()
+    (
+        tracer_provider,
+        span_exporter,
+        logger_provider,
+        log_exporter,
+        meter_provider,
+    ) = _make_providers()
 
     instrumentor = QwenAgentInstrumentor()
     instrumentor.instrument(
@@ -393,6 +537,7 @@ def test_qwen_agent_with_tool_call():
     )
 
     try:
+
         @register_tool("get_current_weather_test")
         class GetCurrentWeatherTool(BaseTool):
             description = "Get the current weather for a given city."
@@ -411,15 +556,26 @@ def test_qwen_agent_with_tool_call():
                         params = json.loads(params)
                     except Exception:
                         params = {"city": params}
-                city = params.get("city", "unknown") if isinstance(params, dict) else "unknown"
-                return f"The weather in {city} is sunny and 22 degrees Celsius."
+                city = (
+                    params.get("city", "unknown")
+                    if isinstance(params, dict)
+                    else "unknown"
+                )
+                return (
+                    f"The weather in {city} is sunny and 22 degrees Celsius."
+                )
 
         bot = Assistant(
             llm={"model": "qwen-max", "model_type": "qwen_dashscope"},
             name="WeatherAgent",
             function_list=["get_current_weather_test"],
         )
-        messages = [{"role": "user", "content": "What is the weather in Beijing right now?"}]
+        messages = [
+            {
+                "role": "user",
+                "content": "What is the weather in Beijing right now?",
+            }
+        ]
         list(bot.run(messages))
     finally:
         instrumentor.uninstrument()
@@ -436,11 +592,20 @@ def test_qwen_agent_with_tool_call():
 
     # Verify chat span attributes
     chat_span = chat_spans[0]
-    assert chat_span.attributes.get(GenAIAttributes.GEN_AI_OPERATION_NAME) == "chat"
-    assert chat_span.attributes.get(GenAIAttributes.GEN_AI_PROVIDER_NAME) == "dashscope"
+    assert (
+        chat_span.attributes.get(GenAIAttributes.GEN_AI_OPERATION_NAME)
+        == "chat"
+    )
+    assert (
+        chat_span.attributes.get(GenAIAttributes.GEN_AI_PROVIDER_NAME)
+        == "dashscope"
+    )
 
     # If the model called the tool, there should be an execute_tool span
     tool_spans = [s for s in spans if "execute_tool" in s.name]
     # Tool call is model-dependent; only assert if tool spans exist
     for tool_span in tool_spans:
-        assert tool_span.attributes.get(GenAIAttributes.GEN_AI_OPERATION_NAME) == "execute_tool"
+        assert (
+            tool_span.attributes.get(GenAIAttributes.GEN_AI_OPERATION_NAME)
+            == "execute_tool"
+        )

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/test_real_api.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/test_real_api.py
@@ -1,0 +1,446 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for Qwen-Agent instrumentation using VCR cassettes.
+
+These tests use real qwen-agent calls that are recorded via VCR so subsequent
+runs replay the HTTP interactions without hitting the real API.
+"""
+
+import json
+import os
+
+import pytest
+from qwen_agent.agents import Assistant
+from qwen_agent.llm import get_chat_model
+from qwen_agent.tools.base import BaseTool, register_tool
+
+from opentelemetry.instrumentation.qwen_agent import QwenAgentInstrumentor
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import (
+    InMemoryLogExporter,
+    SimpleLogRecordProcessor,
+)
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAIAttributes,
+)
+
+# cassette directory for this test module
+VCR_CASSETTE_DIR = os.path.join(os.path.dirname(__file__), "cassettes")
+
+
+def _make_providers():
+    """Create fresh OTel providers for each test."""
+    span_exporter = InMemorySpanExporter()
+    tracer_provider = TracerProvider()
+    tracer_provider.add_span_processor(SimpleSpanProcessor(span_exporter))
+
+    log_exporter = InMemoryLogExporter()
+    logger_provider = LoggerProvider()
+    logger_provider.add_log_record_processor(
+        SimpleLogRecordProcessor(log_exporter)
+    )
+
+    metric_reader = InMemoryMetricReader()
+    meter_provider = MeterProvider(metric_readers=[metric_reader])
+
+    return tracer_provider, span_exporter, logger_provider, log_exporter, meter_provider
+
+
+@pytest.mark.vcr()
+def test_qwen_agent_basic_run():
+    """Test basic qwen-agent Assistant conversation.
+
+    Verifies that:
+    - An invoke_agent span is produced
+    - A chat (LLM) span is produced as a child
+    - Both spans have the expected gen_ai.* attributes
+    """
+    tracer_provider, span_exporter, logger_provider, log_exporter, meter_provider = _make_providers()
+
+    instrumentor = QwenAgentInstrumentor()
+    instrumentor.instrument(
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        skip_dep_check=True,
+    )
+
+    try:
+        bot = Assistant(
+            llm={"model": "qwen-max", "model_type": "qwen_dashscope"},
+            name="TestAssistant",
+        )
+        messages = [{"role": "user", "content": "Hello, what is 1+1?"}]
+        # Consume the generator to trigger all spans
+        list(bot.run(messages))
+    finally:
+        instrumentor.uninstrument()
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) >= 2, f"Expected at least 2 spans, got {len(spans)}: {[s.name for s in spans]}"
+
+    # Find invoke_agent span
+    agent_spans = [s for s in spans if "invoke_agent" in s.name]
+    assert len(agent_spans) >= 1, f"No invoke_agent span found in: {[s.name for s in spans]}"
+    agent_span = agent_spans[0]
+    assert agent_span.attributes.get(GenAIAttributes.GEN_AI_OPERATION_NAME) == "invoke_agent"
+
+    # Find chat/LLM span
+    chat_spans = [s for s in spans if s.name.startswith("chat ")]
+    assert len(chat_spans) >= 1, f"No chat span found in: {[s.name for s in spans]}"
+    chat_span = chat_spans[0]
+
+    # Verify key span attributes on the chat span
+    assert chat_span.attributes.get(GenAIAttributes.GEN_AI_OPERATION_NAME) == "chat"
+    assert chat_span.attributes.get(GenAIAttributes.GEN_AI_PROVIDER_NAME) == "dashscope"
+    assert chat_span.attributes.get(GenAIAttributes.GEN_AI_REQUEST_MODEL) == "qwen-max"
+
+    # response_model_name fix: GEN_AI_RESPONSE_MODEL should now be populated
+    response_model = chat_span.attributes.get(GenAIAttributes.GEN_AI_RESPONSE_MODEL)
+    assert response_model is not None, "gen_ai.response.model should be set (P0 fix)"
+
+    # finish_reasons fix: GEN_AI_RESPONSE_FINISH_REASONS should be populated
+    finish_reasons = chat_span.attributes.get(GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS)
+    assert finish_reasons is not None, "gen_ai.response.finish_reasons should be set (P0 fix)"
+
+
+@pytest.mark.vcr()
+def test_qwen_agent_stream_llm_with_ttft():
+    """Test streaming LLM call and verify TTFT (Time-to-First-Token) is recorded.
+
+    Verifies that P2 fix (monotonic_first_token_s) is working:
+    - gen_ai.response.time_to_first_token attribute is recorded when available
+    """
+    tracer_provider, span_exporter, logger_provider, log_exporter, meter_provider = _make_providers()
+
+    instrumentor = QwenAgentInstrumentor()
+    instrumentor.instrument(
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        skip_dep_check=True,
+    )
+
+    try:
+        llm = get_chat_model({"model": "qwen-max", "model_type": "qwen_dashscope"})
+        messages = [{"role": "user", "content": "Say hello in one word."}]
+        # stream=True is the default; consume the iterator
+        list(llm.chat(messages=messages, stream=True))
+    finally:
+        instrumentor.uninstrument()
+
+    spans = span_exporter.get_finished_spans()
+    chat_spans = [s for s in spans if s.name.startswith("chat ")]
+    assert len(chat_spans) >= 1, f"No chat span found in: {[s.name for s in spans]}"
+    chat_span = chat_spans[0]
+
+    # Verify basic span attributes
+    assert chat_span.attributes.get(GenAIAttributes.GEN_AI_OPERATION_NAME) == "chat"
+    assert chat_span.attributes.get(GenAIAttributes.GEN_AI_PROVIDER_NAME) == "dashscope"
+    assert chat_span.attributes.get(GenAIAttributes.GEN_AI_REQUEST_MODEL) == "qwen-max"
+
+    # TTFT (gen_ai.response.time_to_first_token) may be None during cassette replay;
+    # we assert finish_reasons to ensure the P2 code path ran.
+    finish_reasons = chat_span.attributes.get(GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS)
+    assert finish_reasons is not None, "gen_ai.response.finish_reasons should be set (P0 fix)"
+
+
+@pytest.mark.vcr()
+def test_non_stream_chat():
+    """Test non-streaming LLM chat call (stream=False code path).
+
+    Verifies the else-branch in wrap_chat_model_chat:
+    - chat span is produced
+    - response_model and finish_reasons are set (P0 fix)
+    - no streaming wrapper is used
+    """
+    tracer_provider, span_exporter, logger_provider, log_exporter, meter_provider = _make_providers()
+
+    instrumentor = QwenAgentInstrumentor()
+    instrumentor.instrument(
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        skip_dep_check=True,
+    )
+
+    try:
+        # use_raw_api=False forces the non-streaming code path; newer qwen-agent
+        # versions default use_raw_api=True for qwen_dashscope which only supports stream=True.
+        llm = get_chat_model({
+            "model": "qwen-max",
+            "model_type": "qwen_dashscope",
+            "generate_cfg": {"use_raw_api": False},
+        })
+        messages = [{"role": "user", "content": "What is 2+2? Answer with just the number."}]
+        list(llm.chat(messages=messages, stream=False))
+    finally:
+        instrumentor.uninstrument()
+
+    spans = span_exporter.get_finished_spans()
+    chat_spans = [s for s in spans if s.name.startswith("chat ")]
+    assert len(chat_spans) >= 1, f"Expected at least 1 chat span, got: {[s.name for s in spans]}"
+    chat_span = chat_spans[0]
+
+    assert chat_span.attributes.get(GenAIAttributes.GEN_AI_OPERATION_NAME) == "chat"
+    assert chat_span.attributes.get(GenAIAttributes.GEN_AI_PROVIDER_NAME) == "dashscope"
+    assert chat_span.attributes.get(GenAIAttributes.GEN_AI_REQUEST_MODEL) == "qwen-max"
+
+    response_model = chat_span.attributes.get(GenAIAttributes.GEN_AI_RESPONSE_MODEL)
+    assert response_model is not None, "gen_ai.response.model should be set for non-stream (P0 fix)"
+
+    finish_reasons = chat_span.attributes.get(GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS)
+    assert finish_reasons is not None, "gen_ai.response.finish_reasons should be set for non-stream (P0 fix)"
+
+
+@pytest.mark.vcr()
+def test_agent_run_nonstream():
+    """Test Agent.run_nonstream() produces a single invoke_agent span.
+
+    run_nonstream() is not wrapped separately — it calls self.run() internally,
+    so the invoke_agent span is created once by the run() wrapper.
+    Verifies there is no span duplication when using the non-streaming entry point.
+    """
+    tracer_provider, span_exporter, logger_provider, log_exporter, meter_provider = _make_providers()
+
+    instrumentor = QwenAgentInstrumentor()
+    instrumentor.instrument(
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        skip_dep_check=True,
+    )
+
+    try:
+        bot = Assistant(
+            llm={"model": "qwen-max", "model_type": "qwen_dashscope"},
+            name="NonStreamAssistant",
+        )
+        messages = [{"role": "user", "content": "Say 'OK' and nothing else."}]
+        bot.run_nonstream(messages)
+    finally:
+        instrumentor.uninstrument()
+
+    spans = span_exporter.get_finished_spans()
+    # Assistant may spawn a Memory sub-agent producing extra invoke_agent spans;
+    # filter to the target agent by name.
+    agent_spans = [s for s in spans if s.name == "invoke_agent NonStreamAssistant"]
+    assert len(agent_spans) >= 1, f"Expected invoke_agent NonStreamAssistant span, got: {[s.name for s in spans]}"
+    agent_span = agent_spans[0]
+    assert agent_span.attributes.get(GenAIAttributes.GEN_AI_OPERATION_NAME) == "invoke_agent"
+
+    chat_spans = [s for s in spans if s.name.startswith("chat ")]
+    assert len(chat_spans) >= 1, f"No chat span found in: {[s.name for s in spans]}"
+
+
+@pytest.mark.vcr()
+def test_multi_turn_conversation():
+    """Test multi-turn conversation with history messages.
+
+    Verifies that all input messages (user + assistant history) are correctly
+    captured in the span event log, not just the last message.
+    """
+    tracer_provider, span_exporter, logger_provider, log_exporter, meter_provider = _make_providers()
+
+    instrumentor = QwenAgentInstrumentor()
+    instrumentor.instrument(
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        skip_dep_check=True,
+    )
+
+    try:
+        bot = Assistant(
+            llm={"model": "qwen-max", "model_type": "qwen_dashscope"},
+            name="MultiTurnAssistant",
+        )
+        # Simulate a 2-turn conversation by including history
+        messages = [
+            {"role": "user", "content": "My name is Alice."},
+            {"role": "assistant", "content": "Nice to meet you, Alice!"},
+            {"role": "user", "content": "What is my name?"},
+        ]
+        list(bot.run(messages))
+    finally:
+        instrumentor.uninstrument()
+
+    spans = span_exporter.get_finished_spans()
+    # Filter to our specific agent; Assistant may produce extra Memory sub-agent spans.
+    agent_spans = [s for s in spans if s.name == "invoke_agent MultiTurnAssistant"]
+    assert len(agent_spans) >= 1, f"Expected invoke_agent MultiTurnAssistant span in: {[s.name for s in spans]}"
+
+    chat_spans = [s for s in spans if s.name.startswith("chat ")]
+    assert len(chat_spans) >= 1, f"No chat span found in: {[s.name for s in spans]}"
+    chat_span = chat_spans[0]
+
+    assert chat_span.attributes.get(GenAIAttributes.GEN_AI_REQUEST_MODEL) == "qwen-max"
+    finish_reasons = chat_span.attributes.get(GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS)
+    assert finish_reasons is not None, "gen_ai.response.finish_reasons should be set"
+
+
+@pytest.mark.vcr()
+def test_react_multi_round():
+    """Test ReAct agent completing a multi-round task via tool calls.
+
+    Verifies the react_step span introduced for ReAct tracking:
+    - react_step spans appear when the agent has tools
+    - gen_ai.react.round attribute increments per iteration
+    - chat and execute_tool spans are nested inside react_step
+    """
+    tracer_provider, span_exporter, logger_provider, log_exporter, meter_provider = _make_providers()
+
+    instrumentor = QwenAgentInstrumentor()
+    instrumentor.instrument(
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        skip_dep_check=True,
+    )
+
+    try:
+        @register_tool("calculator_react_test")
+        class CalculatorTool(BaseTool):
+            description = "Evaluate a simple arithmetic expression and return the numeric result."
+            parameters = [
+                {
+                    "name": "expression",
+                    "type": "string",
+                    "description": "The arithmetic expression to evaluate, e.g. '3 * 7'.",
+                    "required": True,
+                }
+            ]
+
+            def call(self, params, **kwargs):
+                if isinstance(params, str):
+                    try:
+                        params = json.loads(params)
+                    except Exception:
+                        params = {"expression": params}
+                expr = params.get("expression", "0")
+                try:
+                    return str(eval(expr, {"__builtins__": {}}, {}))  # noqa: S307
+                except Exception as e:
+                    return f"Error: {e}"
+
+        bot = Assistant(
+            llm={"model": "qwen-max", "model_type": "qwen_dashscope"},
+            name="ReactAgent",
+            function_list=["calculator_react_test"],
+        )
+        messages = [{"role": "user", "content": "What is 6 multiplied by 7?"}]
+        list(bot.run(messages))
+    finally:
+        instrumentor.uninstrument()
+
+    spans = span_exporter.get_finished_spans()
+    span_names = [s.name for s in spans]
+
+    # Filter to our specific agent; Assistant may produce extra Memory sub-agent spans.
+    agent_spans = [s for s in spans if s.name == "invoke_agent ReactAgent"]
+    assert len(agent_spans) >= 1, f"Expected invoke_agent ReactAgent span in: {span_names}"
+
+    # "react step" spans must appear (agent has tools → ReAct mode)
+    react_spans = [s for s in spans if s.name == "react step"]
+    assert len(react_spans) >= 1, (
+        f"Expected 'react step' spans for a tool-enabled agent, got none. All spans: {span_names}"
+    )
+
+    # gen_ai.react.round attribute must be set and start at 1
+    rounds = [s.attributes.get("gen_ai.react.round") for s in react_spans]
+    assert 1 in rounds, f"Expected gen_ai.react.round=1 in react step spans, got rounds={rounds}"
+
+    # chat spans must exist inside react step (nested via OTel context)
+    chat_spans = [s for s in spans if s.name.startswith("chat ")]
+    assert len(chat_spans) >= 1, f"No chat span in: {span_names}"
+
+
+@pytest.mark.vcr()
+def test_qwen_agent_with_tool_call():
+    """Test qwen-agent with tools, verify execute_tool span is produced.
+
+    Uses a custom BaseTool subclass (can be passed directly to Assistant
+    without TOOL_REGISTRY registration) to exercise the tool_definitions P1 fix
+    and verify execute_tool spans are generated when the model calls a tool.
+    """
+    tracer_provider, span_exporter, logger_provider, log_exporter, meter_provider = _make_providers()
+
+    instrumentor = QwenAgentInstrumentor()
+    instrumentor.instrument(
+        tracer_provider=tracer_provider,
+        logger_provider=logger_provider,
+        meter_provider=meter_provider,
+        skip_dep_check=True,
+    )
+
+    try:
+        @register_tool("get_current_weather_test")
+        class GetCurrentWeatherTool(BaseTool):
+            description = "Get the current weather for a given city."
+            parameters = [
+                {
+                    "name": "city",
+                    "type": "string",
+                    "description": "The city name to get weather for.",
+                    "required": True,
+                }
+            ]
+
+            def call(self, params, **kwargs):
+                if isinstance(params, str):
+                    try:
+                        params = json.loads(params)
+                    except Exception:
+                        params = {"city": params}
+                city = params.get("city", "unknown") if isinstance(params, dict) else "unknown"
+                return f"The weather in {city} is sunny and 22 degrees Celsius."
+
+        bot = Assistant(
+            llm={"model": "qwen-max", "model_type": "qwen_dashscope"},
+            name="WeatherAgent",
+            function_list=["get_current_weather_test"],
+        )
+        messages = [{"role": "user", "content": "What is the weather in Beijing right now?"}]
+        list(bot.run(messages))
+    finally:
+        instrumentor.uninstrument()
+
+    spans = span_exporter.get_finished_spans()
+    span_names = [s.name for s in spans]
+
+    # Verify we got invoke_agent and chat spans
+    agent_spans = [s for s in spans if "invoke_agent" in s.name]
+    assert len(agent_spans) >= 1, f"No invoke_agent span in: {span_names}"
+
+    chat_spans = [s for s in spans if s.name.startswith("chat ")]
+    assert len(chat_spans) >= 1, f"No chat span in: {span_names}"
+
+    # Verify chat span attributes
+    chat_span = chat_spans[0]
+    assert chat_span.attributes.get(GenAIAttributes.GEN_AI_OPERATION_NAME) == "chat"
+    assert chat_span.attributes.get(GenAIAttributes.GEN_AI_PROVIDER_NAME) == "dashscope"
+
+    # If the model called the tool, there should be an execute_tool span
+    tool_spans = [s for s in spans if "execute_tool" in s.name]
+    # Tool call is model-dependent; only assert if tool spans exist
+    for tool_span in tool_spans:
+        assert tool_span.attributes.get(GenAIAttributes.GEN_AI_OPERATION_NAME) == "execute_tool"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/test_spans.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/test_spans.py
@@ -113,7 +113,9 @@ class TestLLMChatSpan:
 
         spans = span_exporter.get_finished_spans()
         chat_spans = [s for s in spans if s.name.startswith("chat")]
-        assert len(chat_spans) >= 1, f"Expected a chat span, got: {[s.name for s in spans]}"
+        assert len(chat_spans) >= 1, (
+            f"Expected a chat span, got: {[s.name for s in spans]}"
+        )
 
         span = chat_spans[0]
         assert span.name == "chat qwen-max"
@@ -121,8 +123,12 @@ class TestLLMChatSpan:
         attrs = dict(span.attributes or {})
         assert attrs.get(GenAIAttributes.GEN_AI_REQUEST_MODEL) == "qwen-max"
         # Provider name is stored as "gen_ai.provider.name" in newer semconv
-        provider = attrs.get("gen_ai.provider.name") or attrs.get(GenAIAttributes.GEN_AI_SYSTEM)
-        assert provider == "dashscope", f"Expected 'dashscope', got attrs: {attrs}"
+        provider = attrs.get("gen_ai.provider.name") or attrs.get(
+            GenAIAttributes.GEN_AI_SYSTEM
+        )
+        assert provider == "dashscope", (
+            f"Expected 'dashscope', got attrs: {attrs}"
+        )
 
     def test_stream_chat_creates_span(self, span_exporter, instrument):
         """Streaming chat() should create a chat span after the iterator is consumed."""
@@ -177,7 +183,9 @@ class TestLLMChatSpan:
             return_value=fake_response,
         ):
             model.chat(
-                messages=[Message(role="user", content="What is the weather?")],
+                messages=[
+                    Message(role="user", content="What is the weather?")
+                ],
                 stream=False,
             )
 
@@ -215,7 +223,9 @@ class TestLLMChatSpan:
 class TestAgentRunSpan:
     """Verify that Agent.run() and run_nonstream() produce invoke_agent spans."""
 
-    def test_agent_run_creates_invoke_agent_span(self, span_exporter, instrument):
+    def test_agent_run_creates_invoke_agent_span(
+        self, span_exporter, instrument
+    ):
         """Agent.run() (generator) should create an invoke_agent span."""
         llm = MagicMock()
         llm.model = "qwen-max"
@@ -229,13 +239,17 @@ class TestAgentRunSpan:
             yield response_msgs
 
         with patch.object(_StubAgent, "_run", side_effect=fake_run):
-            results = list(agent.run([Message(role="user", content="Weather?")]))
+            results = list(
+                agent.run([Message(role="user", content="Weather?")])
+            )
 
         assert len(results) >= 1
 
         spans = span_exporter.get_finished_spans()
         agent_spans = [s for s in spans if "invoke_agent" in s.name]
-        assert len(agent_spans) >= 1, f"Expected invoke_agent span, got: {[s.name for s in spans]}"
+        assert len(agent_spans) >= 1, (
+            f"Expected invoke_agent span, got: {[s.name for s in spans]}"
+        )
 
         span = agent_spans[0]
         assert span.name == "invoke_agent WeatherBot"
@@ -273,7 +287,9 @@ class TestAgentRunSpan:
         span_names = [s.name for s in agent_spans]
         assert any("ChatBot" in n for n in span_names)
 
-    def test_agent_run_error_creates_error_span(self, span_exporter, instrument):
+    def test_agent_run_error_creates_error_span(
+        self, span_exporter, instrument
+    ):
         """An exception during Agent.run() should produce an error invoke_agent span."""
         llm = MagicMock()
         llm.model = "qwen-max"
@@ -337,7 +353,9 @@ class TestToolCallSpan:
         agent.function_map = {tool_name: mock_tool}
         return agent, mock_tool
 
-    def test_call_tool_creates_execute_tool_span(self, span_exporter, instrument):
+    def test_call_tool_creates_execute_tool_span(
+        self, span_exporter, instrument
+    ):
         """_call_tool() should create an execute_tool span with tool name."""
         agent, mock_tool = self._make_agent_with_tool("get_weather")
 
@@ -347,7 +365,9 @@ class TestToolCallSpan:
 
         spans = span_exporter.get_finished_spans()
         tool_spans = [s for s in spans if "execute_tool" in s.name]
-        assert len(tool_spans) >= 1, f"Expected execute_tool span, got: {[s.name for s in spans]}"
+        assert len(tool_spans) >= 1, (
+            f"Expected execute_tool span, got: {[s.name for s in spans]}"
+        )
 
         span = tool_spans[0]
         assert span.name == "execute_tool get_weather"
@@ -606,9 +626,7 @@ class TestReactStepSpan:
             with patch.object(
                 _StubChatModel,
                 "_chat_no_stream",
-                return_value=[
-                    Message(role="assistant", content="Hello!")
-                ],
+                return_value=[Message(role="assistant", content="Hello!")],
             ):
                 agent._call_llm(messages=messages, stream=False)
             yield [Message(role="assistant", content="Hello!")]

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/test_spans.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/test_spans.py
@@ -1,0 +1,722 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for span generation from the qwen-agent instrumentation plugin.
+
+Tests verify that the instrumented methods produce correct OpenTelemetry spans
+with the expected names, kinds, and attributes.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from qwen_agent.agent import Agent
+from qwen_agent.llm.base import BaseChatModel
+from qwen_agent.llm.schema import ContentItem, FunctionCall, Message
+
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAIAttributes,
+)
+from opentelemetry.trace import SpanKind, StatusCode
+
+# ---------------------------------------------------------------------------
+# Helpers: minimal concrete subclasses of the abstract qwen-agent classes
+# ---------------------------------------------------------------------------
+
+
+class _StubChatModel(BaseChatModel):
+    """A minimal BaseChatModel subclass for testing.
+
+    The real BaseChatModel.__init__ reads from a cfg dict; we bypass most of
+    that logic by calling super().__init__ with a minimal config and then
+    overriding the attributes we care about.
+    """
+
+    def __init__(self, model="test-model", model_type="qwen_dashscope"):
+        cfg = {"model": model, "model_type": model_type}
+        super().__init__(cfg)
+        # Disable raw_api mode which requires stream-only and API key
+        self.use_raw_api = False
+
+    # Abstract methods required by BaseChatModel
+    def _chat_no_stream(self, messages, **kwargs):
+        raise NotImplementedError
+
+    def _chat_stream(self, messages, **kwargs):
+        raise NotImplementedError
+
+    def _chat_with_functions(self, messages, functions, **kwargs):
+        raise NotImplementedError
+
+
+class _StubAgent(Agent):
+    """A minimal Agent subclass for testing.
+
+    Agent.__init__ normally requires complex setup; we use ``__new__`` and
+    manually assign the attributes the instrumentation reads so that we can
+    test the wrapped methods without triggering real agent initialization.
+    """
+
+    @classmethod
+    def create(cls, name="TestAgent", llm=None):
+        """Factory that skips the heavy __init__."""
+        obj = cls.__new__(cls)
+        obj.name = name
+        obj.description = "A test agent"
+        obj.system_message = "You are a helpful assistant."
+        obj.llm = llm
+        obj.function_map = {}
+        obj.extra_generate_cfg = {}
+        return obj
+
+    # Abstract method required by Agent
+    def _run(self, messages, **kwargs):
+        raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# LLM chat span tests
+# ---------------------------------------------------------------------------
+
+
+class TestLLMChatSpan:
+    """Verify that BaseChatModel.chat() produces a correct LLM (chat) span."""
+
+    def test_non_stream_chat_creates_span(self, span_exporter, instrument):
+        """Non-streaming chat() should create a single chat span with model info."""
+        model = _StubChatModel(model="qwen-max", model_type="qwen_dashscope")
+
+        fake_response = [Message(role="assistant", content="Hello there!")]
+
+        with patch.object(
+            _StubChatModel,
+            "_chat_no_stream",
+            return_value=fake_response,
+        ):
+            result = model.chat(
+                messages=[Message(role="user", content="Hi")],
+                stream=False,
+            )
+
+        assert result is not None
+
+        spans = span_exporter.get_finished_spans()
+        chat_spans = [s for s in spans if s.name.startswith("chat")]
+        assert len(chat_spans) >= 1, f"Expected a chat span, got: {[s.name for s in spans]}"
+
+        span = chat_spans[0]
+        assert span.name == "chat qwen-max"
+        assert span.kind == SpanKind.CLIENT
+        attrs = dict(span.attributes or {})
+        assert attrs.get(GenAIAttributes.GEN_AI_REQUEST_MODEL) == "qwen-max"
+        # Provider name is stored as "gen_ai.provider.name" in newer semconv
+        provider = attrs.get("gen_ai.provider.name") or attrs.get(GenAIAttributes.GEN_AI_SYSTEM)
+        assert provider == "dashscope", f"Expected 'dashscope', got attrs: {attrs}"
+
+    def test_stream_chat_creates_span(self, span_exporter, instrument):
+        """Streaming chat() should create a chat span after the iterator is consumed."""
+        model = _StubChatModel(model="qwen-turbo", model_type="qwen_dashscope")
+
+        chunk1 = [Message(role="assistant", content="Hello")]
+        chunk2 = [Message(role="assistant", content="Hello world")]
+
+        def fake_stream(messages, **kwargs):
+            yield chunk1
+            yield chunk2
+
+        with patch.object(
+            _StubChatModel,
+            "_chat_stream",
+            side_effect=fake_stream,
+        ):
+            response_iter = model.chat(
+                messages=[Message(role="user", content="Hi")],
+                stream=True,
+            )
+            # Consume the iterator to trigger span completion
+            responses = list(response_iter)
+
+        assert len(responses) == 2
+
+        spans = span_exporter.get_finished_spans()
+        chat_spans = [s for s in spans if s.name.startswith("chat")]
+        assert len(chat_spans) >= 1
+        span = chat_spans[0]
+        assert span.name == "chat qwen-turbo"
+        assert span.kind == SpanKind.CLIENT
+
+    def test_chat_with_function_call_response(self, span_exporter, instrument):
+        """Chat response containing a function_call should still produce a valid span."""
+        model = _StubChatModel(model="qwen-max", model_type="qwen_dashscope")
+
+        fake_response = [
+            Message(
+                role="assistant",
+                content="",
+                function_call=FunctionCall(
+                    name="get_weather",
+                    arguments='{"city": "Beijing"}',
+                ),
+            )
+        ]
+
+        with patch.object(
+            _StubChatModel,
+            "_chat_no_stream",
+            return_value=fake_response,
+        ):
+            model.chat(
+                messages=[Message(role="user", content="What is the weather?")],
+                stream=False,
+            )
+
+        spans = span_exporter.get_finished_spans()
+        chat_spans = [s for s in spans if s.name.startswith("chat")]
+        assert len(chat_spans) >= 1
+
+    def test_chat_error_creates_error_span(self, span_exporter, instrument):
+        """An exception during chat() should still produce a span with error status."""
+        model = _StubChatModel(model="qwen-max", model_type="qwen_dashscope")
+
+        with patch.object(
+            _StubChatModel,
+            "_chat_no_stream",
+            side_effect=RuntimeError("API timeout"),
+        ):
+            with pytest.raises(RuntimeError, match="API timeout"):
+                model.chat(
+                    messages=[Message(role="user", content="Hi")],
+                    stream=False,
+                )
+
+        spans = span_exporter.get_finished_spans()
+        chat_spans = [s for s in spans if s.name.startswith("chat")]
+        assert len(chat_spans) >= 1
+        span = chat_spans[0]
+        assert span.status.status_code == StatusCode.ERROR
+
+
+# ---------------------------------------------------------------------------
+# Agent run span tests
+# ---------------------------------------------------------------------------
+
+
+class TestAgentRunSpan:
+    """Verify that Agent.run() and run_nonstream() produce invoke_agent spans."""
+
+    def test_agent_run_creates_invoke_agent_span(self, span_exporter, instrument):
+        """Agent.run() (generator) should create an invoke_agent span."""
+        llm = MagicMock()
+        llm.model = "qwen-max"
+        llm.model_type = "qwen_dashscope"
+
+        agent = _StubAgent.create(name="WeatherBot", llm=llm)
+
+        response_msgs = [Message(role="assistant", content="It is sunny.")]
+
+        def fake_run(messages, **kwargs):
+            yield response_msgs
+
+        with patch.object(_StubAgent, "_run", side_effect=fake_run):
+            results = list(agent.run([Message(role="user", content="Weather?")]))
+
+        assert len(results) >= 1
+
+        spans = span_exporter.get_finished_spans()
+        agent_spans = [s for s in spans if "invoke_agent" in s.name]
+        assert len(agent_spans) >= 1, f"Expected invoke_agent span, got: {[s.name for s in spans]}"
+
+        span = agent_spans[0]
+        assert span.name == "invoke_agent WeatherBot"
+        assert span.kind == SpanKind.INTERNAL
+
+    def test_agent_run_nonstream_creates_invoke_agent_span(
+        self, span_exporter, instrument
+    ):
+        """Agent.run_nonstream() should produce exactly one invoke_agent span.
+
+        run_nonstream is NOT wrapped separately — it calls self.run() internally,
+        so the single invoke_agent span comes from the run() wrapper.
+        """
+        llm = MagicMock()
+        llm.model = "qwen-max"
+        llm.model_type = "qwen_dashscope"
+
+        agent = _StubAgent.create(name="ChatBot", llm=llm)
+
+        response_msgs = [Message(role="assistant", content="Hello!")]
+
+        def fake_run(messages, **kwargs):
+            yield response_msgs
+
+        with patch.object(_StubAgent, "_run", side_effect=fake_run):
+            result = agent.run_nonstream([Message(role="user", content="Hi")])
+
+        assert result is not None
+
+        spans = span_exporter.get_finished_spans()
+        agent_spans = [s for s in spans if "invoke_agent" in s.name]
+        # run_nonstream is not wrapped; only run() creates the invoke_agent span.
+        # Exactly one span should be produced (no duplication).
+        assert len(agent_spans) == 1
+        span_names = [s.name for s in agent_spans]
+        assert any("ChatBot" in n for n in span_names)
+
+    def test_agent_run_error_creates_error_span(self, span_exporter, instrument):
+        """An exception during Agent.run() should produce an error invoke_agent span."""
+        llm = MagicMock()
+        llm.model = "qwen-max"
+        llm.model_type = "qwen_dashscope"
+
+        agent = _StubAgent.create(name="FailBot", llm=llm)
+
+        def fake_run(messages, **kwargs):
+            if False:
+                yield  # make it a generator
+            raise ValueError("Agent processing failed")
+
+        with patch.object(_StubAgent, "_run", side_effect=fake_run):
+            with pytest.raises(ValueError, match="Agent processing failed"):
+                list(agent.run([Message(role="user", content="Go")]))
+
+        spans = span_exporter.get_finished_spans()
+        agent_spans = [s for s in spans if "invoke_agent" in s.name]
+        assert len(agent_spans) >= 1
+        span = agent_spans[0]
+        assert span.status.status_code == StatusCode.ERROR
+
+    def test_agent_run_multiple_yields(self, span_exporter, instrument):
+        """Agent.run() yielding multiple times should produce one invoke_agent span."""
+        llm = MagicMock()
+        llm.model = "qwen-max"
+        llm.model_type = "qwen_dashscope"
+
+        agent = _StubAgent.create(name="MultiYieldBot", llm=llm)
+
+        def fake_run(messages, **kwargs):
+            yield [Message(role="assistant", content="Thinking...")]
+            yield [Message(role="assistant", content="Done!")]
+
+        with patch.object(_StubAgent, "_run", side_effect=fake_run):
+            results = list(agent.run([Message(role="user", content="Go")]))
+
+        assert len(results) == 2
+
+        spans = span_exporter.get_finished_spans()
+        agent_spans = [s for s in spans if "invoke_agent" in s.name]
+        # The wrapper should produce exactly one span per run() call
+        assert len(agent_spans) == 1
+
+
+# ---------------------------------------------------------------------------
+# Tool call span tests
+# ---------------------------------------------------------------------------
+
+
+class TestToolCallSpan:
+    """Verify that Agent._call_tool() produces an execute_tool span."""
+
+    def _make_agent_with_tool(self, tool_name="get_weather"):
+        """Create a stub agent with a tool in its function_map."""
+        agent = _StubAgent.create(name="ToolAgent")
+
+        mock_tool = MagicMock()
+        mock_tool.description = "Get weather information"
+        mock_tool.call = MagicMock(return_value="Sunny, 25 degrees")
+        agent.function_map = {tool_name: mock_tool}
+        return agent, mock_tool
+
+    def test_call_tool_creates_execute_tool_span(self, span_exporter, instrument):
+        """_call_tool() should create an execute_tool span with tool name."""
+        agent, mock_tool = self._make_agent_with_tool("get_weather")
+
+        result = agent._call_tool("get_weather", '{"city": "Beijing"}')
+
+        assert result == "Sunny, 25 degrees"
+
+        spans = span_exporter.get_finished_spans()
+        tool_spans = [s for s in spans if "execute_tool" in s.name]
+        assert len(tool_spans) >= 1, f"Expected execute_tool span, got: {[s.name for s in spans]}"
+
+        span = tool_spans[0]
+        assert span.name == "execute_tool get_weather"
+        assert span.kind == SpanKind.INTERNAL
+
+    def test_call_tool_with_dict_args(self, span_exporter, instrument):
+        """_call_tool() should handle dict arguments."""
+        agent, mock_tool = self._make_agent_with_tool("search")
+        mock_tool.call = MagicMock(return_value="Found 3 results")
+
+        result = agent._call_tool("search", {"query": "OpenTelemetry"})
+
+        assert result == "Found 3 results"
+
+        spans = span_exporter.get_finished_spans()
+        tool_spans = [s for s in spans if "execute_tool" in s.name]
+        assert len(tool_spans) >= 1
+        assert tool_spans[0].name == "execute_tool search"
+
+    def test_call_tool_error_creates_span(self, span_exporter, instrument):
+        """An exception in _call_tool() should still produce an execute_tool span.
+
+        Note: qwen-agent's Agent._call_tool() catches tool exceptions internally
+        and returns an error string rather than re-raising.
+        """
+        agent, mock_tool = self._make_agent_with_tool("broken_tool")
+        mock_tool.call = MagicMock(side_effect=RuntimeError("Tool crashed"))
+
+        # qwen-agent catches the exception and returns an error string
+        result = agent._call_tool("broken_tool", "{}")
+        assert isinstance(result, str)
+
+        spans = span_exporter.get_finished_spans()
+        tool_spans = [s for s in spans if "execute_tool" in s.name]
+        assert len(tool_spans) >= 1
+        assert tool_spans[0].name == "execute_tool broken_tool"
+
+    def test_call_tool_returns_content_items(self, span_exporter, instrument):
+        """_call_tool() returning List[ContentItem] should still create a valid span."""
+        agent, mock_tool = self._make_agent_with_tool("image_gen")
+        mock_tool.call = MagicMock(
+            return_value=[ContentItem(text="Generated image description")]
+        )
+
+        result = agent._call_tool("image_gen", '{"prompt": "a cat"}')
+
+        assert isinstance(result, list)
+
+        spans = span_exporter.get_finished_spans()
+        tool_spans = [s for s in spans if "execute_tool" in s.name]
+        assert len(tool_spans) >= 1
+        assert tool_spans[0].name == "execute_tool image_gen"
+
+    def test_call_unknown_tool_no_crash(self, span_exporter, instrument):
+        """Calling a tool not in function_map should still produce a span without crashing."""
+        agent = _StubAgent.create(name="ToolAgent")
+        agent.function_map = {}
+
+        # The real Agent._call_tool returns an error string for unknown tools
+        result = agent._call_tool("nonexistent", "{}")
+
+        assert "does not exist" in result.lower() or isinstance(result, str)
+
+        spans = span_exporter.get_finished_spans()
+        tool_spans = [s for s in spans if "execute_tool" in s.name]
+        assert len(tool_spans) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Span hierarchy / parent-child tests
+# ---------------------------------------------------------------------------
+
+
+class TestSpanHierarchy:
+    """Verify that spans are correctly nested when operations are composed."""
+
+    def test_agent_run_with_llm_call_produces_nested_spans(
+        self, span_exporter, instrument
+    ):
+        """When an agent run internally calls LLM chat, spans should be nested."""
+        model = _StubChatModel(model="qwen-max", model_type="qwen_dashscope")
+        agent = _StubAgent.create(name="NestBot", llm=model)
+
+        llm_response = [Message(role="assistant", content="The answer is 42.")]
+
+        def fake_run(messages, **kwargs):
+            # Simulate the agent calling LLM internally
+            with patch.object(
+                _StubChatModel,
+                "_chat_no_stream",
+                return_value=llm_response,
+            ):
+                agent.llm.chat(messages=messages, stream=False)
+            yield [Message(role="assistant", content="The answer is 42.")]
+
+        with patch.object(_StubAgent, "_run", side_effect=fake_run):
+            list(agent.run([Message(role="user", content="What is 6*7?")]))
+
+        spans = span_exporter.get_finished_spans()
+        agent_spans = [s for s in spans if "invoke_agent" in s.name]
+        chat_spans = [s for s in spans if s.name.startswith("chat")]
+
+        assert len(agent_spans) >= 1
+        assert len(chat_spans) >= 1
+
+        # The chat span should be a child of the agent span
+        agent_span = agent_spans[0]
+        chat_span = chat_spans[0]
+        assert chat_span.context.trace_id == agent_span.context.trace_id
+        assert chat_span.parent is not None
+        assert chat_span.parent.span_id == agent_span.context.span_id
+
+    def test_agent_run_with_tool_call_produces_nested_spans(
+        self, span_exporter, instrument
+    ):
+        """When an agent run internally calls a tool, spans should be nested."""
+        agent = _StubAgent.create(name="ToolNestBot")
+
+        mock_tool = MagicMock()
+        mock_tool.description = "Calculator tool"
+        mock_tool.call = MagicMock(return_value="42")
+        agent.function_map = {"calculator": mock_tool}
+
+        def fake_run(messages, **kwargs):
+            # Simulate the agent calling a tool internally
+            agent._call_tool("calculator", '{"expr": "6*7"}')
+            yield [Message(role="assistant", content="The result is 42.")]
+
+        with patch.object(_StubAgent, "_run", side_effect=fake_run):
+            list(agent.run([Message(role="user", content="Calculate 6*7")]))
+
+        spans = span_exporter.get_finished_spans()
+        agent_spans = [s for s in spans if "invoke_agent" in s.name]
+        tool_spans = [s for s in spans if "execute_tool" in s.name]
+
+        assert len(agent_spans) >= 1
+        assert len(tool_spans) >= 1
+
+        agent_span = agent_spans[0]
+        tool_span = tool_spans[0]
+        assert tool_span.context.trace_id == agent_span.context.trace_id
+        assert tool_span.parent is not None
+        assert tool_span.parent.span_id == agent_span.context.span_id
+
+
+# ---------------------------------------------------------------------------
+# ReAct Step span tests
+# ---------------------------------------------------------------------------
+
+
+class TestReactStepSpan:
+    """Verify that react_step spans are created for ReAct agents with tools,
+    and NOT created for agents without tools."""
+
+    def test_react_agent_with_tools_creates_react_step_spans(
+        self, span_exporter, instrument
+    ):
+        """FnCallAgent-like agent with tools: each _call_llm round should
+        produce a react_step span."""
+        model = _StubChatModel(model="qwen-max", model_type="qwen_dashscope")
+        agent = _StubAgent.create(name="ReactBot", llm=model)
+
+        # Give the agent a tool -> react mode ON
+        mock_tool = MagicMock()
+        mock_tool.description = "Calculator"
+        mock_tool.call = MagicMock(return_value="42")
+        agent.function_map = {"calculator": mock_tool}
+
+        # Simulate 2-round ReAct: LLM -> tool -> LLM -> done
+        call_count = [0]
+
+        def fake_run(messages, **kwargs):
+            # Round 1: LLM decides to call tool
+            call_count[0] += 1
+            with patch.object(
+                _StubChatModel,
+                "_chat_no_stream",
+                return_value=[
+                    Message(
+                        role="assistant",
+                        content="",
+                        function_call=FunctionCall(
+                            name="calculator",
+                            arguments='{"expr": "6*7"}',
+                        ),
+                    )
+                ],
+            ):
+                # This calls _call_llm internally -> react_step 1
+                agent._call_llm(messages=messages, functions=[], stream=False)
+
+            # Tool call (inside react_step 1 context)
+            agent._call_tool("calculator", '{"expr": "6*7"}')
+
+            # Round 2: LLM summarizes (react_step 2)
+            call_count[0] += 1
+            with patch.object(
+                _StubChatModel,
+                "_chat_no_stream",
+                return_value=[
+                    Message(role="assistant", content="The result is 42.")
+                ],
+            ):
+                agent._call_llm(messages=messages, functions=[], stream=False)
+
+            yield [Message(role="assistant", content="The result is 42.")]
+
+        with patch.object(_StubAgent, "_run", side_effect=fake_run):
+            list(agent.run([Message(role="user", content="Calculate 6*7")]))
+
+        spans = span_exporter.get_finished_spans()
+        react_spans = [s for s in spans if "react step" in s.name]
+        agent_spans = [s for s in spans if "invoke_agent" in s.name]
+        chat_spans = [s for s in spans if s.name.startswith("chat")]
+        tool_spans = [s for s in spans if "execute_tool" in s.name]
+
+        # Should have exactly 2 react_step spans
+        assert len(react_spans) == 2, (
+            f"Expected 2 react_step spans, got {len(react_spans)}: "
+            f"{[s.name for s in spans]}"
+        )
+
+        # react_step spans should be children of invoke_agent
+        agent_span = agent_spans[0]
+        for rs in react_spans:
+            assert rs.parent is not None
+            assert rs.parent.span_id == agent_span.context.span_id
+
+        # chat spans should be children of react_step (not directly of invoke_agent)
+        for cs in chat_spans:
+            assert cs.parent is not None
+            parent_is_react = any(
+                cs.parent.span_id == rs.context.span_id for rs in react_spans
+            )
+            assert parent_is_react, (
+                f"chat span parent should be a react_step, "
+                f"not {cs.parent.span_id}"
+            )
+
+        # tool span should be child of react_step 1 (the first one)
+        assert len(tool_spans) >= 1
+        tool_span = tool_spans[0]
+        assert tool_span.parent is not None
+        assert tool_span.parent.span_id == react_spans[0].context.span_id
+
+    def test_agent_without_tools_no_react_step_spans(
+        self, span_exporter, instrument
+    ):
+        """Agent WITHOUT tools: no react_step spans should be created,
+        even though _call_llm is wrapped."""
+        model = _StubChatModel(model="qwen-max", model_type="qwen_dashscope")
+        agent = _StubAgent.create(name="SimpleBot", llm=model)
+        agent.function_map = {}  # No tools -> react mode OFF
+
+        def fake_run(messages, **kwargs):
+            with patch.object(
+                _StubChatModel,
+                "_chat_no_stream",
+                return_value=[
+                    Message(role="assistant", content="Hello!")
+                ],
+            ):
+                agent._call_llm(messages=messages, stream=False)
+            yield [Message(role="assistant", content="Hello!")]
+
+        with patch.object(_StubAgent, "_run", side_effect=fake_run):
+            list(agent.run([Message(role="user", content="Hi")]))
+
+        spans = span_exporter.get_finished_spans()
+        react_spans = [s for s in spans if "react step" in s.name]
+        agent_spans = [s for s in spans if "invoke_agent" in s.name]
+        chat_spans = [s for s in spans if s.name.startswith("chat")]
+
+        # NO react_step spans
+        assert len(react_spans) == 0, (
+            f"Expected 0 react_step spans for no-tool agent, "
+            f"got {len(react_spans)}: {[s.name for s in spans]}"
+        )
+
+        # invoke_agent and chat should still work normally
+        assert len(agent_spans) >= 1
+        assert len(chat_spans) >= 1
+
+        # chat should be direct child of invoke_agent (no react_step in between)
+        chat_span = chat_spans[0]
+        assert chat_span.parent is not None
+        assert chat_span.parent.span_id == agent_spans[0].context.span_id
+
+    def test_single_round_react_agent_creates_one_step(
+        self, span_exporter, instrument
+    ):
+        """Agent WITH tools but LLM answers directly (no tool call):
+        should create exactly 1 react_step span (step=1)."""
+        model = _StubChatModel(model="qwen-max", model_type="qwen_dashscope")
+        agent = _StubAgent.create(name="DirectBot", llm=model)
+
+        mock_tool = MagicMock()
+        mock_tool.description = "Unused tool"
+        agent.function_map = {"unused_tool": mock_tool}
+
+        def fake_run(messages, **kwargs):
+            # LLM answers directly, no tool call
+            with patch.object(
+                _StubChatModel,
+                "_chat_no_stream",
+                return_value=[
+                    Message(role="assistant", content="I know the answer: 42.")
+                ],
+            ):
+                agent._call_llm(messages=messages, functions=[], stream=False)
+            yield [Message(role="assistant", content="I know the answer: 42.")]
+
+        with patch.object(_StubAgent, "_run", side_effect=fake_run):
+            list(agent.run([Message(role="user", content="What is 42?")]))
+
+        spans = span_exporter.get_finished_spans()
+        react_spans = [s for s in spans if "react step" in s.name]
+
+        # Exactly 1 react_step (agent had tools, so react mode was on)
+        assert len(react_spans) == 1
+
+    def test_react_step_does_not_leak_across_runs(
+        self, span_exporter, instrument
+    ):
+        """Running an agent WITH tools, then an agent WITHOUT tools:
+        the second run should NOT have react_step spans."""
+        model = _StubChatModel(model="qwen-max", model_type="qwen_dashscope")
+
+        # Run 1: agent with tools
+        agent1 = _StubAgent.create(name="ToolBot", llm=model)
+        mock_tool = MagicMock()
+        mock_tool.description = "Tool"
+        mock_tool.call = MagicMock(return_value="ok")
+        agent1.function_map = {"tool1": mock_tool}
+
+        def fake_run_1(messages, **kwargs):
+            with patch.object(
+                _StubChatModel,
+                "_chat_no_stream",
+                return_value=[Message(role="assistant", content="Done")],
+            ):
+                agent1._call_llm(messages=messages, functions=[], stream=False)
+            yield [Message(role="assistant", content="Done")]
+
+        with patch.object(_StubAgent, "_run", side_effect=fake_run_1):
+            list(agent1.run([Message(role="user", content="Go")]))
+
+        spans_after_run1 = span_exporter.get_finished_spans()
+        react_spans_1 = [s for s in spans_after_run1 if "react step" in s.name]
+        assert len(react_spans_1) == 1  # Tool agent had react_step
+
+        span_exporter.clear()
+
+        # Run 2: agent WITHOUT tools
+        agent2 = _StubAgent.create(name="PlainBot", llm=model)
+        agent2.function_map = {}
+
+        def fake_run_2(messages, **kwargs):
+            with patch.object(
+                _StubChatModel,
+                "_chat_no_stream",
+                return_value=[Message(role="assistant", content="Hi")],
+            ):
+                agent2._call_llm(messages=messages, stream=False)
+            yield [Message(role="assistant", content="Hi")]
+
+        with patch.object(_StubAgent, "_run", side_effect=fake_run_2):
+            list(agent2.run([Message(role="user", content="Hello")]))
+
+        spans_after_run2 = span_exporter.get_finished_spans()
+        react_spans_2 = [s for s in spans_after_run2 if "react step" in s.name]
+        assert len(react_spans_2) == 0  # No tool -> no react_step

--- a/tox-loongsuite.ini
+++ b/tox-loongsuite.ini
@@ -44,6 +44,10 @@ envlist =
     py3{9,10,11,12,13}-test-loongsuite-instrumentation-langgraph-{oldest,latest}
     lint-loongsuite-instrumentation-langgraph
 
+    ; loongsuite-instrumentation-qwen-agent
+    py3{9,10,11,12,13}-test-loongsuite-instrumentation-qwen-agent-{oldest,latest}
+    lint-loongsuite-instrumentation-qwen-agent
+
     ; ; loongsuite-instrumentation-mcp
     ; py3{9,10,11,12,13}-test-loongsuite-instrumentation-mcp
     ; lint-loongsuite-instrumentation-mcp
@@ -122,6 +126,11 @@ deps =
   langgraph-latest: -r {toxinidir}/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/tests/requirements.latest.txt
   lint-loongsuite-instrumentation-langgraph: -r {toxinidir}/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/tests/requirements.oldest.txt
 
+  qwen-agent-oldest: -r {toxinidir}/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/requirements.oldest.txt
+  qwen-agent-latest: {[testenv]test_deps}
+  qwen-agent-latest: -r {toxinidir}/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/requirements.latest.txt
+  lint-loongsuite-instrumentation-qwen-agent: -r {toxinidir}/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/requirements.oldest.txt
+
   mcp: {[testenv]test_deps}
   mcp: -r {toxinidir}/instrumentation-loongsuite/loongsuite-instrumentation-mcp/test-requirements.txt
 
@@ -183,6 +192,9 @@ commands =
 
   test-loongsuite-instrumentation-langgraph: pytest {toxinidir}/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/tests {posargs}
   lint-loongsuite-instrumentation-langgraph: python -m ruff check {toxinidir}/instrumentation-loongsuite/loongsuite-instrumentation-langgraph
+
+  test-loongsuite-instrumentation-qwen-agent: pytest {toxinidir}/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests {posargs}
+  lint-loongsuite-instrumentation-qwen-agent: python -m ruff check {toxinidir}/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent
 
   test-loongsuite-instrumentation-mcp: pytest {toxinidir}/instrumentation-loongsuite/loongsuite-instrumentation-mcp/tests {posargs}
   lint-loongsuite-instrumentation-mcp: python -m ruff check {toxinidir}/instrumentation-loongsuite/loongsuite-instrumentation-mcp

--- a/tox-loongsuite.ini
+++ b/tox-loongsuite.ini
@@ -44,6 +44,10 @@ envlist =
     py3{9,10,11,12,13}-test-loongsuite-instrumentation-langgraph-{oldest,latest}
     lint-loongsuite-instrumentation-langgraph
 
+    ; loongsuite-instrumentation-qwen-agent
+    py3{9,10,11,12,13}-test-loongsuite-instrumentation-qwen-agent-{oldest,latest}
+    lint-loongsuite-instrumentation-qwen-agent
+
     ; ; loongsuite-instrumentation-mcp
     ; py3{9,10,11,12,13}-test-loongsuite-instrumentation-mcp
     ; lint-loongsuite-instrumentation-mcp
@@ -118,6 +122,11 @@ deps =
   langgraph-latest: -r {toxinidir}/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/tests/requirements.latest.txt
   lint-loongsuite-instrumentation-langgraph: -r {toxinidir}/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/tests/requirements.oldest.txt
 
+  qwen-agent-oldest: -r {toxinidir}/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/requirements.oldest.txt
+  qwen-agent-latest: {[testenv]test_deps}
+  qwen-agent-latest: -r {toxinidir}/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/requirements.latest.txt
+  lint-loongsuite-instrumentation-qwen-agent: -r {toxinidir}/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/requirements.oldest.txt
+
   loongsuite-mcp: {[testenv]test_deps}
   loongsuite-mcp: -r {toxinidir}/instrumentation-loongsuite/loongsuite-instrumentation-mcp/test-requirements.txt
 
@@ -177,6 +186,9 @@ commands =
 
   test-loongsuite-instrumentation-langgraph: pytest {toxinidir}/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/tests {posargs}
   lint-loongsuite-instrumentation-langgraph: python -m ruff check {toxinidir}/instrumentation-loongsuite/loongsuite-instrumentation-langgraph
+
+  test-loongsuite-instrumentation-qwen-agent: pytest {toxinidir}/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests {posargs}
+  lint-loongsuite-instrumentation-qwen-agent: python -m ruff check {toxinidir}/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent
 
   test-loongsuite-instrumentation-mcp: pytest {toxinidir}/instrumentation-loongsuite/loongsuite-instrumentation-mcp/tests {posargs}
   lint-loongsuite-instrumentation-mcp: python -m ruff check {toxinidir}/instrumentation-loongsuite/loongsuite-instrumentation-mcp


### PR DESCRIPTION
# Description

This PR adds loongsuite-instrumentation-qwen-agent: OpenTelemetry instrumentation for [Qwen-Agent](https://github.com/QwenLM/Qwen-Agent) using ExtendedTelemetryHandler from opentelemetry-util-genai. It emits GenAI semantic-convention traces for agent runs, LLM calls, ReAct steps, and tool execution (invoke_agent, chat, react step, execute_tool), registers an opentelemetry_instrumentor entry point, and includes unit tests plus VCR-based integration tests.

Fixes #11 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

pip install -e ".[test]" under instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent, then pytest on that package’s tests/
From repo root: tox -c tox-loongsuite.ini -e py312-test-loongsuite-instrumentation-qwen-agent-oldest, py312-test-loongsuite-instrumentation-qwen-agent-latest, lint-loongsuite-instrumentation-qwen-agent

- [x] Test A

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
