### PR TITLE
feat(agentscope): detect skill loads and enrich execute_tool spans

### DIFF
--- a/CHANGELOG-loongsuite.md
+++ b/CHANGELOG-loongsuite.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pin the default upstream core SHA used by CI to a 0.62-compatible commit, and
   cap `mem0ai` support to `<2.0.0` while keeping Mem0 oldest/latest test
   coverage aligned with the supported `1.x` range.
+- Constrain LoongSuite instrumentation `wrapt` dependencies to `<2.0.0` to
+  avoid wrapper compatibility regressions from the wrapt 2.x line.
 
 ## Version 0.4.0 (2026-04-03)
 

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Detect skill-load tool executions by matching reads of registered skills'
+  top-level `SKILL.md`, and enrich the corresponding `execute_tool` span with
+  `gen_ai.skill.name`, `gen_ai.skill.id`, `gen_ai.skill.description`, and
+  `gen_ai.skill.version`.
+
+### Fixed
+
+- Pin `wrapt` to `< 2.0.0` for AgentScope instrumentation compatibility with
+  the current wrapper API usage.
+
 ## Version 0.4.0 (2026-04-03)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/README.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/README.md
@@ -92,6 +92,28 @@ export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=NO_CONTENT
 - **Tools**: Toolkit.call_tool_function
 - **Formatters**: TruncatedFormatterBase.format
 
+### Skill metadata on tool spans
+
+When a tool execution reads the top-level `SKILL.md` of a skill already
+registered in `toolkit.skills`, AgentScope enriches that `execute_tool` span
+with:
+
+- `gen_ai.skill.name`
+- `gen_ai.skill.id`
+- `gen_ai.skill.description`
+- `gen_ai.skill.version`
+
+The matching is intentionally conservative:
+
+- only registered skills can match
+- only the top-level `SKILL.md` counts as a skill load
+- reads under other paths such as `scripts/` or `references/` do not emit
+  `gen_ai.skill.*`
+
+For CoPaw-style workspace layouts, `gen_ai.skill.version` is resolved from
+`SKILL.md` frontmatter first and falls back to workspace `skill.json`
+`metadata.version_text` when needed.
+
 ## Concurrency (agents)
 
 ReAct step tracing stores temporary state on the agent instance for the

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "opentelemetry-instrumentation >= 0.58b0",
   "opentelemetry-semantic-conventions >= 0.58b0",
   "opentelemetry-util-genai",
-  "wrapt >= 1.0.0, < 2.0.0",
+  "wrapt >= 1.17.3, < 2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "opentelemetry-instrumentation >= 0.58b0",
   "opentelemetry-semantic-conventions >= 0.58b0",
   "opentelemetry-util-genai",
-  "wrapt",
+  "wrapt >= 1.0.0, < 2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/patch.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/patch.py
@@ -33,6 +33,241 @@ from opentelemetry.util.genai.types import Error
 logger = logging.getLogger(__name__)
 
 
+# The canonical filename that defines a skill.  Only reads targeting this
+# file are treated as "skill load" operations.
+_SKILL_MANIFEST = "SKILL.md"
+
+
+def _resolves_to_skill_md(
+    file_path: str,
+    skill_dir: str,
+    *,
+    allow_bare: bool = False,
+) -> bool:
+    """Return True if *file_path* points to the ``SKILL.md`` inside *skill_dir*.
+
+    Supports three path forms that appear in real CoPaw/QwenPaw traces:
+
+    1. **Absolute path** – e.g.
+       ``/home/user/.copaw/workspaces/default/skills/pdf/SKILL.md``
+       Compared directly against ``{skill_dir}/SKILL.md`` using
+       ``realpath`` to resolve symlinks (important on macOS where
+       ``/var`` → ``/private/var``).
+
+    2. **Bare filename** – ``SKILL.md``
+       Only accepted when *allow_bare* is ``True``.  The caller
+       (``_match_skill_for_tool``) sets this flag only when exactly
+       one skill is registered, so a bare ``SKILL.md`` is unambiguous.
+       With multiple skills a bare name could match any of them, so we
+       conservatively reject it and let the upstream CoPaw context
+       provide the authoritative match instead.
+
+    3. **Workspace-relative path** – e.g. ``skills/pdf/SKILL.md`` or
+       ``workspaces/default/skills/pdf/SKILL.md``
+       CoPaw resolves these against a workspace / WORKING_DIR that may
+       differ from the process cwd.  Instead of guessing the base
+       directory, we use **suffix matching**: the normalised path must
+       end with ``/{skill_dir_basename}/SKILL.md`` where
+       *skill_dir_basename* is the last component of *skill_dir*.
+       This avoids depending on cwd at all.
+    """
+    import os
+
+    try:
+        # Use realpath to resolve symlinks (e.g. /var → /private/var on macOS)
+        real_skill_dir = os.path.normpath(os.path.realpath(skill_dir))
+        expected = os.path.join(real_skill_dir, _SKILL_MANIFEST)
+
+        # --- Try 1: absolute path ---
+        if os.path.isabs(file_path):
+            candidate = os.path.normpath(os.path.realpath(file_path))
+            return candidate == expected
+
+        normalised_rel = os.path.normpath(file_path)
+
+        # --- Try 2: bare "SKILL.md" (only when unambiguous) ---
+        if normalised_rel == _SKILL_MANIFEST:
+            return allow_bare
+
+        # --- Try 3: workspace-relative path (suffix matching) ---
+        # Build the expected suffix: e.g. "pdf/SKILL.md"
+        skill_dir_basename = os.path.basename(real_skill_dir)
+        expected_suffix = os.path.join(skill_dir_basename, _SKILL_MANIFEST)
+
+        # The relative path must end with exactly "{skill_name}/SKILL.md"
+        # Use os.sep-aware comparison to avoid partial-name collisions
+        # (e.g. "pdf-extra/SKILL.md" must NOT match skill dir "pdf")
+        if normalised_rel == expected_suffix:
+            return True
+        if normalised_rel.endswith(os.sep + expected_suffix):
+            return True
+
+    except Exception:
+        return False
+
+    return False
+
+
+def _enrich_skill_metadata(skill):
+    """Enrich a matched skill dict with version and id from SKILL.md.
+
+    AgentScope's ``AgentSkill`` only stores ``name``, ``description``,
+    and ``dir``.  This function reads the SKILL.md frontmatter to extract
+    ``version`` and builds a **runtime / deployment-scoped** ``id``.
+
+    The enrichment is best-effort: if the frontmatter cannot be read
+    (e.g. file missing, parse error, or running without CoPaw), the
+    original skill dict is returned unchanged.
+
+    When CoPaw is available, its ``_read_frontmatter_safe`` and
+    ``_extract_version`` helpers are preferred because they are the
+    canonical source of truth.  Otherwise we fall back to a lightweight
+    ``frontmatter`` parse.
+
+    Returns a new dict (never mutates the original).
+    """
+    import os
+
+    skill_dir = skill.get("dir", "")
+    skill_name = skill.get("name", "")
+    if not skill_dir:
+        return dict(skill)
+
+    enriched = dict(skill)
+
+    # --- Extract version ---
+    version_text = None
+
+    # Prefer CoPaw's own helpers (canonical source of truth). If that
+    # path fails at runtime for any reason, continue to lightweight
+    # frontmatter/manifest fallbacks instead of dropping version entirely.
+    try:
+        from pathlib import Path
+
+        from copaw.agents.skills_manager import (
+            _extract_version,
+            _read_frontmatter_safe,
+        )
+
+        post = _read_frontmatter_safe(Path(skill_dir), skill_name)
+        version_text = _extract_version(post)
+    except Exception:
+        version_text = None
+
+    if not version_text:
+        try:
+            import frontmatter
+
+            skill_md_path = os.path.join(skill_dir, _SKILL_MANIFEST)
+            with open(skill_md_path, "r", encoding="utf-8") as fh:
+                post = frontmatter.load(fh)
+            metadata = post.get("metadata") or {}
+            for value in (
+                post.get("version"),
+                metadata.get("version"),
+                metadata.get("builtin_skill_version"),
+            ):
+                if value not in (None, ""):
+                    version_text = str(value)
+                    break
+        except Exception:
+            version_text = None
+
+    if not version_text:
+        try:
+            import json
+            from pathlib import Path
+
+            skill_path = Path(skill_dir)
+            skill_json_path = skill_path.parent.parent / "skill.json"
+            if skill_json_path.exists():
+                # CoPaw-specific runtime fallback: workspace skill.json may
+                # already contain normalized version_text even when direct
+                # helper/frontmatter extraction is unavailable in-process.
+                payload = json.loads(skill_json_path.read_text(encoding="utf-8"))
+                entry = payload.get("skills", {}).get(skill_name, {})
+                metadata = entry.get("metadata", {}) or {}
+                value = metadata.get("version_text")
+                if value not in (None, ""):
+                    version_text = str(value)
+        except Exception:
+            version_text = None
+
+    if version_text:
+        enriched["version"] = str(version_text)
+
+    # --- Build runtime/deployment-scoped skill ID ---
+    # Format: workspace:{workspace_name}:{skill_name}
+    # NOT a globally canonical ID — stable within one workspace.
+    try:
+        parts = skill_dir.replace("\\", "/").split("/")
+        workspace_name = "default"
+        try:
+            skills_idx = len(parts) - 1 - parts[::-1].index("skills")
+            if skills_idx >= 1:
+                workspace_name = parts[skills_idx - 1]
+        except ValueError:
+            pass
+        enriched["id"] = f"workspace:{workspace_name}:{skill_name}"
+    except Exception:
+        pass
+
+    return enriched
+
+def _match_skill_for_tool(instance, tool_args):
+    """Detect if a tool execution is loading a skill.
+
+    Returns an enriched dict with skill metadata (including version and
+    id when available) when **all** of the following conditions are met:
+
+    1. The Toolkit instance has registered skills.
+    2. The tool arguments contain a file path (``file_path``, ``path``,
+       or ``target_file``).
+    3. That path resolves to the ``SKILL.md`` file at the top level of a
+       registered skill directory.
+
+    Only reads of ``SKILL.md`` are considered skill loads.  Accessing
+    other files inside a skill directory (scripts, references, resources)
+    does **not** trigger skill attributes, keeping the semantic boundary
+    clean.
+
+    The skill judgment is precise: only skills registered in
+    ``toolkit.skills`` (i.e. effective skills for the current workspace
+    and channel) can match.  Arbitrary SKILL.md files outside the
+    registered set are never matched.
+
+    Otherwise ``None`` is returned.
+    """
+    if not hasattr(instance, "skills") or not instance.skills:
+        return None
+
+    # Extract candidate file path from tool arguments
+    file_path = None
+    if isinstance(tool_args, dict):
+        file_path = (
+            tool_args.get("file_path")
+            or tool_args.get("path")
+            or tool_args.get("target_file")
+        )
+    if not file_path:
+        return None
+
+    # Bare "SKILL.md" is ambiguous when multiple skills are registered.
+    # Only allow it when exactly one skill exists.
+    single_skill = len(instance.skills) == 1
+
+    # Check if the path resolves to SKILL.md of any registered skill
+    for skill in instance.skills.values():
+        skill_dir = skill.get("dir", "")
+        if not skill_dir:
+            continue
+
+        if _resolves_to_skill_md(file_path, skill_dir, allow_bare=single_skill):
+            return _enrich_skill_metadata(skill)
+
+    return None
+
+
 def _get_tool_description(instance, tool_name):
     """Get tool description from toolkit."""
     if (
@@ -107,7 +342,6 @@ async def _trace_async_generator_wrapper(
                 pass
 
         # Apply handler's attribute logic (without context management)
-        # TODO: Fix the context management logic in genai util
         try:
             _apply_execute_tool_finish_attributes(span, invocation)
 
@@ -143,6 +377,7 @@ async def wrap_tool_call(wrapped, instance, args, kwargs, handler):
         kwargs: Keyword arguments
         handler: ExtendedTelemetryHandler instance (required)
     """
+
     # Extract tool call information
     tool_call = args[0] if args else kwargs.get("tool_call", {})
     tool_name = (
@@ -158,6 +393,9 @@ async def wrap_tool_call(wrapped, instance, args, kwargs, handler):
     # Get tool description from AgentScope's toolkit
     tool_description = _get_tool_description(instance, tool_name)
 
+    # Detect if this tool execution is loading a skill
+    matched_skill = _match_skill_for_tool(instance, tool_args)
+
     # Create invocation object with all tool data
     invocation = ExecuteToolInvocation(
         tool_name=tool_name,
@@ -165,6 +403,27 @@ async def wrap_tool_call(wrapped, instance, args, kwargs, handler):
         tool_description=tool_description,
         tool_call_arguments=tool_args,
     )
+
+    # --- Skill attributes ---
+    #
+    # ``_match_skill_for_tool`` checks whether this tool call reads a
+    # registered skill's SKILL.md.  Only skills in ``toolkit.skills``
+    # (i.e. effective skills for the current workspace/channel) can match.
+    #
+    # When a match is found, ``_enrich_skill_metadata`` reads the
+    # SKILL.md frontmatter to extract version and builds a runtime-scoped
+    # skill_id.  If CoPaw is available, its canonical helpers are used;
+    # otherwise a lightweight frontmatter parse provides a best-effort
+    # fallback.  When running AgentScope standalone (no CoPaw, no
+    # frontmatter lib), name and description are still available from
+    # the AgentSkill dict.
+
+    if matched_skill is not None:
+        invocation.skill_name = matched_skill.get("name")
+        invocation.skill_id = matched_skill.get("id")
+        invocation.skill_description = matched_skill.get("description")
+        invocation.skill_version = matched_skill.get("version")
+
     invocation.monotonic_start_s = timeit.default_timer()
 
     span_name = f"{GenAIAttributes.GenAiOperationNameValues.EXECUTE_TOOL.value} {tool_name}"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/patch.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/patch.py
@@ -16,8 +16,12 @@
 
 from __future__ import annotations
 
+import json
 import logging
+import os
 import timeit
+from importlib import import_module
+from pathlib import Path
 
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
@@ -71,8 +75,6 @@ def _resolves_to_skill_md(
        *skill_dir_basename* is the last component of *skill_dir*.
        This avoids depending on cwd at all.
     """
-    import os
-
     try:
         # Use realpath to resolve symlinks (e.g. /var → /private/var on macOS)
         real_skill_dir = os.path.normpath(os.path.realpath(skill_dir))
@@ -126,8 +128,6 @@ def _enrich_skill_metadata(skill):
 
     Returns a new dict (never mutates the original).
     """
-    import os
-
     skill_dir = skill.get("dir", "")
     skill_name = skill.get("name", "")
     if not skill_dir:
@@ -142,21 +142,18 @@ def _enrich_skill_metadata(skill):
     # path fails at runtime for any reason, continue to lightweight
     # frontmatter/manifest fallbacks instead of dropping version entirely.
     try:
-        from pathlib import Path
+        skills_manager = import_module("copaw.agents.skills_manager")
 
-        from copaw.agents.skills_manager import (
-            _extract_version,
-            _read_frontmatter_safe,
+        post = skills_manager._read_frontmatter_safe(
+            Path(skill_dir), skill_name
         )
-
-        post = _read_frontmatter_safe(Path(skill_dir), skill_name)
-        version_text = _extract_version(post)
+        version_text = skills_manager._extract_version(post)
     except Exception:
         version_text = None
 
     if not version_text:
         try:
-            import frontmatter
+            frontmatter = import_module("frontmatter")
 
             skill_md_path = os.path.join(skill_dir, _SKILL_MANIFEST)
             with open(skill_md_path, "r", encoding="utf-8") as fh:
@@ -175,16 +172,15 @@ def _enrich_skill_metadata(skill):
 
     if not version_text:
         try:
-            import json
-            from pathlib import Path
-
             skill_path = Path(skill_dir)
             skill_json_path = skill_path.parent.parent / "skill.json"
             if skill_json_path.exists():
                 # CoPaw-specific runtime fallback: workspace skill.json may
                 # already contain normalized version_text even when direct
                 # helper/frontmatter extraction is unavailable in-process.
-                payload = json.loads(skill_json_path.read_text(encoding="utf-8"))
+                payload = json.loads(
+                    skill_json_path.read_text(encoding="utf-8")
+                )
                 entry = payload.get("skills", {}).get(skill_name, {})
                 metadata = entry.get("metadata", {}) or {}
                 value = metadata.get("version_text")
@@ -213,6 +209,7 @@ def _enrich_skill_metadata(skill):
         pass
 
     return enriched
+
 
 def _match_skill_for_tool(instance, tool_args):
     """Detect if a tool execution is loading a skill.
@@ -262,7 +259,9 @@ def _match_skill_for_tool(instance, tool_args):
         if not skill_dir:
             continue
 
-        if _resolves_to_skill_md(file_path, skill_dir, allow_bare=single_skill):
+        if _resolves_to_skill_md(
+            file_path, skill_dir, allow_bare=single_skill
+        ):
             return _enrich_skill_metadata(skill)
 
     return None

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/patch.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/patch.py
@@ -114,12 +114,14 @@ def _enrich_skill_metadata(skill):
     """Enrich a matched skill dict with version and id from SKILL.md.
 
     AgentScope's ``AgentSkill`` only stores ``name``, ``description``,
-    and ``dir``.  This function reads the SKILL.md frontmatter to extract
-    ``version`` and builds a **runtime / deployment-scoped** ``id``.
+    and ``dir``. This function best-effort extracts ``version`` from
+    SKILL.md/frontmatter-related sources and builds a
+    **runtime / deployment-scoped** ``id`` when ``dir`` is available.
 
-    The enrichment is best-effort: if the frontmatter cannot be read
-    (e.g. file missing, parse error, or running without CoPaw), the
-    original skill dict is returned unchanged.
+    The enrichment is best-effort: if frontmatter/version data cannot be
+    read (e.g. file missing, parse error, or running without CoPaw), the
+    returned dict may still include a path-derived ``id`` when possible,
+    but ``version`` is only added when successfully determined.
 
     When CoPaw is available, its ``_read_frontmatter_safe`` and
     ``_extract_version`` helpers are preferred because they are the
@@ -253,7 +255,7 @@ def _match_skill_for_tool(instance, tool_args):
     # Only allow it when exactly one skill exists.
     single_skill = len(instance.skills) == 1
 
-    # Check if the path resolves to SKILL.md of any registered skill
+    matches = []
     for skill in instance.skills.values():
         skill_dir = skill.get("dir", "")
         if not skill_dir:
@@ -262,7 +264,10 @@ def _match_skill_for_tool(instance, tool_args):
         if _resolves_to_skill_md(
             file_path, skill_dir, allow_bare=single_skill
         ):
-            return _enrich_skill_metadata(skill)
+            matches.append(_enrich_skill_metadata(skill))
+
+    if len(matches) == 1:
+        return matches[0]
 
     return None
 

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/requirements.latest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/requirements.latest.txt
@@ -41,7 +41,7 @@ pytest-cov
 pytest-vcr>=1.0.2
 vcrpy>=5.1.0
 pyyaml>=6.0
-wrapt<2.0.0
+wrapt>=1.17.3,<2.0.0
 
 -e opentelemetry-instrumentation
 -e instrumentation-loongsuite/loongsuite-instrumentation-agentscope

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/requirements.latest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/requirements.latest.txt
@@ -41,7 +41,7 @@ pytest-cov
 pytest-vcr>=1.0.2
 vcrpy>=5.1.0
 pyyaml>=6.0
-wrapt
+wrapt<2.0.0
 
 -e opentelemetry-instrumentation
 -e instrumentation-loongsuite/loongsuite-instrumentation-agentscope

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/requirements.oldest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/requirements.oldest.txt
@@ -26,7 +26,7 @@ opentelemetry-api==1.37
 opentelemetry-sdk==1.37
 opentelemetry-instrumentation==0.58b0
 opentelemetry-semantic-conventions==0.58b0
-wrapt
+wrapt<2.0.0
 
 -e instrumentation-loongsuite/loongsuite-instrumentation-agentscope
 -e util/opentelemetry-util-genai

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/requirements.oldest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/requirements.oldest.txt
@@ -26,7 +26,7 @@ opentelemetry-api==1.37
 opentelemetry-sdk==1.37
 opentelemetry-instrumentation==0.58b0
 opentelemetry-semantic-conventions==0.58b0
-wrapt<2.0.0
+wrapt>=1.17.3,<2.0.0
 
 -e instrumentation-loongsuite/loongsuite-instrumentation-agentscope
 -e util/opentelemetry-util-genai

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/test_skill_detection.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/test_skill_detection.py
@@ -30,9 +30,6 @@ from opentelemetry.util.genai.extended_semconv.gen_ai_extended_attributes import
     GEN_AI_SKILL_NAME,
     GEN_AI_SKILL_VERSION,
 )
-from opentelemetry.util.genai.extended_span_utils import (
-    _apply_execute_tool_finish_attributes,
-)
 from opentelemetry.util.genai.extended_types import ExecuteToolInvocation
 
 
@@ -243,34 +240,6 @@ class TestEnrichSkillMetadata:
 
 
 class TestSkillSpanAttributes:
-    def test_apply_execute_tool_finish_attributes_writes_skill_fields(self):
-        invocation = ExecuteToolInvocation(
-            tool_name="read_file",
-            skill_name="news",
-            skill_id="workspace:default:news",
-            skill_description="Latest news",
-            skill_version="1.0",
-        )
-
-        span = _FakeSpan()
-        _apply_execute_tool_finish_attributes(span, invocation)
-
-        assert span.attributes[GEN_AI_SKILL_NAME] == "news"
-        assert span.attributes[GEN_AI_SKILL_ID] == "workspace:default:news"
-        assert span.attributes[GEN_AI_SKILL_DESCRIPTION] == "Latest news"
-        assert span.attributes[GEN_AI_SKILL_VERSION] == "1.0"
-
-    def test_apply_execute_tool_finish_attributes_skips_none(self):
-        span = _FakeSpan()
-        _apply_execute_tool_finish_attributes(
-            span, ExecuteToolInvocation(tool_name="read_file")
-        )
-
-        assert GEN_AI_SKILL_NAME not in span.attributes
-        assert GEN_AI_SKILL_ID not in span.attributes
-        assert GEN_AI_SKILL_DESCRIPTION not in span.attributes
-        assert GEN_AI_SKILL_VERSION not in span.attributes
-
     @pytest.mark.asyncio
     async def test_trace_async_generator_wrapper_preserves_skill_attributes(self):
         async def fake_tool_generator():

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/test_skill_detection.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/test_skill_detection.py
@@ -1,0 +1,300 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Focused tests for AgentScope skill detection and span attributes."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from opentelemetry.instrumentation.agentscope.patch import (
+    _enrich_skill_metadata,
+    _match_skill_for_tool,
+    _resolves_to_skill_md,
+    _trace_async_generator_wrapper,
+)
+from opentelemetry.util.genai.extended_semconv.gen_ai_extended_attributes import (
+    GEN_AI_SKILL_DESCRIPTION,
+    GEN_AI_SKILL_ID,
+    GEN_AI_SKILL_NAME,
+    GEN_AI_SKILL_VERSION,
+)
+from opentelemetry.util.genai.extended_span_utils import (
+    _apply_execute_tool_finish_attributes,
+)
+from opentelemetry.util.genai.extended_types import ExecuteToolInvocation
+
+
+def _make_instance(skills: dict | None = None):
+    instance = SimpleNamespace()
+    if skills is not None:
+        instance.skills = skills
+    return instance
+
+
+class _FakeSpan:
+    def __init__(self):
+        self.attributes = {}
+        self.ended = False
+
+    def set_attributes(self, attrs: dict):
+        self.attributes.update(attrs)
+
+    def set_attribute(self, key, value):
+        self.attributes[key] = value
+
+    def update_name(self, name: str):
+        del name
+
+    def end(self):
+        self.ended = True
+
+    def set_status(self, status):
+        del status
+
+    def record_exception(self, exception):
+        del exception
+
+
+class _FakeHandler:
+    def __init__(self):
+        self._metrics_recorder = None
+
+
+class TestResolvesToSkillMd:
+    def test_absolute_skill_md_matches(self, tmp_path):
+        skill_dir = tmp_path / "skills" / "pdf"
+        skill_dir.mkdir(parents=True)
+        target = skill_dir / "SKILL.md"
+        target.touch()
+
+        assert _resolves_to_skill_md(str(target), str(skill_dir)) is True
+
+    def test_non_skill_file_rejected(self, tmp_path):
+        skill_dir = tmp_path / "skills" / "pdf"
+        skill_dir.mkdir(parents=True)
+        target = skill_dir / "scripts" / "run.sh"
+        target.parent.mkdir(parents=True)
+        target.touch()
+
+        assert _resolves_to_skill_md(str(target), str(skill_dir)) is False
+
+    def test_prefix_collision_rejected(self, tmp_path):
+        skill_dir = tmp_path / "skills" / "pdf"
+        skill_dir.mkdir(parents=True)
+        target_dir = tmp_path / "skills" / "pdf-extra"
+        target_dir.mkdir(parents=True)
+        target = target_dir / "SKILL.md"
+        target.touch()
+
+        assert _resolves_to_skill_md(str(target), str(skill_dir)) is False
+
+    def test_workspace_relative_match(self, tmp_path):
+        skill_dir = tmp_path / "workspaces" / "default" / "skills" / "pdf"
+        skill_dir.mkdir(parents=True)
+
+        assert _resolves_to_skill_md("skills/pdf/SKILL.md", str(skill_dir)) is True
+
+    def test_bare_skill_md_requires_allow_bare(self, tmp_path):
+        skill_dir = tmp_path / "skills" / "pdf"
+        skill_dir.mkdir(parents=True)
+
+        assert _resolves_to_skill_md("SKILL.md", str(skill_dir)) is False
+        assert _resolves_to_skill_md(
+            "SKILL.md", str(skill_dir), allow_bare=True
+        ) is True
+
+
+class TestMatchSkillForTool:
+    def test_matches_registered_skill_manifest(self, tmp_path):
+        skill_dir = tmp_path / "workspaces" / "default" / "skills" / "news"
+        skill_dir.mkdir(parents=True)
+        skill_md = skill_dir / "SKILL.md"
+        skill_md.write_text(
+            "---\n"
+            "name: news\n"
+            "description: Latest news\n"
+            "metadata:\n"
+            "  builtin_skill_version: 1.0\n"
+            "---\n"
+        )
+
+        instance = _make_instance(
+            {
+                "news": {
+                    "name": "news",
+                    "description": "Latest news",
+                    "dir": str(skill_dir),
+                }
+            }
+        )
+
+        result = _match_skill_for_tool(
+            instance,
+            {"file_path": str(skill_md)},
+        )
+
+        assert result is not None
+        assert result["name"] == "news"
+        assert result["id"] == "workspace:default:news"
+        assert result["version"] == "1.0"
+
+    def test_non_manifest_read_does_not_match(self, tmp_path):
+        skill_dir = tmp_path / "skills" / "news"
+        skill_dir.mkdir(parents=True)
+        target = skill_dir / "references" / "note.md"
+        target.parent.mkdir(parents=True)
+        target.touch()
+
+        instance = _make_instance(
+            {"news": {"name": "news", "dir": str(skill_dir)}}
+        )
+
+        assert _match_skill_for_tool(instance, {"file_path": str(target)}) is None
+
+    def test_bare_skill_md_only_matches_single_skill(self, tmp_path):
+        one_dir = tmp_path / "skills" / "one"
+        one_dir.mkdir(parents=True)
+        (one_dir / "SKILL.md").touch()
+
+        single = _make_instance(
+            {"one": {"name": "one", "dir": str(one_dir)}}
+        )
+        multiple = _make_instance(
+            {
+                "one": {"name": "one", "dir": str(one_dir)},
+                "two": {"name": "two", "dir": str(tmp_path / "skills" / "two")},
+            }
+        )
+
+        assert _match_skill_for_tool(single, {"file_path": "SKILL.md"}) is not None
+        assert _match_skill_for_tool(multiple, {"file_path": "SKILL.md"}) is None
+
+
+class TestEnrichSkillMetadata:
+    def test_reads_version_from_frontmatter(self, tmp_path):
+        skill_dir = tmp_path / "workspaces" / "demo" / "skills" / "writer"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: writer\ndescription: Write docs\nversion: 2.1.0\n---\n"
+        )
+
+        skill = {
+            "name": "writer",
+            "description": "Write docs",
+            "dir": str(skill_dir),
+        }
+        enriched = _enrich_skill_metadata(skill)
+
+        assert enriched["version"] == "2.1.0"
+        assert enriched["id"] == "workspace:demo:writer"
+        assert "version" not in skill
+        assert "id" not in skill
+
+    def test_falls_back_to_workspace_skill_json_version(self, tmp_path):
+        workspace_dir = tmp_path / "workspaces" / "demo"
+        skill_dir = workspace_dir / "skills" / "writer"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: writer\ndescription: Write docs\n---\n"
+        )
+        (workspace_dir / "skill.json").write_text(
+            (
+                '{"skills":{"writer":{"metadata":{"version_text":"3.0.0"}}}}'
+            )
+        )
+
+        enriched = _enrich_skill_metadata(
+            {
+                "name": "writer",
+                "description": "Write docs",
+                "dir": str(skill_dir),
+            }
+        )
+
+        assert enriched["version"] == "3.0.0"
+        assert enriched["id"] == "workspace:demo:writer"
+
+    def test_missing_skill_md_is_best_effort(self, tmp_path):
+        skill_dir = tmp_path / "workspaces" / "default" / "skills" / "writer"
+        skill_dir.mkdir(parents=True)
+
+        enriched = _enrich_skill_metadata(
+            {
+                "name": "writer",
+                "description": "Write docs",
+                "dir": str(skill_dir),
+            }
+        )
+
+        assert enriched["id"] == "workspace:default:writer"
+        assert "version" not in enriched
+
+
+class TestSkillSpanAttributes:
+    def test_apply_execute_tool_finish_attributes_writes_skill_fields(self):
+        invocation = ExecuteToolInvocation(
+            tool_name="read_file",
+            skill_name="news",
+            skill_id="workspace:default:news",
+            skill_description="Latest news",
+            skill_version="1.0",
+        )
+
+        span = _FakeSpan()
+        _apply_execute_tool_finish_attributes(span, invocation)
+
+        assert span.attributes[GEN_AI_SKILL_NAME] == "news"
+        assert span.attributes[GEN_AI_SKILL_ID] == "workspace:default:news"
+        assert span.attributes[GEN_AI_SKILL_DESCRIPTION] == "Latest news"
+        assert span.attributes[GEN_AI_SKILL_VERSION] == "1.0"
+
+    def test_apply_execute_tool_finish_attributes_skips_none(self):
+        span = _FakeSpan()
+        _apply_execute_tool_finish_attributes(
+            span, ExecuteToolInvocation(tool_name="read_file")
+        )
+
+        assert GEN_AI_SKILL_NAME not in span.attributes
+        assert GEN_AI_SKILL_ID not in span.attributes
+        assert GEN_AI_SKILL_DESCRIPTION not in span.attributes
+        assert GEN_AI_SKILL_VERSION not in span.attributes
+
+    @pytest.mark.asyncio
+    async def test_trace_async_generator_wrapper_preserves_skill_attributes(self):
+        async def fake_tool_generator():
+            yield "chunk"
+
+        invocation = ExecuteToolInvocation(
+            tool_name="read_file",
+            skill_name="news",
+            skill_id="workspace:default:news",
+            skill_description="Latest news",
+            skill_version="1.0",
+        )
+        span = _FakeSpan()
+        handler = _FakeHandler()
+
+        chunks = []
+        async for chunk in _trace_async_generator_wrapper(
+            fake_tool_generator(), invocation, span, handler
+        ):
+            chunks.append(chunk)
+
+        assert chunks == ["chunk"]
+        assert span.attributes[GEN_AI_SKILL_NAME] == "news"
+        assert span.attributes[GEN_AI_SKILL_ID] == "workspace:default:news"
+        assert span.attributes[GEN_AI_SKILL_DESCRIPTION] == "Latest news"
+        assert span.attributes[GEN_AI_SKILL_VERSION] == "1.0"
+        assert span.ended is True

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/test_skill_detection.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/test_skill_detection.py
@@ -101,16 +101,20 @@ class TestResolvesToSkillMd:
         skill_dir = tmp_path / "workspaces" / "default" / "skills" / "pdf"
         skill_dir.mkdir(parents=True)
 
-        assert _resolves_to_skill_md("skills/pdf/SKILL.md", str(skill_dir)) is True
+        assert (
+            _resolves_to_skill_md("skills/pdf/SKILL.md", str(skill_dir))
+            is True
+        )
 
     def test_bare_skill_md_requires_allow_bare(self, tmp_path):
         skill_dir = tmp_path / "skills" / "pdf"
         skill_dir.mkdir(parents=True)
 
         assert _resolves_to_skill_md("SKILL.md", str(skill_dir)) is False
-        assert _resolves_to_skill_md(
-            "SKILL.md", str(skill_dir), allow_bare=True
-        ) is True
+        assert (
+            _resolves_to_skill_md("SKILL.md", str(skill_dir), allow_bare=True)
+            is True
+        )
 
 
 class TestMatchSkillForTool:
@@ -158,25 +162,33 @@ class TestMatchSkillForTool:
             {"news": {"name": "news", "dir": str(skill_dir)}}
         )
 
-        assert _match_skill_for_tool(instance, {"file_path": str(target)}) is None
+        assert (
+            _match_skill_for_tool(instance, {"file_path": str(target)}) is None
+        )
 
     def test_bare_skill_md_only_matches_single_skill(self, tmp_path):
         one_dir = tmp_path / "skills" / "one"
         one_dir.mkdir(parents=True)
         (one_dir / "SKILL.md").touch()
 
-        single = _make_instance(
-            {"one": {"name": "one", "dir": str(one_dir)}}
-        )
+        single = _make_instance({"one": {"name": "one", "dir": str(one_dir)}})
         multiple = _make_instance(
             {
                 "one": {"name": "one", "dir": str(one_dir)},
-                "two": {"name": "two", "dir": str(tmp_path / "skills" / "two")},
+                "two": {
+                    "name": "two",
+                    "dir": str(tmp_path / "skills" / "two"),
+                },
             }
         )
 
-        assert _match_skill_for_tool(single, {"file_path": "SKILL.md"}) is not None
-        assert _match_skill_for_tool(multiple, {"file_path": "SKILL.md"}) is None
+        assert (
+            _match_skill_for_tool(single, {"file_path": "SKILL.md"})
+            is not None
+        )
+        assert (
+            _match_skill_for_tool(multiple, {"file_path": "SKILL.md"}) is None
+        )
 
 
 class TestEnrichSkillMetadata:
@@ -207,9 +219,7 @@ class TestEnrichSkillMetadata:
             "---\nname: writer\ndescription: Write docs\n---\n"
         )
         (workspace_dir / "skill.json").write_text(
-            (
-                '{"skills":{"writer":{"metadata":{"version_text":"3.0.0"}}}}'
-            )
+            ('{"skills":{"writer":{"metadata":{"version_text":"3.0.0"}}}}')
         )
 
         enriched = _enrich_skill_metadata(
@@ -241,7 +251,9 @@ class TestEnrichSkillMetadata:
 
 class TestSkillSpanAttributes:
     @pytest.mark.asyncio
-    async def test_trace_async_generator_wrapper_preserves_skill_attributes(self):
+    async def test_trace_async_generator_wrapper_preserves_skill_attributes(
+        self,
+    ):
         async def fake_tool_generator():
             yield "chunk"
 

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/test_skill_detection.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/test_skill_detection.py
@@ -190,6 +190,30 @@ class TestMatchSkillForTool:
             _match_skill_for_tool(multiple, {"file_path": "SKILL.md"}) is None
         )
 
+    def test_workspace_relative_match_returns_none_when_ambiguous(
+        self, tmp_path
+    ):
+        default_dir = tmp_path / "workspaces" / "default" / "skills" / "pdf"
+        demo_dir = tmp_path / "workspaces" / "demo" / "skills" / "pdf"
+        default_dir.mkdir(parents=True)
+        demo_dir.mkdir(parents=True)
+        (default_dir / "SKILL.md").touch()
+        (demo_dir / "SKILL.md").touch()
+
+        instance = _make_instance(
+            {
+                "default_pdf": {"name": "pdf", "dir": str(default_dir)},
+                "demo_pdf": {"name": "pdf", "dir": str(demo_dir)},
+            }
+        )
+
+        assert (
+            _match_skill_for_tool(
+                instance, {"file_path": "skills/pdf/SKILL.md"}
+            )
+            is None
+        )
+
 
 class TestEnrichSkillMetadata:
     def test_reads_version_from_frontmatter(self, tmp_path):

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agno/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agno/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "opentelemetry-api ~= 1.37",
   "opentelemetry-instrumentation >= 0.58b0",
   "opentelemetry-semantic-conventions >= 0.58b0",
+  "wrapt >= 1.0.0, < 2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agno/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agno/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "opentelemetry-api ~= 1.37",
   "opentelemetry-instrumentation >= 0.58b0",
   "opentelemetry-semantic-conventions >= 0.58b0",
-  "wrapt >= 1.0.0, < 2.0.0",
+  "wrapt >= 1.17.3, < 2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agno/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agno/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "opentelemetry-api ~= 1.37",
   "opentelemetry-instrumentation >= 0.58b0",
   "opentelemetry-semantic-conventions >= 0.58b0",
-  "wrapt >= 1.17.3, < 2.0.0",
+  "wrapt >= 1.0.0, < 2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "opentelemetry-api ~= 1.37",
   "opentelemetry-instrumentation ~= 0.58b0",
   "opentelemetry-semantic-conventions ~= 0.58b0",
-  "wrapt >= 1.0.0, < 2.0.0",
+  "wrapt >= 1.17.3, < 2.0.0",
   # Note: opentelemetry-util-genai should be installed from local source
   # for extended features (ExtendedTelemetryHandler)
   "opentelemetry-util-genai",

--- a/instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "opentelemetry-api ~= 1.37",
   "opentelemetry-instrumentation ~= 0.58b0",
   "opentelemetry-semantic-conventions ~= 0.58b0",
+  "wrapt >= 1.0.0, < 2.0.0",
   # Note: opentelemetry-util-genai should be installed from local source
   # for extended features (ExtendedTelemetryHandler)
   "opentelemetry-util-genai",
@@ -61,4 +62,3 @@ packages = ["src/opentelemetry"]
 markers = [
   "requires_cli: marks tests that require Claude CLI executable (skipped in CI)",
 ]
-

--- a/instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "opentelemetry-api ~= 1.37",
   "opentelemetry-instrumentation ~= 0.58b0",
   "opentelemetry-semantic-conventions ~= 0.58b0",
-  "wrapt >= 1.17.3, < 2.0.0",
+  "wrapt >= 1.0.0, < 2.0.0",
   # Note: opentelemetry-util-genai should be installed from local source
   # for extended features (ExtendedTelemetryHandler)
   "opentelemetry-util-genai",

--- a/instrumentation-loongsuite/loongsuite-instrumentation-copaw/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-copaw/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "opentelemetry-instrumentation >= 0.58b0",
   "opentelemetry-semantic-conventions >= 0.58b0",
   "opentelemetry-util-genai",
-  "wrapt >= 1.17.3",
+  "wrapt >= 1.17.3, < 2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-loongsuite/loongsuite-instrumentation-copaw/tests/requirements.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-copaw/tests/requirements.txt
@@ -18,7 +18,7 @@
 copaw==1.0.0
 pytest
 pytest-asyncio
-wrapt<2.0.0
+wrapt>=1.17.3,<2.0.0
 opentelemetry-api
 opentelemetry-sdk
 opentelemetry-semantic-conventions

--- a/instrumentation-loongsuite/loongsuite-instrumentation-copaw/tests/requirements.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-copaw/tests/requirements.txt
@@ -18,7 +18,7 @@
 copaw==1.0.0
 pytest
 pytest-asyncio
-wrapt
+wrapt<2.0.0
 opentelemetry-api
 opentelemetry-sdk
 opentelemetry-semantic-conventions

--- a/instrumentation-loongsuite/loongsuite-instrumentation-copaw/tests/requirements.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-copaw/tests/requirements.txt
@@ -18,7 +18,7 @@
 copaw==1.0.0
 pytest
 pytest-asyncio
-wrapt>=1.17.3,<2.0.0
+wrapt<2.0.0
 opentelemetry-api
 opentelemetry-sdk
 opentelemetry-semantic-conventions

--- a/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "opentelemetry-instrumentation >= 0.58b0",
   "opentelemetry-semantic-conventions >= 0.58b0",
   "opentelemetry-util-genai > 0.2b0",
-  "wrapt >= 1.17.3, < 2.0.0",
+  "wrapt >= 1.0.0, < 2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "opentelemetry-instrumentation >= 0.58b0",
   "opentelemetry-semantic-conventions >= 0.58b0",
   "opentelemetry-util-genai > 0.2b0",
-  "wrapt >= 1.0.0, < 2.0.0",
+  "wrapt >= 1.17.3, < 2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
   "opentelemetry-instrumentation >= 0.58b0",
   "opentelemetry-semantic-conventions >= 0.58b0",
   "opentelemetry-util-genai > 0.2b0",
+  "wrapt >= 1.0.0, < 2.0.0",
 ]
 
 [project.optional-dependencies]
@@ -55,4 +56,3 @@ include = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/opentelemetry"]
-

--- a/instrumentation-loongsuite/loongsuite-instrumentation-dify/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-dify/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "opentelemetry-api ~= 1.37",
     "opentelemetry-instrumentation >= 0.58b0",
     "opentelemetry-semantic-conventions >= 0.58b0",
-    "wrapt >= 1.0.0, < 2.0.0",
+  "wrapt >= 1.17.3, < 2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-loongsuite/loongsuite-instrumentation-dify/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-dify/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "opentelemetry-api ~= 1.37",
     "opentelemetry-instrumentation >= 0.58b0",
     "opentelemetry-semantic-conventions >= 0.58b0",
+    "wrapt >= 1.0.0, < 2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-loongsuite/loongsuite-instrumentation-dify/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-dify/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "opentelemetry-api ~= 1.37",
     "opentelemetry-instrumentation >= 0.58b0",
     "opentelemetry-semantic-conventions >= 0.58b0",
-  "wrapt >= 1.17.3, < 2.0.0",
+  "wrapt >= 1.0.0, < 2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/tests/requirements.latest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/tests/requirements.latest.txt
@@ -42,7 +42,7 @@ pytest-cov
 pytest-vcr>=1.0.2
 vcrpy>=5.1.0
 pyyaml>=6.0
-wrapt
+wrapt<2.0.0
 
 -e opentelemetry-instrumentation
 -e instrumentation-loongsuite/loongsuite-instrumentation-google-adk

--- a/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/tests/requirements.latest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/tests/requirements.latest.txt
@@ -42,7 +42,7 @@ pytest-cov
 pytest-vcr>=1.0.2
 vcrpy>=5.1.0
 pyyaml>=6.0
-wrapt<2.0.0
+wrapt>=1.17.3,<2.0.0
 
 -e opentelemetry-instrumentation
 -e instrumentation-loongsuite/loongsuite-instrumentation-google-adk

--- a/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/tests/requirements.latest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/tests/requirements.latest.txt
@@ -42,7 +42,7 @@ pytest-cov
 pytest-vcr>=1.0.2
 vcrpy>=5.1.0
 pyyaml>=6.0
-wrapt>=1.17.3,<2.0.0
+wrapt<2.0.0
 
 -e opentelemetry-instrumentation
 -e instrumentation-loongsuite/loongsuite-instrumentation-google-adk

--- a/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/tests/requirements.oldest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/tests/requirements.oldest.txt
@@ -23,7 +23,7 @@ pytest-cov
 pytest-vcr>=1.0.2
 vcrpy>=5.1.0
 pyyaml>=6.0
-wrapt
+wrapt<2.0.0
 opentelemetry-api==1.37
 opentelemetry-sdk==1.37
 opentelemetry-instrumentation==0.58b0

--- a/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/tests/requirements.oldest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/tests/requirements.oldest.txt
@@ -23,7 +23,7 @@ pytest-cov
 pytest-vcr>=1.0.2
 vcrpy>=5.1.0
 pyyaml>=6.0
-wrapt>=1.17.3,<2.0.0
+wrapt<2.0.0
 opentelemetry-api==1.37
 opentelemetry-sdk==1.37
 opentelemetry-instrumentation==0.58b0

--- a/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/tests/requirements.oldest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/tests/requirements.oldest.txt
@@ -23,7 +23,7 @@ pytest-cov
 pytest-vcr>=1.0.2
 vcrpy>=5.1.0
 pyyaml>=6.0
-wrapt<2.0.0
+wrapt>=1.17.3,<2.0.0
 opentelemetry-api==1.37
 opentelemetry-sdk==1.37
 opentelemetry-instrumentation==0.58b0

--- a/instrumentation-loongsuite/loongsuite-instrumentation-langchain/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-langchain/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "opentelemetry-instrumentation >= 0.58b0",
   "opentelemetry-semantic-conventions >= 0.58b0",
   "opentelemetry-util-genai",
-  "wrapt",
+  "wrapt >= 1.0.0, < 2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-loongsuite/loongsuite-instrumentation-langchain/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-langchain/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "opentelemetry-instrumentation >= 0.58b0",
   "opentelemetry-semantic-conventions >= 0.58b0",
   "opentelemetry-util-genai",
-  "wrapt >= 1.0.0, < 2.0.0",
+  "wrapt >= 1.17.3, < 2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-loongsuite/loongsuite-instrumentation-langchain/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-langchain/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "opentelemetry-instrumentation >= 0.58b0",
   "opentelemetry-semantic-conventions >= 0.58b0",
   "opentelemetry-util-genai",
-  "wrapt >= 1.17.3, < 2.0.0",
+  "wrapt >= 1.0.0, < 2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-loongsuite/loongsuite-instrumentation-langchain/tests/requirements.latest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-langchain/tests/requirements.latest.txt
@@ -39,7 +39,7 @@ langchain<1.0.0
 langchain-community<1.0.0
 langchain-openai>=0.2.0
 pytest
-wrapt<2.0.0
+wrapt>=1.17.3,<2.0.0
 respx>=0.20.0
 httpx>=0.24.0
 numpy>=1.20.0

--- a/instrumentation-loongsuite/loongsuite-instrumentation-langchain/tests/requirements.latest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-langchain/tests/requirements.latest.txt
@@ -39,7 +39,7 @@ langchain<1.0.0
 langchain-community<1.0.0
 langchain-openai>=0.2.0
 pytest
-wrapt>=1.17.3,<2.0.0
+wrapt<2.0.0
 respx>=0.20.0
 httpx>=0.24.0
 numpy>=1.20.0

--- a/instrumentation-loongsuite/loongsuite-instrumentation-langchain/tests/requirements.latest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-langchain/tests/requirements.latest.txt
@@ -39,7 +39,7 @@ langchain<1.0.0
 langchain-community<1.0.0
 langchain-openai>=0.2.0
 pytest
-wrapt
+wrapt<2.0.0
 respx>=0.20.0
 httpx>=0.24.0
 numpy>=1.20.0

--- a/instrumentation-loongsuite/loongsuite-instrumentation-langchain/tests/requirements.oldest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-langchain/tests/requirements.oldest.txt
@@ -20,7 +20,7 @@ langchain<1.0.0
 langchain-community<1.0.0
 langchain-openai>=0.2.0
 pytest
-wrapt
+wrapt<2.0.0
 respx>=0.20.0
 httpx>=0.24.0
 numpy>=1.20.0

--- a/instrumentation-loongsuite/loongsuite-instrumentation-langchain/tests/requirements.oldest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-langchain/tests/requirements.oldest.txt
@@ -20,7 +20,7 @@ langchain<1.0.0
 langchain-community<1.0.0
 langchain-openai>=0.2.0
 pytest
-wrapt<2.0.0
+wrapt>=1.17.3,<2.0.0
 respx>=0.20.0
 httpx>=0.24.0
 numpy>=1.20.0

--- a/instrumentation-loongsuite/loongsuite-instrumentation-langchain/tests/requirements.oldest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-langchain/tests/requirements.oldest.txt
@@ -20,7 +20,7 @@ langchain<1.0.0
 langchain-community<1.0.0
 langchain-openai>=0.2.0
 pytest
-wrapt>=1.17.3,<2.0.0
+wrapt<2.0.0
 respx>=0.20.0
 httpx>=0.24.0
 numpy>=1.20.0

--- a/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "opentelemetry-api ~= 1.37",
   "opentelemetry-instrumentation >= 0.58b0",
   "opentelemetry-semantic-conventions >= 0.58b0",
-  "wrapt",
+  "wrapt >= 1.0.0, < 2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "opentelemetry-api ~= 1.37",
   "opentelemetry-instrumentation >= 0.58b0",
   "opentelemetry-semantic-conventions >= 0.58b0",
-  "wrapt >= 1.0.0, < 2.0.0",
+  "wrapt >= 1.17.3, < 2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "opentelemetry-api ~= 1.37",
   "opentelemetry-instrumentation >= 0.58b0",
   "opentelemetry-semantic-conventions >= 0.58b0",
-  "wrapt >= 1.17.3, < 2.0.0",
+  "wrapt >= 1.0.0, < 2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/tests/requirements.latest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/tests/requirements.latest.txt
@@ -38,7 +38,7 @@ langgraph
 langgraph-prebuilt
 langchain_core<1.0.0
 pytest
-wrapt
+wrapt<2.0.0
 
 -e opentelemetry-instrumentation
 -e util/opentelemetry-util-genai

--- a/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/tests/requirements.latest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/tests/requirements.latest.txt
@@ -38,7 +38,7 @@ langgraph
 langgraph-prebuilt
 langchain_core<1.0.0
 pytest
-wrapt>=1.17.3,<2.0.0
+wrapt<2.0.0
 
 -e opentelemetry-instrumentation
 -e util/opentelemetry-util-genai

--- a/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/tests/requirements.latest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/tests/requirements.latest.txt
@@ -38,7 +38,7 @@ langgraph
 langgraph-prebuilt
 langchain_core<1.0.0
 pytest
-wrapt<2.0.0
+wrapt>=1.17.3,<2.0.0
 
 -e opentelemetry-instrumentation
 -e util/opentelemetry-util-genai

--- a/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/tests/requirements.oldest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/tests/requirements.oldest.txt
@@ -19,7 +19,7 @@ langgraph>=0.2
 langgraph-prebuilt
 langchain_core<1.0.0
 pytest
-wrapt<2.0.0
+wrapt>=1.17.3,<2.0.0
 opentelemetry-api==1.37
 opentelemetry-sdk==1.37
 opentelemetry-instrumentation==0.58b0

--- a/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/tests/requirements.oldest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/tests/requirements.oldest.txt
@@ -19,7 +19,7 @@ langgraph>=0.2
 langgraph-prebuilt
 langchain_core<1.0.0
 pytest
-wrapt
+wrapt<2.0.0
 opentelemetry-api==1.37
 opentelemetry-sdk==1.37
 opentelemetry-instrumentation==0.58b0

--- a/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/tests/requirements.oldest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/tests/requirements.oldest.txt
@@ -19,7 +19,7 @@ langgraph>=0.2
 langgraph-prebuilt
 langchain_core<1.0.0
 pytest
-wrapt>=1.17.3,<2.0.0
+wrapt<2.0.0
 opentelemetry-api==1.37
 opentelemetry-sdk==1.37
 opentelemetry-instrumentation==0.58b0

--- a/instrumentation-loongsuite/loongsuite-instrumentation-mcp/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-mcp/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "opentelemetry-api ~= 1.37",
   "opentelemetry-instrumentation ~= 0.58b0",
   "opentelemetry-semantic-conventions ~= 0.58b0",
-  "wrapt >= 1.0.0, < 2.0.0",
+  "wrapt >= 1.17.3, < 2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-loongsuite/loongsuite-instrumentation-mcp/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-mcp/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "opentelemetry-api ~= 1.37",
   "opentelemetry-instrumentation ~= 0.58b0",
   "opentelemetry-semantic-conventions ~= 0.58b0",
-  "wrapt >= 1.17.3, < 2.0.0",
+  "wrapt >= 1.0.0, < 2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-loongsuite/loongsuite-instrumentation-mcp/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-mcp/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
   "opentelemetry-api ~= 1.37",
   "opentelemetry-instrumentation ~= 0.58b0",
   "opentelemetry-semantic-conventions ~= 0.58b0",
+  "wrapt >= 1.0.0, < 2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-loongsuite/loongsuite-instrumentation-mem0/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-mem0/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-  "wrapt >=1.17.3",
+  "wrapt >=1.17.3, < 2.0.0",
   "opentelemetry-api ~=1.37",
   "opentelemetry-instrumentation >=0.58b0",
   "opentelemetry-semantic-conventions >=0.58b0",

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "opentelemetry-instrumentation >= 0.58b0",
     "opentelemetry-semantic-conventions >= 0.58b0",
     "opentelemetry-util-genai",
-    "wrapt",
+    "wrapt >= 1.0.0, < 2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "opentelemetry-instrumentation >= 0.58b0",
     "opentelemetry-semantic-conventions >= 0.58b0",
     "opentelemetry-util-genai",
-    "wrapt >= 1.0.0, < 2.0.0",
+    "wrapt >= 1.17.3, < 2.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
# Description

This PR adds skill-load detection and skill metadata enrichment to the LoongSuite AgentScope instrumentation.

Specifically, it:
- detects tool executions that read the top-level `SKILL.md` of a registered skill
- enriches the resulting `execute_tool` span with `gen_ai.skill.name`, `gen_ai.skill.id`, `gen_ai.skill.description`, and `gen_ai.skill.version`
- keeps matching conservative: only registered skills match, only top-level `SKILL.md` reads count, and nested reads under paths such as `scripts/` or `references/` do not emit `gen_ai.skill.*`
- resolves `gen_ai.skill.version` from `SKILL.md` frontmatter first and falls back to workspace `skill.json` metadata when needed
- adds focused tests and AgentScope docs/changelog updates
- pins `wrapt` below `2.0.0` for LoongSuite instrumentations that still rely on the current wrapper API usage, including AgentScope and Qwen-Agent

This change is aligned with [alibaba/loongsuite-semantic-conventions#19](https://github.com/alibaba/loongsuite-semantic-conventions/pull/19) and the merged util support from #169.

Fixes # (N/A)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] `tox -e precommit`
- [x] `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=SPAN_ONLY tox -c tox-loongsuite.ini -e py311-loongsuite-instrumentation-agentscope-1 -- -ra`
- [x] `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=SPAN_ONLY tox -c tox-loongsuite.ini -e py311-test-loongsuite-instrumentation-agentscope-latest -- instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/test_skill_detection.py instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/test_span_content.py -k 'skill or span_only' -ra`
- [x] `tox -c tox-loongsuite.ini -e py311-test-loongsuite-instrumentation-qwen-agent-latest -- -ra`
- [x] local otel-gui smoke verification for AgentScope skill loading in `SPAN_ONLY` and `NO_CONTENT` modes

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR:
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
