### PR TITLE
Pin LoongSuite core repo SHA to 0.62-compatible commit

### DIFF
--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/lint.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/lint.yml.j2
@@ -18,15 +18,16 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport' otherwise, set it to 'main'
-  # For PRs you can change the inner fallback ('main')
-  # For pushes you change the outer fallback ('main')
+  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport'
+  # otherwise, set it to the pinned 0.62-compatible core commit.
+  # For PRs you can change the inner fallback if needed.
+  # For pushes you change the outer fallback if needed.
   # The logic below is used during releases and depends on having an equivalent branch name in the core repo.
   CORE_REPO_SHA: {% raw %}${{ github.event_name == 'pull_request' && (
        contains(github.event.pull_request.labels.*.name, 'prepare-release') && github.event.pull_request.head.ref ||
        contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
-       'main'
-    ) || 'main' }}{% endraw %}
+       '37dea4bbdb1a3c83b96fc22c2f68a848b4989fb5'
+    ) || '37dea4bbdb1a3c83b96fc22c2f68a848b4989fb5' }}{% endraw %}
   CONTRIB_REPO_SHA: main
   PIP_EXISTS_ACTION: w
 

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/loongsuite_lint.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/loongsuite_lint.yml.j2
@@ -18,15 +18,15 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport' otherwise, set it to 'main'
-  # For PRs you can change the inner fallback ('main')
-  # For pushes you change the outer fallback ('main')
-  # The logic below is used during releases and depends on having an equivalent branch name in the core repo.
+  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport'
+  # otherwise, fall back to a pinned 0.62-compatible core commit.
+  # The logic below is used during releases and depends on having an equivalent branch name
+  # in the core repo.
   CORE_REPO_SHA: {% raw %}${{ github.event_name == 'pull_request' && (
        contains(github.event.pull_request.labels.*.name, 'prepare-release') && github.event.pull_request.head.ref ||
        contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
-       'main'
-    ) || 'main' }}{% endraw %}
+       '37dea4bbdb1a3c83b96fc22c2f68a848b4989fb5'
+    ) || '37dea4bbdb1a3c83b96fc22c2f68a848b4989fb5' }}{% endraw %}
   CONTRIB_REPO_SHA: main
   PIP_EXISTS_ACTION: w
 
@@ -52,4 +52,3 @@ jobs:
       - name: Run tests
         run: tox -c tox-loongsuite.ini -e {{ job_data.tox_env }}
   {%- endfor %}
-

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/loongsuite_misc.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/loongsuite_misc.yml.j2
@@ -18,15 +18,15 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport' otherwise, set it to 'main'
-  # For PRs you can change the inner fallback ('main')
-  # For pushes you change the outer fallback ('main')
-  # The logic below is used during releases and depends on having an equivalent branch name in the core repo.
+  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport'
+  # otherwise, fall back to a pinned 0.62-compatible core commit.
+  # The logic below is used during releases and depends on having an equivalent branch name
+  # in the core repo.
   CORE_REPO_SHA: {% raw %}${{ github.event_name == 'pull_request' && (
        contains(github.event.pull_request.labels.*.name, 'prepare-release') && github.event.pull_request.head.ref ||
        contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
-       'main'
-    ) || 'main' }}{% endraw %}
+       '37dea4bbdb1a3c83b96fc22c2f68a848b4989fb5'
+    ) || '37dea4bbdb1a3c83b96fc22c2f68a848b4989fb5' }}{% endraw %}
   CONTRIB_REPO_SHA: main
   PIP_EXISTS_ACTION: w
 
@@ -89,4 +89,3 @@ jobs:
         run: git diff --exit-code || (echo 'Generated code is out of date, run "tox -e generate" and commit the changes in this PR.' && exit 1)
       {%- endif %}
   {%- endfor %}
-

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/loongsuite_test.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/loongsuite_test.yml.j2
@@ -18,15 +18,15 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport' otherwise, set it to 'main'
-  # For PRs you can change the inner fallback ('main')
-  # For pushes you change the outer fallback ('main')
-  # The logic below is used during releases and depends on having an equivalent branch name in the core repo.
+  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport'
+  # otherwise, fall back to a pinned 0.62-compatible core commit.
+  # The logic below is used during releases and depends on having an equivalent branch name
+  # in the core repo.
   CORE_REPO_SHA: {% raw %}${{ github.event_name == 'pull_request' && (
        contains(github.event.pull_request.labels.*.name, 'prepare-release') && github.event.pull_request.head.ref ||
        contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
-       'main'
-    ) || 'main' }}{% endraw %}
+       '37dea4bbdb1a3c83b96fc22c2f68a848b4989fb5'
+    ) || '37dea4bbdb1a3c83b96fc22c2f68a848b4989fb5' }}{% endraw %}
   CONTRIB_REPO_SHA: main
   PIP_EXISTS_ACTION: w
 
@@ -57,4 +57,3 @@ jobs:
       - name: Run tests
         run: tox -c tox-loongsuite.ini -e {{ job_data.tox_env }} -- -ra
   {%- endfor %}
-

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/misc.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/misc.yml.j2
@@ -18,15 +18,16 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport' otherwise, set it to 'main'
-  # For PRs you can change the inner fallback ('main')
-  # For pushes you change the outer fallback ('main')
+  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport'
+  # otherwise, set it to the pinned 0.62-compatible core commit.
+  # For PRs you can change the inner fallback if needed.
+  # For pushes you change the outer fallback if needed.
   # The logic below is used during releases and depends on having an equivalent branch name in the core repo.
   CORE_REPO_SHA: {% raw %}${{ github.event_name == 'pull_request' && (
        contains(github.event.pull_request.labels.*.name, 'prepare-release') && github.event.pull_request.head.ref ||
        contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
-       'main'
-    ) || 'main' }}{% endraw %}
+       '37dea4bbdb1a3c83b96fc22c2f68a848b4989fb5'
+    ) || '37dea4bbdb1a3c83b96fc22c2f68a848b4989fb5' }}{% endraw %}
   CONTRIB_REPO_SHA: main
   PIP_EXISTS_ACTION: w
 

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/test.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/test.yml.j2
@@ -18,15 +18,16 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport' otherwise, set it to 'main'
-  # For PRs you can change the inner fallback ('main')
-  # For pushes you change the outer fallback ('main')
+  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport'
+  # otherwise, set it to the pinned 0.62-compatible core commit.
+  # For PRs you can change the inner fallback if needed.
+  # For pushes you change the outer fallback if needed.
   # The logic below is used during releases and depends on having an equivalent branch name in the core repo.
   CORE_REPO_SHA: {% raw %}${{ github.event_name == 'pull_request' && (
        contains(github.event.pull_request.labels.*.name, 'prepare-release') && github.event.pull_request.head.ref ||
        contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
-       'main'
-    ) || 'main' }}{% endraw %}
+       '37dea4bbdb1a3c83b96fc22c2f68a848b4989fb5'
+    ) || '37dea4bbdb1a3c83b96fc22c2f68a848b4989fb5' }}{% endraw %}
   CONTRIB_REPO_SHA: main
   PIP_EXISTS_ACTION: w
 

--- a/.github/workflows/lint_0.yml
+++ b/.github/workflows/lint_0.yml
@@ -18,15 +18,16 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport' otherwise, set it to 'main'
-  # For PRs you can change the inner fallback ('main')
-  # For pushes you change the outer fallback ('main')
+  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport'
+  # otherwise, set it to the pinned 0.62-compatible core commit.
+  # For PRs you can change the inner fallback if needed.
+  # For pushes you change the outer fallback if needed.
   # The logic below is used during releases and depends on having an equivalent branch name in the core repo.
   CORE_REPO_SHA: ${{ github.event_name == 'pull_request' && (
        contains(github.event.pull_request.labels.*.name, 'prepare-release') && github.event.pull_request.head.ref ||
        contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
-       'main'
-    ) || 'main' }}
+       '37dea4bbdb1a3c83b96fc22c2f68a848b4989fb5'
+    ) || '37dea4bbdb1a3c83b96fc22c2f68a848b4989fb5' }}
   CONTRIB_REPO_SHA: main
   PIP_EXISTS_ACTION: w
 

--- a/.github/workflows/loongsuite_lint_0.yml
+++ b/.github/workflows/loongsuite_lint_0.yml
@@ -18,15 +18,15 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport' otherwise, set it to 'main'
-  # For PRs you can change the inner fallback ('main')
-  # For pushes you change the outer fallback ('main')
-  # The logic below is used during releases and depends on having an equivalent branch name in the core repo.
+  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport'
+  # otherwise, fall back to a pinned 0.62-compatible core commit.
+  # The logic below is used during releases and depends on having an equivalent branch name
+  # in the core repo.
   CORE_REPO_SHA: ${{ github.event_name == 'pull_request' && (
        contains(github.event.pull_request.labels.*.name, 'prepare-release') && github.event.pull_request.head.ref ||
        contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
-       'main'
-    ) || 'main' }}
+       '37dea4bbdb1a3c83b96fc22c2f68a848b4989fb5'
+    ) || '37dea4bbdb1a3c83b96fc22c2f68a848b4989fb5' }}
   CONTRIB_REPO_SHA: main
   PIP_EXISTS_ACTION: w
 
@@ -240,4 +240,3 @@ jobs:
 
       - name: Run tests
         run: tox -c tox-loongsuite.ini -e lint-loongsuite-instrumentation-copaw
-

--- a/.github/workflows/loongsuite_misc_0.yml
+++ b/.github/workflows/loongsuite_misc_0.yml
@@ -18,15 +18,15 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport' otherwise, set it to 'main'
-  # For PRs you can change the inner fallback ('main')
-  # For pushes you change the outer fallback ('main')
-  # The logic below is used during releases and depends on having an equivalent branch name in the core repo.
+  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport'
+  # otherwise, fall back to a pinned 0.62-compatible core commit.
+  # The logic below is used during releases and depends on having an equivalent branch name
+  # in the core repo.
   CORE_REPO_SHA: ${{ github.event_name == 'pull_request' && (
        contains(github.event.pull_request.labels.*.name, 'prepare-release') && github.event.pull_request.head.ref ||
        contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
-       'main'
-    ) || 'main' }}
+       '37dea4bbdb1a3c83b96fc22c2f68a848b4989fb5'
+    ) || '37dea4bbdb1a3c83b96fc22c2f68a848b4989fb5' }}
   CONTRIB_REPO_SHA: main
   PIP_EXISTS_ACTION: w
 
@@ -69,4 +69,3 @@ jobs:
 
       - name: Run tests
         run: tox -c tox-loongsuite.ini -e generate-loongsuite
-

--- a/.github/workflows/loongsuite_test_0.yml
+++ b/.github/workflows/loongsuite_test_0.yml
@@ -18,15 +18,15 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport' otherwise, set it to 'main'
-  # For PRs you can change the inner fallback ('main')
-  # For pushes you change the outer fallback ('main')
-  # The logic below is used during releases and depends on having an equivalent branch name in the core repo.
+  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport'
+  # otherwise, fall back to a pinned 0.62-compatible core commit.
+  # The logic below is used during releases and depends on having an equivalent branch name
+  # in the core repo.
   CORE_REPO_SHA: ${{ github.event_name == 'pull_request' && (
        contains(github.event.pull_request.labels.*.name, 'prepare-release') && github.event.pull_request.head.ref ||
        contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
-       'main'
-    ) || 'main' }}
+       '37dea4bbdb1a3c83b96fc22c2f68a848b4989fb5'
+    ) || '37dea4bbdb1a3c83b96fc22c2f68a848b4989fb5' }}
   CONTRIB_REPO_SHA: main
   PIP_EXISTS_ACTION: w
 
@@ -1608,4 +1608,3 @@ jobs:
 
       - name: Run tests
         run: tox -c tox-loongsuite.ini -e py313-test-loongsuite-instrumentation-copaw -- -ra
-

--- a/.github/workflows/misc_0.yml
+++ b/.github/workflows/misc_0.yml
@@ -18,15 +18,16 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport' otherwise, set it to 'main'
-  # For PRs you can change the inner fallback ('main')
-  # For pushes you change the outer fallback ('main')
+  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport'
+  # otherwise, set it to the pinned 0.62-compatible core commit.
+  # For PRs you can change the inner fallback if needed.
+  # For pushes you change the outer fallback if needed.
   # The logic below is used during releases and depends on having an equivalent branch name in the core repo.
   CORE_REPO_SHA: ${{ github.event_name == 'pull_request' && (
        contains(github.event.pull_request.labels.*.name, 'prepare-release') && github.event.pull_request.head.ref ||
        contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
-       'main'
-    ) || 'main' }}
+       '37dea4bbdb1a3c83b96fc22c2f68a848b4989fb5'
+    ) || '37dea4bbdb1a3c83b96fc22c2f68a848b4989fb5' }}
   CONTRIB_REPO_SHA: main
   PIP_EXISTS_ACTION: w
 

--- a/.github/workflows/test_0.yml
+++ b/.github/workflows/test_0.yml
@@ -18,15 +18,16 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport' otherwise, set it to 'main'
-  # For PRs you can change the inner fallback ('main')
-  # For pushes you change the outer fallback ('main')
+  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport'
+  # otherwise, set it to the pinned 0.62-compatible core commit.
+  # For PRs you can change the inner fallback if needed.
+  # For pushes you change the outer fallback if needed.
   # The logic below is used during releases and depends on having an equivalent branch name in the core repo.
   CORE_REPO_SHA: ${{ github.event_name == 'pull_request' && (
        contains(github.event.pull_request.labels.*.name, 'prepare-release') && github.event.pull_request.head.ref ||
        contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
-       'main'
-    ) || 'main' }}
+       '37dea4bbdb1a3c83b96fc22c2f68a848b4989fb5'
+    ) || '37dea4bbdb1a3c83b96fc22c2f68a848b4989fb5' }}
   CONTRIB_REPO_SHA: main
   PIP_EXISTS_ACTION: w
 

--- a/.github/workflows/test_1.yml
+++ b/.github/workflows/test_1.yml
@@ -18,15 +18,16 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport' otherwise, set it to 'main'
-  # For PRs you can change the inner fallback ('main')
-  # For pushes you change the outer fallback ('main')
+  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport'
+  # otherwise, set it to the pinned 0.62-compatible core commit.
+  # For PRs you can change the inner fallback if needed.
+  # For pushes you change the outer fallback if needed.
   # The logic below is used during releases and depends on having an equivalent branch name in the core repo.
   CORE_REPO_SHA: ${{ github.event_name == 'pull_request' && (
        contains(github.event.pull_request.labels.*.name, 'prepare-release') && github.event.pull_request.head.ref ||
        contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
-       'main'
-    ) || 'main' }}
+       '37dea4bbdb1a3c83b96fc22c2f68a848b4989fb5'
+    ) || '37dea4bbdb1a3c83b96fc22c2f68a848b4989fb5' }}
   CONTRIB_REPO_SHA: main
   PIP_EXISTS_ACTION: w
 

--- a/.github/workflows/test_2.yml
+++ b/.github/workflows/test_2.yml
@@ -18,15 +18,16 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport' otherwise, set it to 'main'
-  # For PRs you can change the inner fallback ('main')
-  # For pushes you change the outer fallback ('main')
+  # Set the SHA to the branch name if the PR has a label 'prepare-release' or 'backport'
+  # otherwise, set it to the pinned 0.62-compatible core commit.
+  # For PRs you can change the inner fallback if needed.
+  # For pushes you change the outer fallback if needed.
   # The logic below is used during releases and depends on having an equivalent branch name in the core repo.
   CORE_REPO_SHA: ${{ github.event_name == 'pull_request' && (
        contains(github.event.pull_request.labels.*.name, 'prepare-release') && github.event.pull_request.head.ref ||
        contains(github.event.pull_request.labels.*.name, 'backport') && github.event.pull_request.base.ref ||
-       'main'
-    ) || 'main' }}
+       '37dea4bbdb1a3c83b96fc22c2f68a848b4989fb5'
+    ) || '37dea4bbdb1a3c83b96fc22c2f68a848b4989fb5' }}
   CONTRIB_REPO_SHA: main
   PIP_EXISTS_ACTION: w
 

--- a/CHANGELOG-loongsuite.md
+++ b/CHANGELOG-loongsuite.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Pin the default upstream core SHA used by CI to a 0.62-compatible commit, and
+  cap `mem0ai` support to `<2.0.0` until mem0 v2 compatibility lands.
+
 ## Version 0.4.0 (2026-04-03)
 
 There are no changelog entries for this release.

--- a/CHANGELOG-loongsuite.md
+++ b/CHANGELOG-loongsuite.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Pin the default upstream core SHA used by CI to a 0.62-compatible commit, and
-  cap `mem0ai` support to `<2.0.0` until mem0 v2 compatibility lands.
+  cap `mem0ai` support to `<2.0.0` while keeping Mem0 oldest/latest test
+  coverage aligned with the supported `1.x` range.
 
 ## Version 0.4.0 (2026-04-03)
 

--- a/instrumentation-loongsuite/loongsuite-instrumentation-mem0/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-mem0/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Limit supported `mem0ai` versions to `>=1.0.0,<2.0.0` and pin test
-  environments to `1.0.11` to avoid mem0 v2 API breakage in CI.
+- Limit supported `mem0ai` versions to `>=1.0.0,<2.0.0`, test the true
+  minimum supported version in `requirements.oldest.txt`, and keep the
+  latest test environment on the supported `1.x` line.
 
 ## Version 0.4.0 (2026-04-03)
 

--- a/instrumentation-loongsuite/loongsuite-instrumentation-mem0/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-mem0/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Limit supported `mem0ai` versions to `>=1.0.0,<2.0.0` and pin test
+  environments to `1.0.11` to avoid mem0 v2 API breakage in CI.
+
 ## Version 0.4.0 (2026-04-03)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-mem0/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-mem0/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 
 [project.optional-dependencies]
 instruments = [
-  "mem0ai >= 1.0.0",
+  "mem0ai >= 1.0.0, < 2.0.0",
 ]
 
 [project.entry-points.opentelemetry_instrumentor]

--- a/instrumentation-loongsuite/loongsuite-instrumentation-mem0/src/opentelemetry/instrumentation/mem0/package.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-mem0/src/opentelemetry/instrumentation/mem0/package.py
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-_instruments = ("mem0ai >= 1.0.0",)
+_instruments = ("mem0ai >= 1.0.0, < 2.0.0",)
 
 _supports_metrics = False

--- a/instrumentation-loongsuite/loongsuite-instrumentation-mem0/tests/requirements.latest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-mem0/tests/requirements.latest.txt
@@ -42,7 +42,7 @@ vcrpy>=7.0.0,<8.0.0
 
 # Third-party libraries used in tests
 pyyaml>=6.0.0
-mem0ai==1.0.11
+mem0ai>=1.0.11,<2.0.0
 wrapt==1.17.3
 # Mock and utilities
 mock>=4.0.0
@@ -51,4 +51,3 @@ mock>=4.0.0
 -e opentelemetry-instrumentation
 -e instrumentation-loongsuite/loongsuite-instrumentation-mem0
 -e util/opentelemetry-util-genai
-

--- a/instrumentation-loongsuite/loongsuite-instrumentation-mem0/tests/requirements.latest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-mem0/tests/requirements.latest.txt
@@ -42,7 +42,7 @@ vcrpy>=7.0.0,<8.0.0
 
 # Third-party libraries used in tests
 pyyaml>=6.0.0
-mem0ai>=1.0.0
+mem0ai==1.0.11
 wrapt==1.17.3
 # Mock and utilities
 mock>=4.0.0
@@ -51,5 +51,4 @@ mock>=4.0.0
 -e opentelemetry-instrumentation
 -e instrumentation-loongsuite/loongsuite-instrumentation-mem0
 -e util/opentelemetry-util-genai
-
 

--- a/instrumentation-loongsuite/loongsuite-instrumentation-mem0/tests/requirements.oldest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-mem0/tests/requirements.oldest.txt
@@ -23,7 +23,7 @@ vcrpy>=7.0.0,<8.0.0
 
 # Third-party libraries used in tests
 pyyaml>=6.0.0
-mem0ai>=1.0.0
+mem0ai==1.0.11
 wrapt==1.17.3
 # OpenTelemetry SDK and testing utilities (pinned to stable versions)
 opentelemetry-api==1.37
@@ -37,5 +37,4 @@ mock>=4.0.0
 # Internal dependency (this package, editable install)
 -e instrumentation-loongsuite/loongsuite-instrumentation-mem0
 -e util/opentelemetry-util-genai
-
 

--- a/instrumentation-loongsuite/loongsuite-instrumentation-mem0/tests/requirements.oldest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-mem0/tests/requirements.oldest.txt
@@ -23,7 +23,7 @@ vcrpy>=7.0.0,<8.0.0
 
 # Third-party libraries used in tests
 pyyaml>=6.0.0
-mem0ai==1.0.11
+mem0ai==1.0.0
 wrapt==1.17.3
 # OpenTelemetry SDK and testing utilities (pinned to stable versions)
 opentelemetry-api==1.37
@@ -37,4 +37,3 @@ mock>=4.0.0
 # Internal dependency (this package, editable install)
 -e instrumentation-loongsuite/loongsuite-instrumentation-mem0
 -e util/opentelemetry-util-genai
-

--- a/instrumentation-loongsuite/loongsuite-instrumentation-mem0/tests/test_memory_operations_vcr.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-mem0/tests/test_memory_operations_vcr.py
@@ -372,11 +372,13 @@ def test_internal_subphases_attributes(
         if s.attributes.get("gen_ai.provider.name") is not None
     ]
     if m.reranker is not None:
-        # If Memory instance has reranker, should be able to collect reranker span
-        # Because reranker is created via factory, will be instrumented
-        assert reranker_spans, (
-            "When reranker exists, should collect reranker stage spans"
-        )
+        # mem0 1.x does not always invoke the reranker path under the fake/VCR
+        # setup used here, so only validate attributes when a reranker span
+        # is actually emitted.
+        if not reranker_spans:
+            pytest.skip(
+                "mem0 did not emit reranker subphase spans under the current test setup"
+            )
         # Verify attributes
         assert any(
             s.attributes.get("gen_ai.provider.name") is not None
@@ -568,7 +570,10 @@ def test_reranker_operations_detailed_attributes(
         s for s in spans if "gen_ai.provider.name" in s.attributes
     ]
 
-    assert reranker_spans, "should collect reranker spans"
+    if not reranker_spans:
+        pytest.skip(
+            "mem0 did not emit reranker spans under the current fake/VCR setup"
+        )
 
     reranker_span = reranker_spans[0]
     assert reranker_span.attributes.get("gen_ai.provider.name") == "fake", (

--- a/instrumentation-loongsuite/loongsuite-instrumentation-mem0/tests/test_memory_operations_vcr.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-mem0/tests/test_memory_operations_vcr.py
@@ -323,12 +323,16 @@ def test_internal_subphases_attributes(
     m.llm = FakeLLM()
     m.embedding_model = FakeEmbedder()
 
-    # Trigger operations
-    assert (
-        m.add("我叫小王，我不喜欢川菜，常住上海。", user_id="u_abc")
-        is not None
+    m.vector_store.reset()
+    m.vector_store.insert(
+        payloads=[
+            {"data": "我喜欢川菜和火锅。"},
+            {"data": "我喜欢清淡饮食。"},
+            {"data": "我常住上海。"},
+        ]
     )
-    # Using rerank=True to trigger reranker (if exists)
+
+    # Search across multiple seeded candidates so reranking deterministically runs.
     assert (
         m.search("川菜推荐", user_id="u_abc", limit=2, rerank=True) is not None
     )
@@ -372,13 +376,9 @@ def test_internal_subphases_attributes(
         if s.attributes.get("gen_ai.provider.name") is not None
     ]
     if m.reranker is not None:
-        # mem0 1.x does not always invoke the reranker path under the fake/VCR
-        # setup used here, so only validate attributes when a reranker span
-        # is actually emitted.
-        if not reranker_spans:
-            pytest.skip(
-                "mem0 did not emit reranker subphase spans under the current test setup"
-            )
+        assert reranker_spans, (
+            "When reranker is enabled, should collect reranker stage spans"
+        )
         # Verify attributes
         assert any(
             s.attributes.get("gen_ai.provider.name") is not None
@@ -560,9 +560,16 @@ def test_reranker_operations_detailed_attributes(
     m.llm = FakeLLM()
     m.embedding_model = FakeEmbedder()
 
-    m.add("测试data1", user_id="u_rerank_test")
-    m.add("测试data2", user_id="u_rerank_test")
-    m.search("测试", user_id="u_rerank_test", limit=5, rerank=True)
+    m.vector_store.reset()
+    m.vector_store.insert(
+        payloads=[
+            {"data": "测试data1"},
+            {"data": "测试data2"},
+            {"data": "测试data3"},
+        ]
+    )
+
+    m.search("测试", user_id="u_rerank_test", limit=2, rerank=True)
 
     spans = span_exporter.get_finished_spans()
     # Now uses gen_ai.provider.name instead of gen_ai.memory.reranker.provider
@@ -570,18 +577,20 @@ def test_reranker_operations_detailed_attributes(
         s for s in spans if "gen_ai.provider.name" in s.attributes
     ]
 
-    if not reranker_spans:
-        pytest.skip(
-            "mem0 did not emit reranker spans under the current fake/VCR setup"
-        )
+    assert reranker_spans, (
+        "expected mem0 reranker instrumentation to emit at least one reranker "
+        "span, but none were found"
+    )
 
     reranker_span = reranker_spans[0]
     assert reranker_span.attributes.get("gen_ai.provider.name") == "fake", (
         "should contain correct provider.name"
     )
-    # Now uses gen_ai.rerank.documents_count instead of gen_ai.memory.reranker.input_count
-    if "gen_ai.rerank.documents_count" in reranker_span.attributes:
-        documents_count = reranker_span.attributes.get(
-            "gen_ai.rerank.documents_count"
-        )
-        assert documents_count > 0, "documents_count should be greater than 0"
+    documents_count = reranker_span.attributes.get(
+        "gen_ai.rerank.documents_count"
+    )
+    assert documents_count == 2, (
+        f"documents_count should match seeded candidate count, got {documents_count}"
+    )
+    top_k = reranker_span.attributes.get("gen_ai.request.top_k")
+    assert top_k == 2, f"top_k should reflect the search limit, got {top_k}"

--- a/tox-loongsuite.ini
+++ b/tox-loongsuite.ini
@@ -147,9 +147,10 @@ allowlist_externals =
   pytest
 
 setenv =
-  ; override CORE_REPO_SHA via env variable when testing other branches/commits than main
+  ; override CORE_REPO_SHA via env variable when testing other branches/commits
+  ; than the default pinned 0.62-compatible core commit
   ; i.e: CORE_REPO_SHA=dde62cebffe519c35875af6d06fae053b3be65ec tox -e <env to test>
-  CORE_REPO_SHA={env:CORE_REPO_SHA:main}
+  CORE_REPO_SHA={env:CORE_REPO_SHA:37dea4bbdb1a3c83b96fc22c2f68a848b4989fb5}
   CORE_REPO=git+https://github.com/open-telemetry/opentelemetry-python.git@{env:CORE_REPO_SHA}
   UV_CONFIG_FILE={toxinidir}/tox-uv.toml
 

--- a/tox.ini
+++ b/tox.ini
@@ -775,9 +775,10 @@ allowlist_externals =
   pytest
 
 setenv =
-  ; override CORE_REPO_SHA via env variable when testing other branches/commits than main
-  ; i.e: CORE_REPO_SHA=dde62cebffe519c35875af6d06fae053b3be65ec tox -e <env to test>
-  CORE_REPO_SHA={env:CORE_REPO_SHA:main}
+  ; override CORE_REPO_SHA via env variable when testing other branches/commits than the pinned
+  ; 0.62-compatible core commit, e.g.:
+  ; CORE_REPO_SHA=dde62cebffe519c35875af6d06fae053b3be65ec tox -e <env to test>
+  CORE_REPO_SHA={env:CORE_REPO_SHA:37dea4bbdb1a3c83b96fc22c2f68a848b4989fb5}
   CORE_REPO=git+https://github.com/open-telemetry/opentelemetry-python.git@{env:CORE_REPO_SHA}
   UV_CONFIG_FILE={toxinidir}/tox-uv.toml
   PIP_CONSTRAINTS={toxinidir}/test-constraints.txt


### PR DESCRIPTION
# Description

This PR pins the default `CORE_REPO_SHA` used by LoongSuite CI to a
0.62-compatible upstream core commit.

This avoids CI breakage caused by upstream core `main` moving from the
`0.62b0.dev` line to `0.63b0.dev` while local LoongSuite packages are still
tested against the `0.62` line.

Fixes #167

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- `tox -c tox-loongsuite.ini -e lint-util-genai,lint-loongsuite-instrumentation-litellm`
- GitHub Actions `LoongSuite Lint 0`: passed for `util-genai` and `loongsuite-instrumentation-litellm`
- GitHub Actions `LoongSuite Test 0`: passed for watched `util-genai` and `loongsuite-instrumentation-litellm` jobs

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
