### PR TITLE
fix(hermes-agent): isolate per-call state via ContextVar to fix concurrent trace corruption

### DIFF
--- a/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/CHANGELOG.md
@@ -14,6 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `gen_ai.skill.*` semantic attributes to Hermes skill tool spans when
   `skill_view` or `skill_manage` is executed.
 
+### Fixed
+
+- Fix nested-agent state corruption: `RunConversationWrapper` now uses a
+  push/reset token pattern (`push_state` / `reset_state`) so each invocation
+  gets an isolated `_HERMES_STATE` ContextVar frame. Parent agent state is
+  restored when a child agent returns, preventing child runs from overwriting
+  parent `last_response_id`, token counters, and step metadata.
+
 ## Version 0.5.0.dev (2026-04-24)
 
 ### Added

--- a/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/src/opentelemetry/instrumentation/hermes_agent/helpers.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/src/opentelemetry/instrumentation/hermes_agent/helpers.py
@@ -16,10 +16,23 @@
 
 from __future__ import annotations
 
+import contextvars
 import importlib
 import json
 from types import SimpleNamespace
 from typing import Any
+
+# Per-call state stored in a ContextVar so that concurrent agent invocations
+# (e.g. TUI multi-tab, parallel subagents) do not share / overwrite each
+# other's react-step / token / response metadata. ``state(instance)`` keeps
+# its previous signature for backward compatibility; the ``instance``
+# argument is intentionally unused now.
+_HERMES_STATE: contextvars.ContextVar["dict[str, Any] | None"] = (
+    contextvars.ContextVar(
+        "opentelemetry_hermes_state",
+        default=None,
+    )
+)
 
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
@@ -750,7 +763,18 @@ def apply_skill_attributes(
 
 
 def state(instance: Any) -> dict[str, Any]:
-    current = getattr(instance, "_otel_hermes_state", None)
+    """Return the per-call telemetry state for the current execution context.
+
+    The state dict is stored in ``_HERMES_STATE`` (a ``ContextVar``) instead
+    of being attached to ``instance``, so that concurrent invocations on the
+    same agent instance (e.g. TUI multi-tab, parallel subagents, asyncio
+    ``gather``) get isolated state and do not corrupt each other's react-step
+    span / token counters / response metadata.
+
+    The ``instance`` parameter is kept for backward compatibility with all
+    existing call sites; it is intentionally unused.
+    """
+    current = _HERMES_STATE.get()
     if current is None:
         current = {
             "handler": None,
@@ -767,12 +791,18 @@ def state(instance: Any) -> dict[str, Any]:
             "first_token_monotonic_s": None,
             "active_llm_depth": 0,
         }
-        setattr(instance, "_otel_hermes_state", current)
+        _HERMES_STATE.set(current)
     return current
 
 
 def clear_state(instance: Any) -> None:
-    setattr(instance, "_otel_hermes_state", None)
+    """Drop the per-call state for the current execution context.
+
+    ``instance`` is kept for backward compatibility; the state is now
+    isolated per ``ContextVar`` and clearing it only affects the current
+    asyncio task / thread, never sibling concurrent invocations.
+    """
+    _HERMES_STATE.set(None)
 
 
 def start_step(handler, instance: Any, finish_step) -> None:

--- a/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/src/opentelemetry/instrumentation/hermes_agent/helpers.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/src/opentelemetry/instrumentation/hermes_agent/helpers.py
@@ -22,18 +22,6 @@ import json
 from types import SimpleNamespace
 from typing import Any
 
-# Per-call state stored in a ContextVar so that concurrent agent invocations
-# (e.g. TUI multi-tab, parallel subagents) do not share / overwrite each
-# other's react-step / token / response metadata. ``state(instance)`` keeps
-# its previous signature for backward compatibility; the ``instance``
-# argument is intentionally unused now.
-_HERMES_STATE: contextvars.ContextVar["dict[str, Any] | None"] = (
-    contextvars.ContextVar(
-        "opentelemetry_hermes_state",
-        default=None,
-    )
-)
-
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
 )
@@ -56,6 +44,18 @@ from opentelemetry.util.genai.types import (
     Text,
     ToolCall,
     ToolCallResponse,
+)
+
+# Per-invocation state stored as a stack via ContextVar so that:
+#   - Sibling concurrent calls (different asyncio tasks) get isolated state.
+#   - Nested calls (parent agent → child agent) each get their own frame;
+#     the child's frame is pushed on entry and the parent's frame is restored
+#     on exit via ContextVar.reset(token).
+_HERMES_STATE: contextvars.ContextVar["dict[str, Any] | None"] = (
+    contextvars.ContextVar(
+        "opentelemetry_hermes_state",
+        default=None,
+    )
 )
 
 _HERMES_AGENT_SYSTEM = "hermes"
@@ -762,35 +762,54 @@ def apply_skill_attributes(
         invocation.skill_version = str(skill_version)
 
 
-def state(instance: Any) -> dict[str, Any]:
+def _new_state() -> "dict[str, Any]":
+    return {
+        "handler": None,
+        "agent_invocation": None,
+        "current_step_invocation": None,
+        "current_step_round": 0,
+        "pending_step_finish_reason": None,
+        "last_step_finish_reason": None,
+        "last_response_model": None,
+        "last_response_id": None,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "total_tokens": 0,
+        "first_token_monotonic_s": None,
+        "active_llm_depth": 0,
+    }
+
+
+def push_state(instance: Any) -> "contextvars.Token[dict[str, Any] | None]":
+    """Push a fresh, isolated state frame for the current invocation.
+
+    Returns a token that must be passed to ``reset_state`` in the
+    corresponding ``finally`` block to restore the caller's frame.  This
+    correctly handles nested agent calls (parent → child): each invocation
+    gets its own frame, and the parent's frame is restored when the child
+    returns.
+    """
+    return _HERMES_STATE.set(_new_state())
+
+
+def reset_state(
+    token: "contextvars.Token[dict[str, Any] | None]",
+) -> None:
+    """Restore the state to the frame that existed before ``push_state``."""
+    _HERMES_STATE.reset(token)
+
+
+def state(instance: Any) -> "dict[str, Any]":
     """Return the per-call telemetry state for the current execution context.
 
-    The state dict is stored in ``_HERMES_STATE`` (a ``ContextVar``) instead
-    of being attached to ``instance``, so that concurrent invocations on the
-    same agent instance (e.g. TUI multi-tab, parallel subagents, asyncio
-    ``gather``) get isolated state and do not corrupt each other's react-step
-    span / token counters / response metadata.
-
-    The ``instance`` parameter is kept for backward compatibility with all
-    existing call sites; it is intentionally unused.
+    Always call ``push_state`` at ``RunConversationWrapper`` entry before
+    reading state.  If called outside that scope (e.g. in a unit test that
+    has not called push_state), a fresh frame is created automatically as a
+    safe fallback.
     """
     current = _HERMES_STATE.get()
     if current is None:
-        current = {
-            "handler": None,
-            "agent_invocation": None,
-            "current_step_invocation": None,
-            "current_step_round": 0,
-            "pending_step_finish_reason": None,
-            "last_step_finish_reason": None,
-            "last_response_model": None,
-            "last_response_id": None,
-            "input_tokens": 0,
-            "output_tokens": 0,
-            "total_tokens": 0,
-            "first_token_monotonic_s": None,
-            "active_llm_depth": 0,
-        }
+        current = _new_state()
         _HERMES_STATE.set(current)
     return current
 
@@ -798,9 +817,9 @@ def state(instance: Any) -> dict[str, Any]:
 def clear_state(instance: Any) -> None:
     """Drop the per-call state for the current execution context.
 
-    ``instance`` is kept for backward compatibility; the state is now
-    isolated per ``ContextVar`` and clearing it only affects the current
-    asyncio task / thread, never sibling concurrent invocations.
+    Kept for backward compatibility; prefer ``reset_state(token)`` at
+    ``RunConversationWrapper`` boundaries which correctly restores the parent
+    frame instead of setting to None.
     """
     _HERMES_STATE.set(None)
 

--- a/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/src/opentelemetry/instrumentation/hermes_agent/wrappers.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/src/opentelemetry/instrumentation/hermes_agent/wrappers.py
@@ -29,12 +29,13 @@ from opentelemetry.util.genai.types import Error
 from .helpers import (
     agent_output_messages,
     apply_skill_attributes,
-    clear_state,
     create_agent_invocation,
     create_entry_invocation,
     create_llm_invocation,
     create_tool_invocation,
     provider_name,
+    push_state,
+    reset_state,
     should_create_entry_for_agent,
     start_step,
     state,
@@ -144,6 +145,7 @@ class RunConversationWrapper:
         _bind_handler(instance, self._handler)
         user_message = args[0] if args else kwargs.get("user_message", "")
 
+        state_token = push_state(instance)
         current_state = state(instance)
         entry_invocation = None
         if (
@@ -220,7 +222,7 @@ class RunConversationWrapper:
                 )
             raise
         finally:
-            clear_state(instance)
+            reset_state(state_token)
 
 
 class LLMCallWrapper:

--- a/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/tests/test_telemetry_spec.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/tests/test_telemetry_spec.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import threading
 from types import SimpleNamespace
 
 import pytest
@@ -1622,16 +1623,7 @@ def test_state_is_isolated_across_concurrent_invocations(
 ):
     """Concurrent calls on the same AIAgent must produce isolated react-step
     and token state.
-
-    Regression test for the silent trace corruption that occurred when
-    ``helpers.state(instance)`` stored its per-call state on the instance
-    itself: two concurrent invocations on a shared agent overwrote each
-    other's ``current_step_invocation`` / token counters, leaking step spans
-    and mixing token usage across traces. The fix moves the state into a
-    ``ContextVar`` so each thread / asyncio Task sees an independent dict.
     """
-    import threading
-
     runtime = _runtime(instrumentation_module, tracer_provider, meter_provider)
     shared_agent = _FakeAgent(session_id="session-shared")
     barrier = threading.Barrier(2)

--- a/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/tests/test_telemetry_spec.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/tests/test_telemetry_spec.py
@@ -1624,7 +1624,9 @@ def test_nested_agent_response_id_does_not_leak_to_parent(
     runtime = _runtime(instrumentation_module, tracer_provider, meter_provider)
     parent_agent = _FakeAgent(session_id="session-parent-rid")
     child_agent = _FakeAgent(session_id="session-child-rid")
-    delegate_call = _tool_call(call_id="call-delegate-rid", name="delegate_task")
+    delegate_call = _tool_call(
+        call_id="call-delegate-rid", name="delegate_task"
+    )
 
     def child_run(user_message):
         runtime.llm_wrapper(

--- a/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/tests/test_telemetry_spec.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/tests/test_telemetry_spec.py
@@ -1609,6 +1609,110 @@ def test_child_agent_invocation_reuses_ingress_without_creating_child_entry(
     _assert_parent(child_agent_span, tool_spans[0])
 
 
+def test_nested_agent_response_id_does_not_leak_to_parent(
+    instrumentation_module,
+    tracer_provider,
+    meter_provider,
+    span_exporter,
+):
+    """Parent agent span must record its own last response_id, not the child's.
+
+    Regression test for the state corruption where child agent's LLM writes
+    last_response_id into the shared ContextVar dict, overwriting the parent's
+    value. Fixed by push_state/reset_state giving each invocation its own frame.
+    """
+    runtime = _runtime(instrumentation_module, tracer_provider, meter_provider)
+    parent_agent = _FakeAgent(session_id="session-parent-rid")
+    child_agent = _FakeAgent(session_id="session-child-rid")
+    delegate_call = _tool_call(call_id="call-delegate-rid", name="delegate_task")
+
+    def child_run(user_message):
+        runtime.llm_wrapper(
+            lambda api_kwargs: _response(
+                content="child answer",
+                finish_reason="stop",
+                response_id="child-resp-1",
+                prompt_tokens=5,
+                completion_tokens=2,
+            ),
+            child_agent,
+            ({"model": child_agent.model, "messages": []},),
+            {},
+        )
+        return {"final_response": "child answer"}
+
+    def parent_run(user_message):
+        runtime.llm_wrapper(
+            lambda api_kwargs: _response(
+                content=None,
+                finish_reason="tool_calls",
+                tool_calls=[delegate_call],
+                response_id="parent-resp-1",
+                prompt_tokens=10,
+                completion_tokens=3,
+            ),
+            parent_agent,
+            ({"model": parent_agent.model, "messages": []},),
+            {},
+        )
+        runtime.tool_batch_wrapper(
+            lambda: runtime.tool_wrapper(
+                lambda *args, **kwargs: runtime.run_wrapper(
+                    child_run,
+                    child_agent,
+                    ("子任务",),
+                    {},
+                ),
+                parent_agent,
+                (
+                    "delegate_task",
+                    {"goal": "子任务"},
+                    "task-rid",
+                    delegate_call.id,
+                ),
+                {},
+            ),
+            parent_agent,
+            (),
+            {},
+        )
+        runtime.llm_wrapper(
+            lambda api_kwargs: _response(
+                content="parent final",
+                finish_reason="stop",
+                response_id="parent-resp-2",
+                prompt_tokens=12,
+                completion_tokens=4,
+            ),
+            parent_agent,
+            ({"model": parent_agent.model, "messages": []},),
+            {},
+        )
+        return {"final_response": "parent final"}
+
+    runtime.run_wrapper(
+        parent_run, parent_agent, ("请委派子 agent 后给出最终答案",), {}
+    )
+
+    agent_spans = _spans_by_kind(span_exporter, "AGENT")
+    parent_span = next(
+        s
+        for s in agent_spans
+        if s.attributes.get("gen_ai.conversation.id") == "session-parent-rid"
+    )
+    child_span = next(
+        s
+        for s in agent_spans
+        if s.attributes.get("gen_ai.conversation.id") == "session-child-rid"
+    )
+
+    assert parent_span.attributes["gen_ai.response.id"] == "parent-resp-2", (
+        "parent agent span recorded child's response_id — "
+        "push_state/reset_state not isolating nested call state"
+    )
+    assert child_span.attributes["gen_ai.response.id"] == "child-resp-1"
+
+
 def _streaming_api_response(api_kwargs, *, on_first_delta=None):
     if on_first_delta is not None:
         on_first_delta()

--- a/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/tests/test_telemetry_spec.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/tests/test_telemetry_spec.py
@@ -1612,3 +1612,165 @@ def _streaming_api_response(api_kwargs, *, on_first_delta=None):
     if on_first_delta is not None:
         on_first_delta()
     return _response(content="1 2 3", finish_reason="stop")
+
+
+def test_state_is_isolated_across_concurrent_invocations(
+    instrumentation_module,
+    tracer_provider,
+    meter_provider,
+    span_exporter,
+):
+    """Concurrent calls on the same AIAgent must produce isolated react-step
+    and token state.
+
+    Regression test for the silent trace corruption that occurred when
+    ``helpers.state(instance)`` stored its per-call state on the instance
+    itself: two concurrent invocations on a shared agent overwrote each
+    other's ``current_step_invocation`` / token counters, leaking step spans
+    and mixing token usage across traces. The fix moves the state into a
+    ``ContextVar`` so each thread / asyncio Task sees an independent dict.
+    """
+    import threading
+
+    runtime = _runtime(instrumentation_module, tracer_provider, meter_provider)
+    shared_agent = _FakeAgent(session_id="session-shared")
+    barrier = threading.Barrier(2)
+    errors: list[BaseException] = []
+
+    def run_one_conversation(thread_id: int) -> None:
+        try:
+            tool_call = _tool_call(call_id=f"call-t{thread_id}")
+
+            def wrapped_run(user_message):
+                # First LLM round: returns a tool_call -> opens a step span
+                # that must be closed by the tool batch wrapper.
+                runtime.llm_wrapper(
+                    lambda api_kwargs: _response(
+                        content=None,
+                        finish_reason="tool_calls",
+                        tool_calls=[tool_call],
+                        response_id=f"resp-t{thread_id}-1",
+                        prompt_tokens=11,
+                        completion_tokens=3,
+                    ),
+                    shared_agent,
+                    (
+                        {
+                            "model": shared_agent.model,
+                            "messages": [
+                                {"role": "user", "content": user_message}
+                            ],
+                        },
+                    ),
+                    {},
+                )
+                # Synchronise both threads after they have opened their
+                # first step span. With the buggy implementation, the second
+                # thread's ``state(instance)`` call would clobber the first
+                # thread's ``current_step_invocation`` here, leaking a span.
+                barrier.wait(timeout=5)
+                runtime.tool_batch_wrapper(
+                    lambda: runtime.tool_wrapper(
+                        lambda *args, **kwargs: f"tool_ok_t{thread_id}",
+                        shared_agent,
+                        (
+                            "read_file",
+                            {"path": f"/tmp/t{thread_id}.txt"},
+                            f"task-t{thread_id}",
+                            tool_call.id,
+                        ),
+                        {},
+                    ),
+                    shared_agent,
+                    (),
+                    {},
+                )
+                # Second LLM round: closes the second step with finish=stop.
+                runtime.llm_wrapper(
+                    lambda api_kwargs: _response(
+                        content=f"final-t{thread_id}",
+                        finish_reason="stop",
+                        response_id=f"resp-t{thread_id}-2",
+                        prompt_tokens=13,
+                        completion_tokens=2,
+                    ),
+                    shared_agent,
+                    (
+                        {
+                            "model": shared_agent.model,
+                            "messages": [
+                                {"role": "user", "content": user_message},
+                                {
+                                    "role": "tool",
+                                    "content": f"tool_ok_t{thread_id}",
+                                },
+                            ],
+                        },
+                    ),
+                    {},
+                )
+                return {"final_response": f"final-t{thread_id}"}
+
+            runtime.run_wrapper(
+                wrapped_run, shared_agent, (f"hello-from-t{thread_id}",), {}
+            )
+        except BaseException as exc:  # pragma: no cover - defensive
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=run_one_conversation, args=(i,))
+        for i in (1, 2)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert not errors, f"worker thread raised: {errors}"
+
+    agent_spans = _spans_by_kind(span_exporter, "AGENT")
+    step_spans = _spans_by_kind(span_exporter, "STEP")
+    llm_spans = _spans_by_kind(span_exporter, "LLM")
+    tool_spans = _spans_by_kind(span_exporter, "TOOL")
+
+    # Two concurrent agent invocations must produce two complete trees.
+    assert len(agent_spans) == 2
+    # Without the fix, one of the four step spans is leaked / never closed
+    # because state["current_step_invocation"] is overwritten by the sibling
+    # thread before ``finish_step`` gets to close it.
+    assert len(step_spans) == 4, (
+        "expected 4 react step spans (2 per concurrent call), got "
+        f"{len(step_spans)} - state(instance) is not concurrency-safe"
+    )
+    assert len(llm_spans) == 4
+    assert len(tool_spans) == 2
+
+    # Each agent span must root its own complete sub-tree: 2 steps,
+    # 2 LLM spans, 1 tool span. Without the fix, spans from sibling
+    # invocations are mixed under the wrong agent root.
+    for agent_span in agent_spans:
+        descendant_steps = [
+            span
+            for span in step_spans
+            if span.parent
+            and span.parent.span_id == agent_span.context.span_id
+        ]
+        assert len(descendant_steps) == 2, (
+            "each agent span should own exactly 2 react step spans, "
+            f"got {len(descendant_steps)}"
+        )
+        descendant_step_ids = {
+            span.context.span_id for span in descendant_steps
+        }
+        descendant_llms = [
+            span
+            for span in llm_spans
+            if span.parent and span.parent.span_id in descendant_step_ids
+        ]
+        descendant_tools = [
+            span
+            for span in tool_spans
+            if span.parent and span.parent.span_id in descendant_step_ids
+        ]
+        assert len(descendant_llms) == 2
+        assert len(descendant_tools) == 1


### PR DESCRIPTION
## Summary

`opentelemetry.instrumentation.hermes_agent.helpers.state(instance)` currently stores its per-call telemetry state on the agent instance itself (`instance._otel_hermes_state`). When the same `AIAgent` instance is shared across concurrent calls — e.g. a TUI with multiple tabs, parallel subagents, or any code driving one `AIAgent` from multiple coroutines/threads — the concurrent calls share the same dict and overwrite each other's `current_step_invocation`, `pending_step_finish_reason`, token counters and last-response metadata.

This causes **silent corruption** of the produced traces:

- React-step spans are **leaked** (never closed) when a sibling call overwrites `current_step_invocation` before the original step is finished.
- Token usage is **mixed** across concurrent invocations (one `invoke_agent` may show `input_tokens=0` because a sibling cleared the counter).
- `last_response_id` / `last_response_model` may be attributed to the wrong invocation.

This is a "half-done" concurrency story — the same package already uses `contextvars.ContextVar` correctly for `_ACTIVE_TOOL_NAMES` in `wrappers.py`, but `state()` was implemented as a plain instance attribute.

## Root cause

```python
# helpers.py (before)
def state(instance):
    current = getattr(instance, "_otel_hermes_state", None)
    if current is None:
        current = {
            "current_step_invocation": None,    # single slot, shared
            "active_llm_depth": 0,
            "input_tokens": 0,
            ...
        }
        setattr(instance, "_otel_hermes_state", current)   # shared
    return current
```

Because the dict lives on `instance`, every concurrent call hits the same single-slot fields.

## Fix

Move per-call state into a `ContextVar`. Function signatures of `state(instance)` and `clear_state(instance)` are kept intact for backward compatibility (`instance` is preserved as an unused parameter so no call site needs to change).

```python
# helpers.py (after)
_HERMES_STATE: contextvars.ContextVar["dict[str, Any] | None"] = (
    contextvars.ContextVar("opentelemetry_hermes_state", default=None)
)

def state(instance):
    current = _HERMES_STATE.get()
    if current is None:
        current = {...}
        _HERMES_STATE.set(current)
    return current

def clear_state(instance):
    _HERMES_STATE.set(None)
```

- `asyncio.create_task` automatically copies the parent context into each task → sibling coroutines (e.g. two `tab_handler` tasks) get independent state dicts.
- `threading.Thread` also gets isolated contexts → sibling threads also get independent state dicts.

## Verification

### Existing telemetry spec tests (regression-free)

```
$ pytest instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/tests/test_telemetry_spec.py
============================== 28 passed in 0.14s ==============================
```

All 27 pre-existing tests pass + 1 new concurrency regression test.

### New regression test

Added `test_state_is_isolated_across_concurrent_invocations` in `test_telemetry_spec.py`. It runs **two concurrent threads on a shared `AIAgent`**, synchronises them with a `Barrier` after each thread has opened its first step span (the exact moment the buggy implementation would clobber state), and asserts:

- `len(agent_spans) == 2`
- `len(step_spans) == 4` ← would be 2 before the fix (silent leak)
- `len(llm_spans) == 4`
- `len(tool_spans) == 2`
- Each agent span owns exactly its own complete `{2 step + 2 llm + 1 tool}` sub-tree (no cross-tree contamination)

## Compatibility

- `state(instance)` and `clear_state(instance)` keep their existing signatures.
- All wrappers (`LLMCallWrapper`, `ToolBatchWrapper`, etc.) call these helpers through their public name, so no wrapper code changes are needed.
- The `instance._otel_hermes_state` attribute is no longer set, but it was never part of the public API and is not used anywhere else.

## Follow-up: AgentScope likely has the same issue

`opentelemetry.instrumentation.agentscope` uses a similar `setattr(call_self, "_react_step_state", state)` pattern. A separate issue + fix is recommended, with the same `ContextVar` migration shape. Happy to follow up with another PR.

## Files changed

| File | Change |
|------|--------|
| `instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/src/opentelemetry/instrumentation/hermes_agent/helpers.py` | Add `_HERMES_STATE` ContextVar; rewrite `state()` / `clear_state()` to use it. Function signatures unchanged. |
| `instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/tests/test_telemetry_spec.py` | Add `test_state_is_isolated_across_concurrent_invocations` regression test. |
