### PR TITLE
feat: use GenAI util for Google ADK spans

### DIFF
--- a/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Route Google ADK `AGENT`, `LLM`, and `TOOL` spans through
+  `opentelemetry-util-genai`, emitting current GenAI attributes such as
+  `gen_ai.input.messages`, `gen_ai.output.messages`,
+  `gen_ai.tool.call.arguments`, `gen_ai.tool.call.result`,
+  `gen_ai.span.kind`, and `gen_ai.provider.name=google_adk`.
+  ([#194](https://github.com/alibaba/loongsuite-python-agent/pull/194))
+
+### Fixed
+
+- Keep Google ADK streaming model spans open until the final response and
+  protect same-session concurrent invocations from cross-finishing spans.
+- Ensure Google ADK spans include LoongSuite `gen_ai.span.kind` values such as
+  `AGENT`.
+
 ## Version 0.5.0 (2026-05-11)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/README.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/README.md
@@ -71,7 +71,8 @@ Here's a simple demonstration of Google ADK instrumentation. The demo uses:
 export DASHSCOPE_API_KEY=your-dashscope-api-key
 
 # Enable content capture (optional, for debugging)
-export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true
+export OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental
+export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=SPAN_ONLY
 
 # Run with loongsuite instrumentation
 loongsuite-instrument \
@@ -87,7 +88,8 @@ loongsuite-instrument \
 export DASHSCOPE_API_KEY=your-dashscope-api-key
 
 # Configure OTLP exporter
-export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true
+export OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental
+export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=SPAN_ONLY
 export OTEL_TRACES_EXPORTER=otlp
 export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
@@ -96,6 +98,51 @@ export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
 loongsuite-instrument \
   --service_name demo-google-adk \
   python examples/main.py
+```
+
+#### Option 3: Local otel-gui smoke scenarios
+
+`examples/otelgui_smoke.py` produces real non-streaming, SSE streaming, and
+concurrent Google ADK calls for local trace validation.
+
+```bash
+export DASHSCOPE_API_KEY=your-dashscope-api-key
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:5173
+export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://127.0.0.1:5173/v1/traces
+export OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental
+export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=SPAN_ONLY
+export OTEL_SERVICE_NAME=loongsuite-google-adk-smoke
+export GOOGLE_ADK_SMOKE_CONFIGURE_OTLP=1
+export GOOGLE_ADK_SMOKE_DISABLE_NATIVE_AGENT_SPAN=1
+
+python examples/otelgui_smoke.py --scenario all
+```
+
+`GOOGLE_ADK_SMOKE_DISABLE_NATIVE_AGENT_SPAN=1` uses a private ADK telemetry
+monkey-patch during smoke validation to remove ADK's native wrapper span, making
+the LoongSuite GenAI span tree easier to inspect in otel-gui. Keep it limited to
+local smoke tests because private ADK internals may change.
+
+When using the local `loongsuite-otelgui-plugin-verify` helper, select the
+GenAI util agent trace explicitly because Google ADK also emits an `invocation`
+trace:
+
+```bash
+python /path/to/run_loongsuite_plugin_smoke.py \
+  --repo-root /path/to/loongsuite-python-agent \
+  --base-url http://127.0.0.1:5173 \
+  --service-name loongsuite-google-adk-non-stream \
+  --root-span-contains invoke_agent \
+  --capture-message-content SPAN_ONLY \
+  --expect-span-kind AGENT \
+  --expect-span-kind LLM \
+  --expect-span-kind TOOL \
+  --expect-content \
+  --env GOOGLE_ADK_SMOKE_CONFIGURE_OTLP=1 \
+  --env GOOGLE_ADK_SMOKE_DISABLE_NATIVE_AGENT_SPAN=1 \
+  --env OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://127.0.0.1:5173/v1/traces \
+  --run "python examples/otelgui_smoke.py --scenario non-stream"
 ```
 
 ### Expected Results
@@ -121,10 +168,11 @@ The instrumentation will generate traces showing the Google ADK operations:
     },
     "attributes": {
         "gen_ai.operation.name": "execute_tool",
+        "gen_ai.span.kind": "TOOL",
         "gen_ai.tool.name": "get_current_time",
         "gen_ai.tool.description": "xxx",
-        "input.value": "{xxx}",
-        "output.value": "{xxx}"
+        "gen_ai.tool.call.arguments": "{xxx}",
+        "gen_ai.tool.call.result": "{xxx}"
     },
     "events": [],
     "links": [],
@@ -148,6 +196,7 @@ The instrumentation will generate traces showing the Google ADK operations:
     "kind": "SpanKind.CLIENT",
     "attributes": {
         "gen_ai.operation.name": "chat",
+        "gen_ai.span.kind": "LLM",
         "gen_ai.request.model": "qwen-max",
         "gen_ai.response.model": "qwen-max",
         "gen_ai.usage.input_tokens": 150,
@@ -164,9 +213,10 @@ The instrumentation will generate traces showing the Google ADK operations:
     "kind": "SpanKind.CLIENT",
     "attributes": {
         "gen_ai.operation.name": "invoke_agent",
+        "gen_ai.span.kind": "AGENT",
         "gen_ai.agent.name": "ToolAgent",
-        "input.value": "[{\"role\": \"user\", \"parts\": [{\"type\": \"text\", \"content\": \"现在几点了？\"}]}]",
-        "output.value": "[{\"role\": \"assistant\", \"parts\": [{\"type\": \"text\", \"content\": \"当前时间是 2025-11-27 14:36:33\"}]}]"
+        "gen_ai.input.messages": "[{\"role\": \"user\", \"parts\": [{\"type\": \"text\", \"content\": \"What time is it?\"}]}]",
+        "gen_ai.output.messages": "[{\"role\": \"assistant\", \"parts\": [{\"type\": \"text\", \"content\": \"The current time is 2025-11-27 14:36:33\"}]}]"
     }
 }
 ```
@@ -183,7 +233,8 @@ The following environment variables can be used to configure the Google ADK inst
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | Capture message content in traces | `false` |
+| `OTEL_SEMCONV_STABILITY_OPT_IN` | Enable latest experimental GenAI semantic conventions | - |
+| `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` | Capture message content in traces (`NO_CONTENT`, `SPAN_ONLY`, `SPAN_AND_EVENT`) | `NO_CONTENT` |
 | `DASHSCOPE_API_KEY` | DashScope API key (required for demo) | - |
 
 ### Programmatic Configuration

--- a/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/examples/otelgui_smoke.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/examples/otelgui_smoke.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Google ADK smoke scenarios for local otel-gui verification.
+
+Run this script through loongsuite-instrument so spans are exported to otel-gui:
+
+    OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:5173 \
+    OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
+    OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental \
+    OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=SPAN_ONLY \
+    OTEL_SERVICE_NAME=loongsuite-google-adk-smoke \
+    OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://127.0.0.1:5173/v1/traces \
+    GOOGLE_ADK_SMOKE_CONFIGURE_OTLP=1 python examples/otelgui_smoke.py --scenario all
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import os
+import time
+from collections.abc import Iterable
+
+from google.adk.agents import LlmAgent
+from google.adk.agents.run_config import RunConfig, StreamingMode
+from google.adk.models.lite_llm import LiteLlm
+from google.adk.runners import Runner
+from google.adk.sessions.in_memory_session_service import (
+    InMemorySessionService,
+)
+from google.adk.tools import FunctionTool
+from google.genai import types
+
+from opentelemetry.instrumentation.google_adk import GoogleAdkInstrumentor
+
+
+def _configure_otlp_exporter_from_env():
+    """Configure an OTLP HTTP exporter for standalone smoke runs."""
+    enabled = os.getenv("GOOGLE_ADK_SMOKE_CONFIGURE_OTLP", "").lower()
+    if enabled not in ("1", "true", "yes"):
+        return None
+
+    try:
+        from opentelemetry import trace  # noqa: PLC0415
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (  # noqa: PLC0415
+            OTLPSpanExporter,
+        )
+        from opentelemetry.sdk.resources import Resource  # noqa: PLC0415
+        from opentelemetry.sdk.trace import TracerProvider  # noqa: PLC0415
+        from opentelemetry.sdk.trace.export import (  # noqa: PLC0415
+            BatchSpanProcessor,
+        )
+    except ImportError as exc:
+        raise SystemExit(
+            "GOOGLE_ADK_SMOKE_CONFIGURE_OTLP=1 requires "
+            "opentelemetry-exporter-otlp-proto-http"
+        ) from exc
+
+    resource = Resource.create(
+        {
+            "service.name": os.getenv(
+                "OTEL_SERVICE_NAME", "loongsuite-google-adk-smoke"
+            )
+        }
+    )
+    provider = TracerProvider(resource=resource)
+    endpoint = os.getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
+    exporter = (
+        OTLPSpanExporter(endpoint=endpoint) if endpoint else OTLPSpanExporter()
+    )
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    return provider
+
+
+def _disable_native_agent_span_for_smoke() -> None:
+    """Optionally suppress ADK's native agent wrapper span during smoke tests.
+
+    This private ADK monkey-patch is only for otel-gui smoke validation: it
+    removes ADK's native wrapper span so the LoongSuite GenAI span tree is
+    easier to inspect. It may need adjustment when ADK changes internals.
+    """
+    enabled = os.getenv(
+        "GOOGLE_ADK_SMOKE_DISABLE_NATIVE_AGENT_SPAN", ""
+    ).lower()
+    if enabled not in ("1", "true", "yes"):
+        return
+
+    from google.adk.telemetry import _instrumentation  # noqa: PLC0415
+
+    import opentelemetry.context as context_api  # noqa: PLC0415
+
+    @contextlib.asynccontextmanager
+    async def _record_agent_invocation(ctx, agent):
+        token = context_api.attach(context_api.Context())
+        try:
+            yield _instrumentation.TelemetryContext(
+                otel_context=context_api.get_current()
+            )
+        finally:
+            context_api.detach(token)
+
+    _instrumentation.record_agent_invocation = _record_agent_invocation
+
+
+def get_city_weather(city: str) -> str:
+    """Return deterministic weather text so the model can exercise a tool."""
+    return f"{city}: sunny, 24C, light wind"
+
+
+def _require_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise SystemExit(f"Missing required environment variable: {name}")
+    return value
+
+
+def _extract_event_text(event) -> str:
+    content = getattr(event, "content", None)
+    if not content:
+        return ""
+    parts = getattr(content, "parts", None) or []
+    return "".join(
+        getattr(part, "text", "") or "" for part in parts if part is not None
+    )
+
+
+def _last_non_empty_text(events: Iterable[object]) -> str:
+    text = ""
+    for event in events:
+        event_text = _extract_event_text(event)
+        if event_text:
+            text = event_text
+    return text
+
+
+async def _create_runner() -> tuple[Runner, InMemorySessionService]:
+    api_key = _require_env("DASHSCOPE_API_KEY")
+    model = LiteLlm(
+        model=os.getenv("DASHSCOPE_MODEL", "dashscope/qwen-plus"),
+        api_key=api_key,
+        base_url=os.getenv(
+            "DASHSCOPE_BASE_URL",
+            "https://dashscope.aliyuncs.com/compatible-mode/v1",
+        ),
+        temperature=float(os.getenv("DASHSCOPE_TEMPERATURE", "0.2")),
+        max_tokens=int(os.getenv("DASHSCOPE_MAX_TOKENS", "256")),
+    )
+    weather_tool = FunctionTool(func=get_city_weather)
+    agent = LlmAgent(
+        name="google_adk_smoke_agent",
+        model=model,
+        instruction=(
+            "You are a concise assistant. Use tools when a prompt asks for "
+            "weather, then answer with one short sentence."
+        ),
+        description="Google ADK instrumentation smoke-test agent",
+        tools=[weather_tool],
+    )
+    session_service = InMemorySessionService()
+    runner = Runner(
+        app_name="google_adk_smoke",
+        agent=agent,
+        session_service=session_service,
+    )
+    return runner, session_service
+
+
+async def _run_once(
+    runner: Runner,
+    session_service: InMemorySessionService,
+    *,
+    user_id: str,
+    session_id: str,
+    prompt: str,
+    streaming: bool = False,
+) -> str:
+    session = await session_service.create_session(
+        app_name="google_adk_smoke",
+        user_id=user_id,
+        session_id=session_id,
+    )
+    user_message = types.Content(role="user", parts=[types.Part(text=prompt)])
+    run_config = (
+        RunConfig(streaming_mode=StreamingMode.SSE) if streaming else None
+    )
+    events = []
+    async for event in runner.run_async(
+        user_id=user_id,
+        session_id=session.id,
+        new_message=user_message,
+        run_config=run_config,
+    ):
+        events.append(event)
+    return _last_non_empty_text(events)
+
+
+async def run_non_stream() -> None:
+    runner, session_service = await _create_runner()
+    response = await _run_once(
+        runner,
+        session_service,
+        user_id="otelgui_user",
+        session_id=f"non_stream_{int(time.time() * 1000)}",
+        prompt="Use get_city_weather for Hangzhou and summarize it.",
+    )
+    print(f"non_stream response: {response}")
+
+
+async def run_stream() -> None:
+    runner, session_service = await _create_runner()
+    response = await _run_once(
+        runner,
+        session_service,
+        user_id="otelgui_user",
+        session_id=f"stream_{int(time.time() * 1000)}",
+        prompt="Reply with a short streaming-friendly greeting.",
+        streaming=True,
+    )
+    print(f"stream response: {response}")
+
+
+async def run_concurrent(count: int) -> None:
+    runner, session_service = await _create_runner()
+    now_ms = int(time.time() * 1000)
+    tasks = [
+        _run_once(
+            runner,
+            session_service,
+            user_id=f"otelgui_user_{index}",
+            session_id=f"concurrent_{now_ms}_{index}",
+            prompt=f"Use get_city_weather for city {index} and summarize it.",
+        )
+        for index in range(count)
+    ]
+    responses = await asyncio.gather(*tasks)
+    for index, response in enumerate(responses):
+        print(f"concurrent response {index}: {response}")
+
+
+async def _amain(args: argparse.Namespace) -> None:
+    tracer_provider = _configure_otlp_exporter_from_env()
+    _disable_native_agent_span_for_smoke()
+    GoogleAdkInstrumentor().instrument()
+    try:
+        if args.scenario in ("non-stream", "all"):
+            await run_non_stream()
+        if args.scenario in ("stream", "all"):
+            await run_stream()
+        if args.scenario in ("concurrent", "all"):
+            await run_concurrent(args.concurrent_count)
+    finally:
+        if tracer_provider is not None:
+            tracer_provider.force_flush()
+            tracer_provider.shutdown()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--scenario",
+        choices=("non-stream", "stream", "concurrent", "all"),
+        default="all",
+    )
+    parser.add_argument("--concurrent-count", type=int, default=3)
+    args = parser.parse_args()
+    asyncio.run(_amain(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "opentelemetry-api ~= 1.37",
   "opentelemetry-sdk ~= 1.37",
   "opentelemetry-semantic-conventions ~= 0.58b0",
-  "opentelemetry-util-genai ~= 0.2b0",
+  "opentelemetry-util-genai",
   "wrapt >= 1.0.0, < 2.0.0",
 ]
 

--- a/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/src/opentelemetry/instrumentation/google_adk/internal/_plugin.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/src/opentelemetry/instrumentation/google_adk/internal/_plugin.py
@@ -23,6 +23,8 @@ for standard span and metrics management.
 """
 
 import logging
+import timeit
+from contextvars import ContextVar
 from typing import Any, Dict, List, Optional
 
 from google.adk.agents.base_agent import BaseAgent
@@ -36,6 +38,7 @@ from google.adk.tools.base_tool import BaseTool
 from google.adk.tools.tool_context import ToolContext
 from google.genai import types
 
+from opentelemetry import context as otel_context
 from opentelemetry.util.genai.extended_handler import ExtendedTelemetryHandler
 from opentelemetry.util.genai.extended_types import (
     ExecuteToolInvocation,
@@ -52,6 +55,9 @@ from opentelemetry.util.genai.types import (
 from ._extractors import AdkAttributeExtractors
 
 _logger = logging.getLogger(__name__)
+_ACTIVE_LLM_REQUEST_KEY: ContextVar[Optional[str]] = ContextVar(
+    "google_adk_active_llm_request_key", default=None
+)
 
 
 class GoogleAdkObservabilityPlugin(BasePlugin):
@@ -88,6 +94,7 @@ class GoogleAdkObservabilityPlugin(BasePlugin):
 
         # Track llm_request -> model mapping to avoid fallback model names
         self._llm_req_models: Dict[str, str] = {}
+        self._llm_stream_outputs: Dict[str, str] = {}
 
     # ===== Runner Level Callbacks - Top-level invoke_agent span =====
 
@@ -103,8 +110,9 @@ class GoogleAdkObservabilityPlugin(BasePlugin):
             # Extract conversation_id
             conversation_id = None
 
-            if invocation_context.session:
-                conversation_id = invocation_context.session.id
+            conversation_id = self._session_id_from_invocation_context(
+                invocation_context
+            )
 
             # Create invocation object
             invocation = InvokeAgentInvocation(
@@ -128,7 +136,7 @@ class GoogleAdkObservabilityPlugin(BasePlugin):
                 )
 
             # Check if we already have a stored user message
-            runner_key = f"runner_{invocation_context.invocation_id}"
+            runner_key = self._runner_key(invocation_context)
             if runner_key in self._runner_inputs:
                 user_message = self._runner_inputs[runner_key]
                 input_messages = self._convert_user_message_to_input_messages(
@@ -164,7 +172,7 @@ class GoogleAdkObservabilityPlugin(BasePlugin):
         """
         try:
             # Store user message for later use in Runner span
-            runner_key = f"runner_{invocation_context.invocation_id}"
+            runner_key = self._runner_key(invocation_context)
             self._runner_inputs[runner_key] = user_message
 
             # Update active Runner invocation if it exists
@@ -201,7 +209,7 @@ class GoogleAdkObservabilityPlugin(BasePlugin):
                 event_content = self._extract_text_from_content(event.data)
 
             if event_content:
-                runner_key = f"runner_{invocation_context.invocation_id}"
+                runner_key = self._runner_key(invocation_context)
 
                 # Accumulate output content
                 if runner_key not in self._runner_outputs:
@@ -226,6 +234,9 @@ class GoogleAdkObservabilityPlugin(BasePlugin):
                 f"Captured event for Runner: {invocation_context.invocation_id}"
             )
 
+            if self._is_root_final_event(event, invocation_context):
+                self._finish_runner_invocation(invocation_context)
+
         except Exception as e:
             _logger.exception(f"Error in on_event_callback: {e}")
 
@@ -238,19 +249,7 @@ class GoogleAdkObservabilityPlugin(BasePlugin):
         End Runner execution - finish top-level invoke_agent span.
         """
         try:
-            runner_key = f"runner_{invocation_context.invocation_id}"
-            invocation = self._active_runner_invocations.pop(runner_key, None)
-
-            if invocation:
-                # Stop invocation (ends span and records metrics automatically)
-                self._handler.stop_invoke_agent(invocation)
-                _logger.debug(
-                    f"Finished Runner invocation for {invocation_context.app_name}"
-                )
-
-            # Clean up stored data
-            self._runner_inputs.pop(runner_key, None)
-            self._runner_outputs.pop(runner_key, None)
+            self._finish_runner_invocation(invocation_context)
 
         except Exception as e:
             _logger.exception(f"Error in after_run_callback: {e}")
@@ -267,10 +266,9 @@ class GoogleAdkObservabilityPlugin(BasePlugin):
             # Extract conversation_id
             conversation_id = None
 
-            if callback_context._invocation_context.session:
-                conversation_id = (
-                    callback_context._invocation_context.session.id
-                )
+            conversation_id = self._session_id_from_callback_context(
+                callback_context
+            )
 
             # Create invocation object
             invocation = InvokeAgentInvocation(
@@ -288,11 +286,21 @@ class GoogleAdkObservabilityPlugin(BasePlugin):
             if conversation_id:
                 invocation.conversation_id = conversation_id
 
+            user_id = getattr(callback_context, "user_id", None)
+            if not user_id:
+                user_id = getattr(
+                    self._get_invocation_context(callback_context),
+                    "user_id",
+                    None,
+                )
+            if user_id:
+                invocation.attributes["enduser.id"] = user_id
+
             # Start invocation (creates span)
             self._handler.start_invoke_agent(invocation)
 
             # Store invocation for later use
-            agent_key = f"agent_{id(agent)}_{conversation_id}"
+            agent_key = self._agent_key(agent, callback_context)
             self._active_agent_invocations[agent_key] = invocation
 
             _logger.debug(
@@ -309,19 +317,20 @@ class GoogleAdkObservabilityPlugin(BasePlugin):
         End Agent execution - finish invoke_agent span.
         """
         try:
-            conversation_id = None
-            if callback_context._invocation_context.session:
-                conversation_id = (
-                    callback_context._invocation_context.session.id
-                )
-
-            agent_key = f"agent_{id(agent)}_{conversation_id}"
+            agent_key = self._agent_key(agent, callback_context)
             invocation = self._active_agent_invocations.pop(agent_key, None)
 
             if invocation:
                 # Stop invocation (ends span and records metrics automatically)
                 self._handler.stop_invoke_agent(invocation)
                 _logger.debug(f"Finished Agent invocation for {agent.name}")
+
+            if self._is_root_agent(agent, callback_context):
+                invocation_context = self._get_invocation_context(
+                    callback_context
+                )
+                if invocation_context:
+                    self._finish_runner_invocation(invocation_context)
 
         except Exception as e:
             _logger.exception(f"Error in after_agent_callback: {e}")
@@ -354,37 +363,41 @@ class GoogleAdkObservabilityPlugin(BasePlugin):
             # Extract request parameters
             if llm_request.config:
                 config = llm_request.config
-                if hasattr(config, "max_tokens") and config.max_tokens:
-                    invocation.max_tokens = config.max_tokens
-                if (
-                    hasattr(config, "temperature")
-                    and config.temperature is not None
-                ):
-                    invocation.temperature = config.temperature
-                if hasattr(config, "top_p") and config.top_p is not None:
-                    invocation.top_p = config.top_p
+                max_tokens = self._get_real_attr(config, "max_tokens")
+                if max_tokens:
+                    invocation.max_tokens = max_tokens
+                temperature = self._get_real_attr(config, "temperature")
+                if temperature is not None:
+                    invocation.temperature = temperature
+                top_p = self._get_real_attr(config, "top_p")
+                if top_p is not None:
+                    invocation.top_p = top_p
 
             # Extract conversation_id and user_id
-            if callback_context._invocation_context.session:
-                invocation.attributes["gen_ai.conversation.id"] = (
-                    callback_context._invocation_context.session.id
-                )
+            session_id = self._session_id_from_callback_context(
+                callback_context
+            )
+            if session_id:
+                invocation.attributes["gen_ai.conversation.id"] = session_id
 
             user_id = getattr(callback_context, "user_id", None)
             if not user_id:
                 user_id = getattr(
-                    callback_context._invocation_context, "user_id", None
+                    self._get_invocation_context(callback_context),
+                    "user_id",
+                    None,
                 )
             if user_id:
                 invocation.attributes["enduser.id"] = user_id
 
             # Start invocation (creates span)
             self._handler.start_llm(invocation)
+            self._detach_current_context(invocation)
 
             # Store invocation for later use
-            session_id = callback_context._invocation_context.session.id
-            request_key = f"llm_{id(llm_request)}_{session_id}"
+            request_key = self._llm_key(callback_context, llm_request)
             self._active_llm_invocations[request_key] = invocation
+            _ACTIVE_LLM_REQUEST_KEY.set(request_key)
 
             # Store the requested model for reliable retrieval later
             if hasattr(llm_request, "model") and llm_request.model:
@@ -402,61 +415,41 @@ class GoogleAdkObservabilityPlugin(BasePlugin):
         End LLM call - finish chat span.
         """
         try:
-            # Find the matching invocation
-            session_id = callback_context._invocation_context.session.id
-            llm_invocation = None
-            request_key = None
-
-            for key, invocation in list(self._active_llm_invocations.items()):
-                if key.startswith("llm_") and session_id in key:
-                    llm_invocation = self._active_llm_invocations.pop(key)
-                    request_key = key
-                    break
+            request_key, llm_invocation = self._find_active_llm_invocation(
+                callback_context
+            )
 
             if llm_invocation:
                 # Update invocation with response data
                 if llm_response:
-                    # Set response model
-                    if hasattr(llm_response, "model") and llm_response.model:
-                        llm_invocation.response_model_name = llm_response.model
-
-                    # Extract token usage
-                    if llm_response.usage_metadata:
-                        usage = llm_response.usage_metadata
-                        if hasattr(usage, "prompt_token_count"):
-                            llm_invocation.input_tokens = (
-                                usage.prompt_token_count
-                            )
-                        if hasattr(usage, "candidates_token_count"):
-                            llm_invocation.output_tokens = (
-                                usage.candidates_token_count
-                            )
-
-                    # Extract finish reason
-                    if hasattr(llm_response, "finish_reason"):
-                        finish_reason = llm_response.finish_reason or "stop"
-                        if hasattr(finish_reason, "value"):
-                            finish_reason = finish_reason.value
-                        elif not isinstance(
-                            finish_reason, (str, int, float, bool)
-                        ):
-                            finish_reason = str(finish_reason)
-                        llm_invocation.finish_reasons = [finish_reason]
-
-                    # Extract output messages
-                    output_messages = (
-                        self._convert_llm_response_to_output_messages(
-                            llm_response
-                        )
+                    self._update_llm_invocation_from_response(
+                        llm_invocation, llm_response, request_key
                     )
-                    llm_invocation.output_messages = output_messages
+
+                    if self._is_streaming_partial_response(llm_response):
+                        if llm_invocation.monotonic_first_token_s is None:
+                            llm_invocation.monotonic_first_token_s = (
+                                timeit.default_timer()
+                            )
+                        _logger.debug(
+                            "Captured partial LLM response for %s",
+                            request_key,
+                        )
+                        return None
+
+                if request_key:
+                    self._active_llm_invocations.pop(request_key, None)
 
                 # Stop invocation (ends span and records metrics automatically)
                 self._handler.stop_llm(llm_invocation)
+                if request_key == _ACTIVE_LLM_REQUEST_KEY.get():
+                    _ACTIVE_LLM_REQUEST_KEY.set(None)
 
                 model_name = self._resolve_model_name(
                     llm_response, request_key, llm_invocation
                 )
+                if request_key:
+                    self._llm_stream_outputs.pop(request_key, None)
                 _logger.debug(
                     f"Finished LLM invocation for model {model_name}"
                 )
@@ -476,16 +469,19 @@ class GoogleAdkObservabilityPlugin(BasePlugin):
         """
         try:
             # Find and finish the invocation with error status
-            session_id = callback_context._invocation_context.session.id
-            for key, invocation in list(self._active_llm_invocations.items()):
-                if key.startswith("llm_") and session_id in key:
-                    invocation = self._active_llm_invocations.pop(key)
+            request_key, invocation = self._find_active_llm_invocation(
+                callback_context, llm_request
+            )
+            if request_key and invocation:
+                self._active_llm_invocations.pop(request_key, None)
+                self._llm_stream_outputs.pop(request_key, None)
+                if request_key == _ACTIVE_LLM_REQUEST_KEY.get():
+                    _ACTIVE_LLM_REQUEST_KEY.set(None)
 
-                    # Fail invocation (sets error attributes and ends span)
-                    self._handler.fail_llm(
-                        invocation, Error(message=str(error), type=type(error))
-                    )
-                    break
+                # Fail invocation (sets error attributes and ends span)
+                self._handler.fail_llm(
+                    invocation, Error(message=str(error), type=type(error))
+                )
 
             _logger.debug(f"Handled LLM error: {error}")
 
@@ -530,7 +526,7 @@ class GoogleAdkObservabilityPlugin(BasePlugin):
             self._handler.start_execute_tool(invocation)
 
             # Store invocation for later use
-            tool_key = f"tool_{id(tool)}_{id(tool_args)}"
+            tool_key = self._tool_key(tool, tool_args, tool_context)
             self._active_tool_invocations[tool_key] = invocation
 
             _logger.debug(f"Started Tool invocation: execute_tool {tool.name}")
@@ -550,7 +546,7 @@ class GoogleAdkObservabilityPlugin(BasePlugin):
         End Tool execution - finish execute_tool span.
         """
         try:
-            tool_key = f"tool_{id(tool)}_{id(tool_args)}"
+            tool_key = self._tool_key(tool, tool_args, tool_context)
             invocation = self._active_tool_invocations.pop(tool_key, None)
 
             if invocation:
@@ -577,7 +573,7 @@ class GoogleAdkObservabilityPlugin(BasePlugin):
         Handle Tool execution errors.
         """
         try:
-            tool_key = f"tool_{id(tool)}_{id(tool_args)}"
+            tool_key = self._tool_key(tool, tool_args, tool_context)
             invocation = self._active_tool_invocations.pop(tool_key, None)
 
             if invocation:
@@ -594,6 +590,178 @@ class GoogleAdkObservabilityPlugin(BasePlugin):
         return None
 
     # ===== Helper Methods =====
+
+    @staticmethod
+    def _detach_current_context(invocation: LLMInvocation) -> None:
+        if invocation.context_token is None:
+            return
+        try:
+            otel_context.detach(invocation.context_token)
+        except (ValueError, RuntimeError):
+            pass
+
+    @staticmethod
+    def _get_invocation_context(
+        callback_context: CallbackContext,
+    ) -> Optional[InvocationContext]:
+        return getattr(callback_context, "_invocation_context", None)
+
+    def _finish_runner_invocation(
+        self, invocation_context: InvocationContext
+    ) -> None:
+        runner_key = self._runner_key(invocation_context)
+        invocation = self._active_runner_invocations.pop(runner_key, None)
+
+        if invocation:
+            self._handler.stop_invoke_agent(invocation)
+            _logger.debug(
+                "Finished Runner invocation for %s",
+                getattr(invocation_context, "app_name", "unknown"),
+            )
+
+        self._runner_inputs.pop(runner_key, None)
+        self._runner_outputs.pop(runner_key, None)
+
+    def _is_root_agent(
+        self, agent: BaseAgent, callback_context: CallbackContext
+    ) -> bool:
+        invocation_context = self._get_invocation_context(callback_context)
+        if not invocation_context:
+            return False
+
+        root_agent = getattr(invocation_context, "agent", None)
+        if root_agent is agent:
+            return True
+
+        root_name = getattr(root_agent, "name", None)
+        return bool(root_name and root_name == getattr(agent, "name", None))
+
+    @staticmethod
+    def _is_root_final_event(
+        event: Event, invocation_context: InvocationContext
+    ) -> bool:
+        is_final_response = getattr(event, "is_final_response", None)
+        if callable(is_final_response):
+            try:
+                if not is_final_response():
+                    return False
+            except Exception:
+                return False
+        else:
+            return False
+
+        root_agent = getattr(invocation_context, "agent", None)
+        root_name = getattr(root_agent, "name", None)
+        event_author = getattr(event, "author", None)
+        return bool(root_name and event_author and event_author == root_name)
+
+    @staticmethod
+    def _session_id_from_invocation_context(
+        invocation_context: InvocationContext,
+    ) -> Optional[str]:
+        session = getattr(invocation_context, "session", None)
+        return getattr(session, "id", None)
+
+    def _session_id_from_callback_context(
+        self, callback_context: CallbackContext
+    ) -> Optional[str]:
+        invocation_context = self._get_invocation_context(callback_context)
+        if not invocation_context:
+            return None
+        return self._session_id_from_invocation_context(invocation_context)
+
+    @staticmethod
+    def _invocation_id_from_invocation_context(
+        invocation_context: InvocationContext,
+    ) -> str:
+        invocation_id = getattr(invocation_context, "invocation_id", None)
+        return str(invocation_id) if invocation_id is not None else "unknown"
+
+    def _invocation_id_from_callback_context(
+        self, callback_context: CallbackContext
+    ) -> str:
+        invocation_context = self._get_invocation_context(callback_context)
+        if not invocation_context:
+            return "unknown"
+        return self._invocation_id_from_invocation_context(invocation_context)
+
+    def _runner_key(self, invocation_context: InvocationContext) -> str:
+        invocation_id = self._invocation_id_from_invocation_context(
+            invocation_context
+        )
+        return f"runner_{invocation_id}"
+
+    def _agent_key(
+        self, agent: BaseAgent, callback_context: CallbackContext
+    ) -> str:
+        invocation_id = self._invocation_id_from_callback_context(
+            callback_context
+        )
+        conversation_id = self._session_id_from_callback_context(
+            callback_context
+        )
+        return f"agent_{invocation_id}_{id(agent)}_{conversation_id}"
+
+    def _llm_key(
+        self, callback_context: CallbackContext, llm_request: LlmRequest
+    ) -> str:
+        invocation_id = self._invocation_id_from_callback_context(
+            callback_context
+        )
+        session_id = self._session_id_from_callback_context(callback_context)
+        return f"llm_{invocation_id}_{id(llm_request)}_{session_id}"
+
+    def _tool_key(
+        self,
+        tool: BaseTool,
+        tool_args: dict[str, Any],
+        tool_context: ToolContext,
+    ) -> str:
+        invocation_context = getattr(tool_context, "_invocation_context", None)
+        invocation_id = (
+            self._invocation_id_from_invocation_context(invocation_context)
+            if invocation_context
+            else str(getattr(tool_context, "invocation_id", "unknown"))
+        )
+        call_id = getattr(tool_context, "call_id", None)
+        return f"tool_{invocation_id}_{call_id}_{id(tool)}_{id(tool_args)}"
+
+    def _find_active_llm_invocation(
+        self,
+        callback_context: CallbackContext,
+        llm_request: Optional[LlmRequest] = None,
+    ) -> tuple[Optional[str], Optional[LLMInvocation]]:
+        context_request_key = _ACTIVE_LLM_REQUEST_KEY.get()
+        if context_request_key:
+            invocation = self._active_llm_invocations.get(context_request_key)
+            if invocation:
+                return context_request_key, invocation
+
+        if llm_request is not None:
+            request_key = self._llm_key(callback_context, llm_request)
+            invocation = self._active_llm_invocations.get(request_key)
+            if invocation:
+                return request_key, invocation
+
+        invocation_id = self._invocation_id_from_callback_context(
+            callback_context
+        )
+        session_id = self._session_id_from_callback_context(callback_context)
+        preferred_prefix = f"llm_{invocation_id}_"
+
+        for key, invocation in list(self._active_llm_invocations.items()):
+            if key.startswith(preferred_prefix):
+                return key, invocation
+
+        for key, invocation in list(self._active_llm_invocations.items()):
+            if (
+                key.startswith("llm_")
+                and session_id
+                and key.endswith(f"_{session_id}")
+            ):
+                return key, invocation
+
+        return None, None
 
     @staticmethod
     def _extract_text_from_content(content: Any) -> str:
@@ -623,6 +791,23 @@ class GoogleAdkObservabilityPlugin(BasePlugin):
             return content.text or ""
         return str(content)
 
+    @staticmethod
+    def _is_mock_placeholder(value: Any) -> bool:
+        return type(value).__module__.startswith("unittest.mock")
+
+    @staticmethod
+    def _mock_has_explicit_attrs(
+        value: Any, attr_names: tuple[str, ...]
+    ) -> bool:
+        value_dict = getattr(value, "__dict__", {})
+        return any(attr_name in value_dict for attr_name in attr_names)
+
+    def _get_real_attr(self, value: Any, attr_name: str) -> Any:
+        attr_value = getattr(value, attr_name, None)
+        if self._is_mock_placeholder(attr_value):
+            return None
+        return attr_value
+
     def _resolve_model_name(
         self,
         llm_response: LlmResponse,
@@ -642,13 +827,9 @@ class GoogleAdkObservabilityPlugin(BasePlugin):
         """
         model_name = None
 
-        # 1) Prefer llm_response.model if available
-        if (
-            llm_response
-            and hasattr(llm_response, "model")
-            and getattr(llm_response, "model")
-        ):
-            model_name = getattr(llm_response, "model")
+        # 1) Prefer response model fields if available
+        if llm_response:
+            model_name = self._get_response_model_name(llm_response)
 
         # 2) Use stored request model by request_key
         if (
@@ -667,6 +848,84 @@ class GoogleAdkObservabilityPlugin(BasePlugin):
             model_name = "unknown"
 
         return model_name
+
+    @staticmethod
+    def _get_response_model_name(llm_response: LlmResponse) -> Optional[str]:
+        for attr_name in ("model", "model_version", "modelVersion"):
+            model_name = getattr(llm_response, attr_name, None)
+            if (
+                model_name
+                and not GoogleAdkObservabilityPlugin._is_mock_placeholder(
+                    model_name
+                )
+            ):
+                return model_name
+        return None
+
+    @staticmethod
+    def _is_streaming_partial_response(llm_response: LlmResponse) -> bool:
+        return bool(getattr(llm_response, "partial", False)) and not bool(
+            getattr(llm_response, "turn_complete", False)
+        )
+
+    def _merge_stream_output(self, request_key: str, text: str) -> str:
+        if not text:
+            return self._llm_stream_outputs.get(request_key, "")
+
+        # ADK streaming responses are cumulative snapshots, not deltas.
+        merged = text
+        self._llm_stream_outputs[request_key] = merged
+        return merged
+
+    def _update_llm_invocation_from_response(
+        self,
+        invocation: LLMInvocation,
+        llm_response: LlmResponse,
+        request_key: Optional[str],
+    ) -> None:
+        response_model = self._get_response_model_name(llm_response)
+        if response_model:
+            invocation.response_model_name = response_model
+
+        usage = getattr(llm_response, "usage_metadata", None)
+        if self._is_mock_placeholder(
+            usage
+        ) and not self._mock_has_explicit_attrs(
+            usage,
+            ("prompt_token_count", "candidates_token_count"),
+        ):
+            usage = None
+        if usage:
+            input_tokens = self._get_real_attr(usage, "prompt_token_count")
+            if input_tokens is not None:
+                invocation.input_tokens = input_tokens
+
+            output_tokens = self._get_real_attr(
+                usage, "candidates_token_count"
+            )
+            if output_tokens is not None:
+                invocation.output_tokens = output_tokens
+
+        finish_reason = self._get_real_attr(llm_response, "finish_reason")
+        if finish_reason:
+            if hasattr(finish_reason, "value"):
+                finish_reason = finish_reason.value
+            elif not isinstance(finish_reason, (str, int, float, bool)):
+                finish_reason = str(finish_reason)
+            invocation.finish_reasons = [finish_reason]
+
+        extracted_text = self._extract_text_from_llm_response(llm_response)
+        accumulated_text = (
+            self._merge_stream_output(request_key, extracted_text)
+            if request_key
+            else extracted_text
+        )
+        output_messages = self._convert_text_to_output_messages(
+            accumulated_text,
+            llm_response,
+        )
+        if output_messages:
+            invocation.output_messages = output_messages
 
     def _convert_user_message_to_input_messages(
         self, user_message: types.Content
@@ -721,14 +980,31 @@ class GoogleAdkObservabilityPlugin(BasePlugin):
                     )
         return input_messages
 
-    def _convert_llm_response_to_output_messages(
+    def _extract_text_from_llm_response(
         self, llm_response: LlmResponse
+    ) -> str:
+        if not llm_response:
+            return ""
+
+        content = self._get_real_attr(llm_response, "content")
+        if content is not None:
+            return self._extract_text_from_content(content)
+
+        text = self._get_real_attr(llm_response, "text")
+        if text is not None:
+            return self._extract_text_from_content(text)
+
+        return ""
+
+    def _convert_text_to_output_messages(
+        self, text: str, llm_response: LlmResponse
     ) -> List[OutputMessage]:
         """
-        Convert ADK LlmResponse to GenAI OutputMessage format.
+        Convert ADK response text to GenAI OutputMessage format.
 
         Args:
-            llm_response: ADK LlmResponse object
+            text: ADK response text
+            llm_response: ADK LlmResponse object, used for finish reason
 
         Returns:
             List of OutputMessage objects
@@ -748,35 +1024,32 @@ class GoogleAdkObservabilityPlugin(BasePlugin):
             elif not isinstance(finish_reason, (str, int, float, bool)):
                 finish_reason = str(finish_reason)
 
-            # Check if response has text content
-            if hasattr(llm_response, "text") and llm_response.text is not None:
-                extracted_text = self._extract_text_from_content(
-                    llm_response.text
-                )
-                if extracted_text:
-                    output_messages.append(
-                        OutputMessage(
-                            role="assistant",
-                            parts=[Text(content=extracted_text)],
-                            finish_reason=finish_reason,
-                        )
+            if text:
+                output_messages.append(
+                    OutputMessage(
+                        role="assistant",
+                        parts=[Text(content=text)],
+                        finish_reason=finish_reason,
                     )
-            elif (
-                hasattr(llm_response, "content")
-                and llm_response.content is not None
-            ):
-                extracted_text = self._extract_text_from_content(
-                    llm_response.content
                 )
-                if extracted_text:
-                    output_messages.append(
-                        OutputMessage(
-                            role="assistant",
-                            parts=[Text(content=extracted_text)],
-                            finish_reason=finish_reason,
-                        )
-                    )
         except Exception as e:
             _logger.debug(f"Failed to extract output messages: {e}")
 
         return output_messages
+
+    def _convert_llm_response_to_output_messages(
+        self, llm_response: LlmResponse
+    ) -> List[OutputMessage]:
+        """
+        Convert ADK LlmResponse to GenAI OutputMessage format.
+
+        Args:
+            llm_response: ADK LlmResponse object
+
+        Returns:
+            List of OutputMessage objects
+        """
+        return self._convert_text_to_output_messages(
+            self._extract_text_from_llm_response(llm_response),
+            llm_response,
+        )

--- a/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/tests/test_integration.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/tests/test_integration.py
@@ -45,6 +45,22 @@ DASHSCOPE_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
 DASHSCOPE_MODEL = "dashscope/qwen-plus"
 
 
+def _metric_data_points(metrics_data, metric_name: str):
+    """Return all data points for a named metric."""
+    if not metrics_data:
+        return []
+
+    data_points = []
+    for resource_metrics in metrics_data.resource_metrics:
+        for scope_metrics in resource_metrics.scope_metrics:
+            for metric in scope_metrics.metrics:
+                if metric.name == metric_name and hasattr(
+                    metric.data, "data_points"
+                ):
+                    data_points.extend(metric.data.data_points)
+    return data_points
+
+
 # Simple tool functions for testing
 # Use fixed return values to ensure VCR cassette matching
 def get_current_time() -> str:
@@ -162,6 +178,7 @@ class TestGoogleAdkSDKIntegration:
         # Verify chat span attributes
         chat_span = chat_spans[0]
         assert chat_span.attributes.get("gen_ai.operation.name") == "chat"
+        assert chat_span.attributes.get("gen_ai.span.kind") == "LLM"
         assert chat_span.attributes.get("gen_ai.provider.name") is not None
         assert chat_span.attributes.get("gen_ai.request.model") is not None
         assert chat_span.name.startswith("chat ")
@@ -221,6 +238,7 @@ class TestGoogleAdkSDKIntegration:
             agent_span.attributes.get("gen_ai.operation.name")
             == "invoke_agent"
         )
+        assert agent_span.attributes.get("gen_ai.span.kind") == "AGENT"
         assert (
             agent_span.attributes.get("gen_ai.provider.name") == "google_adk"
         )
@@ -269,61 +287,14 @@ class TestGoogleAdkSDKIntegration:
         metrics = metric_reader.get_metrics_data()
 
         # Should have operation duration metrics
-        # Note: Metrics may be recorded asynchronously, so we check if any metrics exist
         assert metrics is not None, "Should have metrics data"
-
-    @pytest.mark.asyncio
-    @pytest.mark.vcr()
-    async def test_error_handling_creates_error_spans(
-        self, instrument, span_exporter, runner, session_service
-    ):
-        """
-        Test that errors are properly handled and recorded in spans.
-
-        This test may need to be adjusted based on how errors are triggered.
-        """
-        # Create session
-        session = await session_service.create_session(
-            app_name="test_app",
-            user_id="test_user",
-            session_id="test_session_7",
+        duration_points = _metric_data_points(
+            metrics, "gen_ai.client.operation.duration"
         )
-
-        # Create user message
-        user_message = types.Content(
-            role="user", parts=[types.Part(text="Hello")]
+        assert duration_points, (
+            "Should have gen_ai.client.operation.duration data points"
         )
-
-        # Clear spans before test
-        span_exporter.clear()
-
-        # Run conversation (should succeed)
-        events = []
-        try:
-            async for event in runner.run_async(
-                user_id="test_user",
-                session_id=session.id,
-                new_message=user_message,
-            ):
-                events.append(event)
-        except Exception:
-            # If error occurs, verify it's recorded
-            await asyncio.sleep(0.5)
-            spans = span_exporter.get_finished_spans()
-
-            # Check if any span has error status
-            error_spans = [
-                span
-                for span in spans
-                if span.status.status_code.value == 2  # ERROR status
-            ]
-
-            # If errors occurred, they should be recorded
-            if error_spans:
-                error_span = error_spans[0]
-                assert "error.type" in error_span.attributes
-
-        # For now, just verify spans are created
-        await asyncio.sleep(0.5)
-        spans = span_exporter.get_finished_spans()
-        assert len(spans) >= 1, "Should have at least one span"
+        assert any(
+            dict(point.attributes).get("gen_ai.operation.name") == "chat"
+            for point in duration_points
+        ), "Should record operation duration for chat"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/tests/test_plugin_integration.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/tests/test_plugin_integration.py
@@ -23,10 +23,14 @@ This test follows the same pattern as the commercial ARMS version but validates
 against the latest OpenTelemetry GenAI semantic conventions.
 """
 
+import asyncio
+import timeit
 from typing import Any, Dict
 from unittest.mock import Mock
 
 import pytest
+from google.adk.events.event import Event
+from google.genai import types
 
 from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.google_adk import GoogleAdkInstrumentor
@@ -39,16 +43,41 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
 )
 
 
-def create_mock_callback_context(session_id="session_123", user_id="user_456"):
+def create_mock_callback_context(
+    session_id="session_123", user_id="user_456", invocation_id="inv_123"
+):
     """Create properly structured mock CallbackContext following ADK structure."""
     mock_callback_context = Mock()
     mock_session = Mock()
     mock_session.id = session_id
     mock_invocation_context = Mock()
     mock_invocation_context.session = mock_session
+    mock_invocation_context.invocation_id = invocation_id
+    mock_invocation_context.user_id = user_id
     mock_callback_context._invocation_context = mock_invocation_context
     mock_callback_context.user_id = user_id
     return mock_callback_context
+
+
+def create_mock_llm_response(
+    *,
+    model_version=None,
+    content=None,
+    partial=False,
+    finish_reason=None,
+):
+    """Create an ADK-version-neutral LLM response test double."""
+    response = Mock()
+    response.model = None
+    response.model_version = None
+    response.modelVersion = model_version
+    response.content = content
+    response.text = None
+    response.partial = partial
+    response.turn_complete = not partial
+    response.finish_reason = finish_reason
+    response.usage_metadata = None
+    return response
 
 
 class OTelGenAISpanValidator:
@@ -70,6 +99,7 @@ class OTelGenAISpanValidator:
         "chat": {
             "required": {
                 "gen_ai.operation.name",
+                "gen_ai.span.kind",
                 "gen_ai.provider.name",
                 "gen_ai.request.model",
             },
@@ -80,11 +110,15 @@ class OTelGenAISpanValidator:
             },
         },
         "invoke_agent": {
-            "required": {"gen_ai.operation.name"},
+            "required": {"gen_ai.operation.name", "gen_ai.span.kind"},
             "recommended": {"gen_ai.agent.name", "gen_ai.agent.description"},
         },
         "execute_tool": {
-            "required": {"gen_ai.operation.name", "gen_ai.tool.name"},
+            "required": {
+                "gen_ai.operation.name",
+                "gen_ai.span.kind",
+                "gen_ai.tool.name",
+            },
             "recommended": {"gen_ai.tool.description"},
         },
     }
@@ -278,6 +312,7 @@ class TestGoogleAdkPluginIntegration:
         assert attributes.get("gen_ai.operation.name") == "chat", (
             "Should have gen_ai.operation.name = 'chat'"
         )
+        assert attributes.get("gen_ai.span.kind") == "LLM"
         assert "gen_ai.provider.name" in attributes, (
             "Should have gen_ai.provider.name (not gen_ai.system)"
         )
@@ -364,6 +399,7 @@ class TestGoogleAdkPluginIntegration:
 
         attributes = agent_span.attributes
         assert attributes.get("gen_ai.operation.name") == "invoke_agent"
+        assert attributes.get("gen_ai.span.kind") == "AGENT"
 
         # Validate agent attributes have gen_ai. prefix
         assert (
@@ -442,6 +478,7 @@ class TestGoogleAdkPluginIntegration:
 
         attributes = tool_span.attributes
         assert attributes.get("gen_ai.operation.name") == "execute_tool"
+        assert attributes.get("gen_ai.span.kind") == "TOOL"
 
         # Validate tool attributes
         assert attributes.get("gen_ai.tool.name") == "calculator"
@@ -491,8 +528,507 @@ class TestGoogleAdkPluginIntegration:
         # Validate attributes
         attributes = runner_span.attributes
         assert attributes.get("gen_ai.operation.name") == "invoke_agent"
+        assert attributes.get("gen_ai.span.kind") == "AGENT"
         # Note: runner.app_name is namespaced with google_adk prefix
         assert attributes.get("google_adk.runner.app_name") == "test_app"
+
+    @pytest.mark.asyncio
+    async def test_runner_span_finishes_on_root_final_event(self):
+        """ADK node runtime may emit final events without after_run_callback."""
+        self.instrumentor.instrument(
+            tracer_provider=self.tracer_provider,
+            meter_provider=self.meter_provider,
+        )
+
+        plugin = self.instrumentor._plugin
+
+        mock_invocation_context = Mock()
+        mock_invocation_context.invocation_id = "run_final_event"
+        mock_invocation_context.app_name = "test_app"
+        mock_invocation_context.session = Mock()
+        mock_invocation_context.session.id = "session_final"
+        mock_invocation_context.user_id = "user_222"
+        mock_invocation_context.agent = Mock()
+        mock_invocation_context.agent.name = "test_agent"
+
+        await plugin.before_run_callback(
+            invocation_context=mock_invocation_context
+        )
+        await plugin.on_event_callback(
+            invocation_context=mock_invocation_context,
+            event=Event(
+                author="test_agent",
+                content=types.Content(
+                    role="model", parts=[types.Part(text="done")]
+                ),
+            ),
+        )
+
+        spans = self.span_exporter.get_finished_spans()
+        assert len(spans) == 1, "Should finish the Runner span on final event"
+        assert spans[0].name == "invoke_agent test_app"
+        assert spans[0].attributes.get("gen_ai.span.kind") == "AGENT"
+        assert plugin._active_runner_invocations == {}
+
+    @pytest.mark.asyncio
+    async def test_runner_span_ignores_non_root_final_event(self):
+        """Sub-agent final responses should not close the Runner span early."""
+        self.instrumentor.instrument(
+            tracer_provider=self.tracer_provider,
+            meter_provider=self.meter_provider,
+        )
+
+        plugin = self.instrumentor._plugin
+
+        mock_invocation_context = Mock()
+        mock_invocation_context.invocation_id = "run_subagent_final"
+        mock_invocation_context.app_name = "test_app"
+        mock_invocation_context.session = Mock()
+        mock_invocation_context.session.id = "session_subagent_final"
+        mock_invocation_context.agent = Mock()
+        mock_invocation_context.agent.name = "root_agent"
+
+        await plugin.before_run_callback(
+            invocation_context=mock_invocation_context
+        )
+        await plugin.on_event_callback(
+            invocation_context=mock_invocation_context,
+            event=Event(
+                author="child_agent",
+                content=types.Content(
+                    role="model", parts=[types.Part(text="child done")]
+                ),
+            ),
+        )
+
+        assert self.span_exporter.get_finished_spans() == ()
+        assert plugin._active_runner_invocations
+
+        await plugin.after_run_callback(
+            invocation_context=mock_invocation_context
+        )
+
+    @pytest.mark.asyncio
+    async def test_streaming_llm_span_finishes_on_final_response(
+        self, monkeypatch
+    ):
+        """Streaming partial chunks should accumulate before ending one LLM span."""
+        # The util reads this setting when serializing span attributes.
+        monkeypatch.setenv(
+            "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT",
+            "SPAN_ONLY",
+        )
+        self.instrumentor.instrument(
+            tracer_provider=self.tracer_provider,
+            meter_provider=self.meter_provider,
+        )
+
+        plugin = self.instrumentor._plugin
+
+        mock_llm_request = Mock()
+        mock_llm_request.model = "gemini-pro"
+        mock_llm_request.config = Mock()
+        mock_llm_request.config.max_tokens = 1000
+        mock_llm_request.config.temperature = 0.7
+        mock_llm_request.config.top_p = 0.9
+        mock_llm_request.contents = [
+            types.Content(
+                role="user", parts=[types.Part(text="stream please")]
+            )
+        ]
+
+        mock_callback_context = create_mock_callback_context(
+            "stream_session", "stream_user", "stream_invocation"
+        )
+
+        start_time = timeit.default_timer()
+        await plugin.before_model_callback(
+            callback_context=mock_callback_context,
+            llm_request=mock_llm_request,
+        )
+
+        await plugin.after_model_callback(
+            callback_context=mock_callback_context,
+            llm_response=create_mock_llm_response(
+                model_version="gemini-pro-001",
+                content=types.Content(
+                    role="model", parts=[types.Part(text="Part")]
+                ),
+                partial=True,
+            ),
+        )
+        first_partial_end_time = timeit.default_timer()
+        assert len(self.span_exporter.get_finished_spans()) == 0
+        await asyncio.sleep(0.05)
+
+        await plugin.after_model_callback(
+            callback_context=mock_callback_context,
+            llm_response=create_mock_llm_response(
+                model_version="gemini-pro-001",
+                content=types.Content(
+                    role="model", parts=[types.Part(text="Partial")]
+                ),
+                partial=False,
+                finish_reason=types.FinishReason.STOP,
+            ),
+        )
+        end_time = timeit.default_timer()
+
+        spans = self.span_exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.attributes.get("gen_ai.span.kind") == "LLM"
+        assert span.attributes.get("gen_ai.response.model") == "gemini-pro-001"
+        ttft_ns = span.attributes.get("gen_ai.response.time_to_first_token")
+        assert isinstance(ttft_ns, int)
+        assert ttft_ns > 0
+        assert (
+            ttft_ns
+            <= int((first_partial_end_time - start_time) * 1_000_000_000)
+            + 1_000_000
+        )
+        assert ttft_ns < int((end_time - start_time) * 1_000_000_000) - (
+            20 * 1_000_000
+        )
+        assert '"Partial"' in span.attributes.get("gen_ai.output.messages", "")
+
+    @pytest.mark.asyncio
+    async def test_concurrent_llm_callbacks_same_session_do_not_cross_finish(
+        self,
+    ):
+        """Concurrent calls in the same ADK session should keep their own spans."""
+        self.instrumentor.instrument(
+            tracer_provider=self.tracer_provider,
+            meter_provider=self.meter_provider,
+        )
+
+        plugin = self.instrumentor._plugin
+
+        request_one = Mock()
+        request_one.model = "gemini-pro-one"
+        request_one.config = None
+        request_one.contents = []
+
+        request_two = Mock()
+        request_two.model = "gemini-pro-two"
+        request_two.config = None
+        request_two.contents = []
+
+        context_one = create_mock_callback_context(
+            "shared_session", "user_one", "invocation_one"
+        )
+        context_two = create_mock_callback_context(
+            "shared_session", "user_two", "invocation_two"
+        )
+
+        await plugin.before_model_callback(
+            callback_context=context_one, llm_request=request_one
+        )
+        await plugin.before_model_callback(
+            callback_context=context_two, llm_request=request_two
+        )
+
+        await plugin.after_model_callback(
+            callback_context=context_two,
+            llm_response=create_mock_llm_response(
+                model_version="gemini-pro-two-response"
+            ),
+        )
+        await plugin.after_model_callback(
+            callback_context=context_one,
+            llm_response=create_mock_llm_response(
+                model_version="gemini-pro-one-response"
+            ),
+        )
+
+        spans = self.span_exporter.get_finished_spans()
+        assert len(spans) == 2
+
+        response_by_request = {
+            span.attributes.get("gen_ai.request.model"): span.attributes.get(
+                "gen_ai.response.model"
+            )
+            for span in spans
+        }
+        assert response_by_request == {
+            "gemini-pro-one": "gemini-pro-one-response",
+            "gemini-pro-two": "gemini-pro-two-response",
+        }
+
+    @pytest.mark.asyncio
+    async def test_concurrent_llm_callbacks_same_invocation_use_task_context(
+        self,
+    ):
+        """Same-invocation concurrent LLM callbacks should finish their own span."""
+        self.instrumentor.instrument(
+            tracer_provider=self.tracer_provider,
+            meter_provider=self.meter_provider,
+        )
+
+        plugin = self.instrumentor._plugin
+
+        async def drive_call(request_model: str, response_model: str) -> None:
+            request = Mock()
+            request.model = request_model
+            request.config = None
+            request.contents = []
+            context = create_mock_callback_context(
+                "shared_session", "shared_user", "shared_invocation"
+            )
+            await plugin.before_model_callback(
+                callback_context=context,
+                llm_request=request,
+            )
+            await asyncio.sleep(0.01)
+            await plugin.after_model_callback(
+                callback_context=context,
+                llm_response=create_mock_llm_response(
+                    model_version=response_model
+                ),
+            )
+
+        await asyncio.gather(
+            drive_call("gemini-pro-one", "gemini-pro-one-response"),
+            drive_call("gemini-pro-two", "gemini-pro-two-response"),
+        )
+
+        spans = self.span_exporter.get_finished_spans()
+        assert len(spans) == 2
+        response_by_request = {
+            span.attributes.get("gen_ai.request.model"): span.attributes.get(
+                "gen_ai.response.model"
+            )
+            for span in spans
+        }
+        assert response_by_request == {
+            "gemini-pro-one": "gemini-pro-one-response",
+            "gemini-pro-two": "gemini-pro-two-response",
+        }
+
+    @pytest.mark.asyncio
+    async def test_concurrent_streaming_llm_outputs_do_not_cross(
+        self, monkeypatch
+    ):
+        """Interleaved streaming calls should keep output content isolated."""
+        monkeypatch.setenv(
+            "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT",
+            "SPAN_ONLY",
+        )
+        self.instrumentor.instrument(
+            tracer_provider=self.tracer_provider,
+            meter_provider=self.meter_provider,
+        )
+
+        plugin = self.instrumentor._plugin
+        partial_count = 0
+        all_partials_seen = asyncio.Event()
+        partial_lock = asyncio.Lock()
+
+        async def mark_partial_seen() -> None:
+            nonlocal partial_count
+            async with partial_lock:
+                partial_count += 1
+                if partial_count == 2:
+                    all_partials_seen.set()
+
+        async def drive_stream(
+            request_model: str, partial_text: str, final_text: str
+        ) -> None:
+            request = Mock()
+            request.model = request_model
+            request.config = None
+            request.contents = [
+                types.Content(
+                    role="user", parts=[types.Part(text=request_model)]
+                )
+            ]
+            context = create_mock_callback_context(
+                "shared_stream_session",
+                "shared_stream_user",
+                "shared_stream_invocation",
+            )
+            await plugin.before_model_callback(
+                callback_context=context,
+                llm_request=request,
+            )
+            await plugin.after_model_callback(
+                callback_context=context,
+                llm_response=create_mock_llm_response(
+                    model_version=f"{request_model}-response",
+                    content=types.Content(
+                        role="model",
+                        parts=[types.Part(text=partial_text)],
+                    ),
+                    partial=True,
+                ),
+            )
+            await mark_partial_seen()
+            await all_partials_seen.wait()
+            await plugin.after_model_callback(
+                callback_context=context,
+                llm_response=create_mock_llm_response(
+                    model_version=f"{request_model}-response",
+                    content=types.Content(
+                        role="model",
+                        parts=[types.Part(text=final_text)],
+                    ),
+                    partial=False,
+                ),
+            )
+
+        await asyncio.gather(
+            drive_stream("gemini-alpha", "Al", "Alpha done"),
+            drive_stream("gemini-beta", "Be", "Beta done"),
+        )
+
+        spans = self.span_exporter.get_finished_spans()
+        assert len(spans) == 2
+        outputs_by_request = {
+            span.attributes.get("gen_ai.request.model"): span.attributes.get(
+                "gen_ai.output.messages", ""
+            )
+            for span in spans
+        }
+        assert '"Alpha done"' in outputs_by_request["gemini-alpha"]
+        assert '"Beta done"' not in outputs_by_request["gemini-alpha"]
+        assert '"Beta done"' in outputs_by_request["gemini-beta"]
+        assert '"Alpha done"' not in outputs_by_request["gemini-beta"]
+
+    @pytest.mark.asyncio
+    async def test_concurrent_agent_callbacks_same_session_do_not_overwrite(
+        self,
+    ):
+        """Agent spans use invocation id so same-session concurrent runs survive."""
+        self.instrumentor.instrument(
+            tracer_provider=self.tracer_provider,
+            meter_provider=self.meter_provider,
+        )
+
+        plugin = self.instrumentor._plugin
+
+        mock_agent = Mock()
+        mock_agent.name = "weather_agent"
+        mock_agent.description = "Agent for weather queries"
+
+        context_one = create_mock_callback_context(
+            "shared_agent_session", "user_one", "agent_invocation_one"
+        )
+        context_two = create_mock_callback_context(
+            "shared_agent_session", "user_two", "agent_invocation_two"
+        )
+
+        await plugin.before_agent_callback(
+            agent=mock_agent, callback_context=context_one
+        )
+        await plugin.before_agent_callback(
+            agent=mock_agent, callback_context=context_two
+        )
+        await plugin.after_agent_callback(
+            agent=mock_agent, callback_context=context_two
+        )
+        await plugin.after_agent_callback(
+            agent=mock_agent, callback_context=context_one
+        )
+
+        spans = self.span_exporter.get_finished_spans()
+        assert len(spans) == 2
+        assert all(
+            span.attributes.get("gen_ai.span.kind") == "AGENT"
+            for span in spans
+        )
+        assert {span.attributes.get("enduser.id") for span in spans} == {
+            "user_one",
+            "user_two",
+        }
+
+    @pytest.mark.asyncio
+    async def test_tool_error_creates_error_span(self):
+        """Tool errors should finish the execute_tool span with error fields."""
+        self.instrumentor.instrument(
+            tracer_provider=self.tracer_provider,
+            meter_provider=self.meter_provider,
+        )
+
+        plugin = self.instrumentor._plugin
+
+        mock_tool = Mock()
+        mock_tool.name = "calculator"
+        mock_tool.description = "Mathematical calculator"
+        tool_args = {"operation": "divide", "a": 1, "b": 0}
+        mock_tool_context = Mock()
+        mock_tool_context.call_id = "tool_call_error"
+        mock_tool_context._invocation_context = Mock()
+        mock_tool_context._invocation_context.invocation_id = (
+            "tool_error_invocation"
+        )
+
+        await plugin.before_tool_callback(
+            tool=mock_tool,
+            tool_args=tool_args,
+            tool_context=mock_tool_context,
+        )
+        await plugin.on_tool_error_callback(
+            tool=mock_tool,
+            tool_args=tool_args,
+            tool_context=mock_tool_context,
+            error=ValueError("division by zero"),
+        )
+
+        spans = self.span_exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        assert span.name == "execute_tool calculator"
+        assert span.status.status_code == trace_api.StatusCode.ERROR
+        assert "division by zero" in span.status.description
+        assert span.attributes.get("error.type") == "ValueError"
+
+    @pytest.mark.asyncio
+    async def test_no_content_mode_does_not_capture_message_payloads(
+        self, monkeypatch
+    ):
+        """Default NO_CONTENT mode should not serialize prompt or response text."""
+        monkeypatch.delenv(
+            "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT",
+            raising=False,
+        )
+        self.instrumentor.instrument(
+            tracer_provider=self.tracer_provider,
+            meter_provider=self.meter_provider,
+        )
+
+        plugin = self.instrumentor._plugin
+
+        mock_llm_request = Mock()
+        mock_llm_request.model = "gemini-pro"
+        mock_llm_request.config = None
+        mock_llm_request.contents = [
+            types.Content(
+                role="user", parts=[types.Part(text="private prompt")]
+            )
+        ]
+        mock_callback_context = create_mock_callback_context(
+            "no_content_session", "no_content_user"
+        )
+
+        await plugin.before_model_callback(
+            callback_context=mock_callback_context,
+            llm_request=mock_llm_request,
+        )
+        await plugin.after_model_callback(
+            callback_context=mock_callback_context,
+            llm_response=create_mock_llm_response(
+                model_version="gemini-pro-001",
+                content=types.Content(
+                    role="model", parts=[types.Part(text="private response")]
+                ),
+            ),
+        )
+
+        spans = self.span_exporter.get_finished_spans()
+        assert len(spans) == 1
+        attributes = spans[0].attributes
+        assert "gen_ai.input.messages" not in attributes
+        assert "gen_ai.output.messages" not in attributes
 
     @pytest.mark.asyncio
     async def test_error_handling_attributes(self):


### PR DESCRIPTION
# Description

This PR updates the LoongSuite Google ADK instrumentation to construct GenAI spans through the shared GenAI util lifecycle, preserving streaming state, concurrent invocations, response metadata, and `gen_ai.span.kind` attributes for agent/tool/LLM spans. It also adds a local otel-gui smoke example covering non-streaming, streaming, and concurrent Google ADK calls, updates documentation, and expands tests for callback concurrency and runner span finalization.

Fixes # (N/A)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] `tox -e precommit`
- [x] `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=SPAN_ONLY python -m tox -c tox-loongsuite.ini -e py312-test-loongsuite-instrumentation-google-adk-latest`
- [x] `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=SPAN_ONLY python -m tox -c tox-loongsuite.ini -e py39-test-loongsuite-instrumentation-google-adk-latest`
- [x] `python -m tox -c tox-loongsuite.ini -e lint-loongsuite-instrumentation-google-adk`
- [x] `python instrumentation-loongsuite/loongsuite-instrumentation-google-adk/examples/otelgui_smoke.py --scenario all`

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR:
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
