### PR TITLE
chore: post-release 0.5.0 - archive changelogs & bump dev versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,4 +19,5 @@ repos:
     hooks:
       - id: rstcheck
         additional_dependencies: ['rstcheck[sphinx]']
+        exclude: ^_template/
         args: ["--report-level", "warning"]

--- a/CHANGELOG-loongsuite.md
+++ b/CHANGELOG-loongsuite.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.5.0 (2026-05-11)
+
 ### Fixed
 
 - Pin the default upstream core SHA used by CI to a 0.62-compatible commit, and

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.5.0 (2026-05-11)
+
 ### Added
 
 - Detect skill-load tool executions by matching reads of registered skills'

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.0.dev"
+__version__ = "0.6.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agno/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agno/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.5.0 (2026-05-11)
+
+There are no changelog entries for this release.
+
 ## Version 0.4.0 (2026-04-03)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agno/src/opentelemetry/instrumentation/agno/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agno/src/opentelemetry/instrumentation/agno/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.0.dev"
+__version__ = "0.6.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.5.0 (2026-05-11)
+
+There are no changelog entries for this release.
+
 ## Version 0.4.0 (2026-04-03)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/src/opentelemetry/instrumentation/claude_agent_sdk/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/src/opentelemetry/instrumentation/claude_agent_sdk/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.0.dev"
+__version__ = "0.6.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-crewai/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-crewai/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.5.0 (2026-05-11)
+
+There are no changelog entries for this release.
+
 ## Version 0.4.0 (2026-04-03)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-crewai/src/opentelemetry/instrumentation/crewai/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-crewai/src/opentelemetry/instrumentation/crewai/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.0.dev"
+__version__ = "0.6.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.5.0 (2026-05-11)
+
+There are no changelog entries for this release.
+
 ## Version 0.4.0 (2026-04-03)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/src/opentelemetry/instrumentation/dashscope/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/src/opentelemetry/instrumentation/dashscope/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.0.dev"
+__version__ = "0.6.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-dify/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-dify/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.5.0 (2026-05-11)
+
+There are no changelog entries for this release.
+
 ## Version 0.4.0 (2026-04-03)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-dify/src/opentelemetry/instrumentation/dify/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-dify/src/opentelemetry/instrumentation/dify/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.0.dev"
+__version__ = "0.6.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.5.0 (2026-05-11)
+
+There are no changelog entries for this release.
+
 ## Version 0.4.0 (2026-04-03)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/src/opentelemetry/instrumentation/google_adk/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/src/opentelemetry/instrumentation/google_adk/version.py
@@ -14,4 +14,4 @@
 
 """Version information for OpenTelemetry Google ADK Instrumentation."""
 
-__version__ = "0.5.0.dev"
+__version__ = "0.6.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.5.0 (2026-05-11)
+
 ### Added
 
 - Create `ENTRY` spans for Hermes `AIAgent` platform requests,

--- a/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/src/opentelemetry/instrumentation/hermes_agent/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/src/opentelemetry/instrumentation/hermes_agent/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.0.dev"
+__version__ = "0.6.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-langchain/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-langchain/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.5.0 (2026-05-11)
+
+There are no changelog entries for this release.
+
 ## Version 0.4.0 (2026-04-03)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-langchain/src/opentelemetry/instrumentation/langchain/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-langchain/src/opentelemetry/instrumentation/langchain/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.0.dev"
+__version__ = "0.6.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.5.0 (2026-05-11)
+
+There are no changelog entries for this release.
+
 ## Version 0.4.0 (2026-04-03)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/src/opentelemetry/instrumentation/langgraph/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/src/opentelemetry/instrumentation/langgraph/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.0.dev"
+__version__ = "0.6.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-litellm/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-litellm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.5.0 (2026-05-11)
+
+There are no changelog entries for this release.
+
 ## Version 0.4.0 (2026-04-03)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-litellm/src/opentelemetry/instrumentation/litellm/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-litellm/src/opentelemetry/instrumentation/litellm/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.0.dev"
+__version__ = "0.6.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-mcp/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-mcp/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.5.0 (2026-05-11)
+
+There are no changelog entries for this release.
+
 ## Version 0.4.0 (2026-04-03)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-mcp/src/opentelemetry/instrumentation/mcp/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-mcp/src/opentelemetry/instrumentation/mcp/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.0.dev"
+__version__ = "0.6.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-mem0/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-mem0/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.5.0 (2026-05-11)
+
 ### Fixed
 
 - Limit supported `mem0ai` versions to `>=1.0.0,<2.0.0`, test the true

--- a/instrumentation-loongsuite/loongsuite-instrumentation-mem0/src/opentelemetry/instrumentation/mem0/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-mem0/src/opentelemetry/instrumentation/mem0/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.0.dev"
+__version__ = "0.6.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.5.0 (2026-05-11)
+
+There are no changelog entries for this release.
+
 ## Version 0.4.0.dev
 
 ### Added

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.0.dev"
+__version__ = "0.6.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.5.0 (2026-05-11)
+
 ### Added
 
 - Renamed the primary instrumentation package to QwenPaw and kept runtime

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/src/opentelemetry/instrumentation/qwenpaw/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/src/opentelemetry/instrumentation/qwenpaw/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.0.dev"
+__version__ = "0.6.0.dev"

--- a/loongsuite-distro/src/loongsuite/distro/version.py
+++ b/loongsuite-distro/src/loongsuite/distro/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.0.dev"
+__version__ = "0.6.0.dev"

--- a/loongsuite-site-bootstrap/src/loongsuite_site_bootstrap/version.py
+++ b/loongsuite-site-bootstrap/src/loongsuite_site_bootstrap/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.5.0.dev"
+__version__ = "0.6.0.dev"

--- a/util/opentelemetry-util-genai/CHANGELOG-loongsuite.md
+++ b/util/opentelemetry-util-genai/CHANGELOG-loongsuite.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.5.0 (2026-05-11)
+
 ### Added
 
 - Add `gen_ai.skill.name`, `gen_ai.skill.id`, `gen_ai.skill.description`, and


### PR DESCRIPTION
## Post-release updates for loongsuite-python-agent 0.5.0

Automated housekeeping after the `0.5.0` release:

- Archive `Unreleased` changelogs as `Version 0.5.0 (2026-05-11)`
- Bump `instrumentation-loongsuite/**/version.py`, `loongsuite-distro/src/loongsuite/distro/version.py`, and `loongsuite-site-bootstrap/src/loongsuite_site_bootstrap/version.py` to `0.6.0.dev`

Validation:

- `tox -e precommit`