### PR TITLE
chore(ci): scope LoongSuite tests to changed packages

### DIFF
--- a/.github/scripts/detect_loongsuite_changes.py
+++ b/.github/scripts/detect_loongsuite_changes.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import PurePosixPath
+
+FULL_RUN_LABELS = {"prepare-release", "backport"}
+FULL_RUN_PREFIXES = (
+    ".github/scripts/detect_loongsuite_changes.py",
+    ".github/workflows/generate_workflows_loongsuite.py",
+    ".github/workflows/generate_workflows_lib/src/generate_workflows_lib/",
+    ".github/workflows/loongsuite_",
+    "loongsuite-distro/",
+    "loongsuite-site-bootstrap/",
+    "scripts/loongsuite/",
+)
+FULL_RUN_FILES = {
+    ".pre-commit-config.yaml",
+    ".pylintrc",
+    "dev-requirements.txt",
+    "eachdist.ini",
+    "gen-requirements.txt",
+    "pkg-requirements.txt",
+    "pyproject.toml",
+    "pytest.ini",
+    "test-constraints.txt",
+    "tox-loongsuite.ini",
+    "tox-uv.toml",
+    "uv.lock",
+}
+UTIL_GENAI_PREFIX = "util/opentelemetry-util-genai/"
+LOONGSUITE_INSTRUMENTATION_PREFIX = "instrumentation-loongsuite/"
+
+
+def _load_event() -> dict:
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path:
+        return {}
+
+    try:
+        with open(event_path, encoding="utf-8") as event_file:
+            return json.load(event_file)
+    except OSError as exc:
+        print(f"Unable to read GitHub event: {exc}", file=sys.stderr)
+        return {}
+
+
+def _run_git_diff(base_ref: str) -> list[str]:
+    completed = subprocess.run(
+        ["git", "diff", "--name-only", f"{base_ref}...HEAD"],
+        check=True,
+        encoding="utf-8",
+        stdout=subprocess.PIPE,
+    )
+    return [
+        line.strip()
+        for line in completed.stdout.splitlines()
+        if line.strip()
+    ]
+
+
+def _changed_files(event: dict) -> list[str]:
+    changed_files = os.environ.get("LOONGSUITE_CHANGED_FILES")
+    if changed_files:
+        return [
+            line.strip()
+            for line in changed_files.splitlines()
+            if line.strip()
+        ]
+
+    pull_request = event.get("pull_request", {})
+    base_sha = pull_request.get("base", {}).get("sha")
+    if not base_sha:
+        raise RuntimeError("pull request base SHA is unavailable")
+
+    return _run_git_diff(base_sha)
+
+
+def _has_full_run_label(event: dict) -> bool:
+    pull_request = event.get("pull_request", {})
+    labels = {
+        label.get("name")
+        for label in pull_request.get("labels", [])
+        if label.get("name")
+    }
+    return bool(labels & FULL_RUN_LABELS)
+
+
+def _is_release_pull_request(event: dict) -> bool:
+    pull_request = event.get("pull_request", {})
+    base_ref = pull_request.get("base", {}).get("ref", "")
+    head_ref = pull_request.get("head", {}).get("ref", "")
+    return base_ref.startswith("release/") or head_ref.startswith("release/")
+
+
+def _package_for_path(path: str) -> str | None:
+    normalized = path.strip("/")
+    if not normalized.startswith(LOONGSUITE_INSTRUMENTATION_PREFIX):
+        return None
+
+    package_path = PurePosixPath(normalized)
+    if len(package_path.parts) < 2:
+        return None
+
+    package = package_path.parts[1]
+    if package.startswith("loongsuite-instrumentation-"):
+        return package
+
+    return None
+
+
+def _requires_full_run(path: str) -> bool:
+    normalized = path.strip("/")
+    return (
+        normalized in FULL_RUN_FILES
+        or normalized.startswith(FULL_RUN_PREFIXES)
+        or normalized.startswith(UTIL_GENAI_PREFIX)
+    )
+
+
+def _write_outputs(outputs: dict[str, str]) -> None:
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        return
+
+    with open(output_path, "a", encoding="utf-8") as output_file:
+        for name, value in outputs.items():
+            output_file.write(f"{name}={value}\n")
+
+
+def main() -> int:
+    event_name = os.environ.get("GITHUB_EVENT_NAME", "")
+    event = _load_event()
+
+    full = event_name != "pull_request"
+    packages: set[str] = set()
+    reason = "non-pull-request event"
+
+    if not full and (
+        _has_full_run_label(event) or _is_release_pull_request(event)
+    ):
+        full = True
+        reason = "release or backport pull request"
+
+    if not full:
+        try:
+            changed_files = _changed_files(event)
+        except (RuntimeError, subprocess.CalledProcessError) as exc:
+            full = True
+            reason = f"could not determine changed files: {exc}"
+        else:
+            for changed_file in changed_files:
+                if _requires_full_run(changed_file):
+                    full = True
+                    reason = f"shared LoongSuite file changed: {changed_file}"
+                    break
+
+                package = _package_for_path(changed_file)
+                if package:
+                    packages.add(package)
+
+            if not full:
+                if packages:
+                    reason = "package-scoped LoongSuite change"
+                else:
+                    reason = "no LoongSuite package changes"
+
+    package_output = "|" + "|".join(sorted(packages)) + "|"
+    outputs = {
+        "full": str(full).lower(),
+        "packages": package_output,
+        "reason": reason.replace("\n", " "),
+    }
+    _write_outputs(outputs)
+
+    print(f"full={outputs['full']}")
+    print(f"packages={outputs['packages']}")
+    print(f"reason={outputs['reason']}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/detect_loongsuite_changes.py
+++ b/.github/scripts/detect_loongsuite_changes.py
@@ -29,7 +29,6 @@ FULL_RUN_FILES = {
     "pyproject.toml",
     "pytest.ini",
     "test-constraints.txt",
-    "tox-loongsuite.ini",
     "tox-uv.toml",
     "uv.lock",
 }
@@ -42,11 +41,17 @@ FULL_RUN_PREFIXES = (
     "loongsuite-site-bootstrap/",
     "scripts/loongsuite/",
 )
+TOX_LOONGSUITE_INI_PATH = "tox-loongsuite.ini"
 UTIL_GENAI_PREFIX = "util/opentelemetry-util-genai/"
 LOONGSUITE_INSTRUMENTATION_PREFIX = "instrumentation-loongsuite/"
 DOC_ONLY_SUFFIXES = (".md", ".rst")
 REPO_ROOT = Path.cwd()
-TOX_LOONGSUITE_INI = REPO_ROOT / "tox-loongsuite.ini"
+TOX_LOONGSUITE_INI = REPO_ROOT / TOX_LOONGSUITE_INI_PATH
+PACKAGE_MENTION_RE = re.compile(
+    r"(?<![A-Za-z0-9])"
+    r"(?P<package>loongsuite-instrumentation-[A-Za-z0-9-]+|util-genai)"
+    r"(?![A-Za-z0-9-])"
+)
 
 
 def _load_event() -> dict:
@@ -92,6 +97,15 @@ def _git_ref_exists(ref: str) -> bool:
     )
 
 
+def _pull_request_base_sha(event: dict) -> str:
+    pull_request = event.get("pull_request", {})
+    base_sha = pull_request.get("base", {}).get("sha")
+    if not base_sha:
+        raise RuntimeError("pull request base SHA is unavailable")
+
+    return base_sha
+
+
 def _changed_files(event: dict) -> list[str]:
     if "LOONGSUITE_CHANGED_FILES" in os.environ:
         changed_files = os.environ["LOONGSUITE_CHANGED_FILES"]
@@ -99,12 +113,7 @@ def _changed_files(event: dict) -> list[str]:
             line.strip() for line in changed_files.splitlines() if line.strip()
         ]
 
-    pull_request = event.get("pull_request", {})
-    base_sha = pull_request.get("base", {}).get("sha")
-    if not base_sha:
-        raise RuntimeError("pull request base SHA is unavailable")
-
-    return _run_git_diff(base_sha)
+    return _run_git_diff(_pull_request_base_sha(event))
 
 
 def _has_full_run_label(event: dict) -> bool:
@@ -143,12 +152,10 @@ def _loongsuite_package_from_path(path: str) -> str | None:
 def _known_loongsuite_packages() -> set[str]:
     text = TOX_LOONGSUITE_INI.read_text(encoding="utf-8")
     packages = set()
-    for match in re.finditer(
-        r"(?:test|lint)-(?P<package>"
-        r"(?:loongsuite-instrumentation-[A-Za-z0-9-]+|util-genai))",
-        text,
-    ):
-        packages.add(match.group("package").rstrip("-"))
+    for line in text.splitlines():
+        if line.lstrip().startswith(";"):
+            continue
+        packages.update(_package_mentions(line))
 
     return packages
 
@@ -174,6 +181,89 @@ def _requires_full_run(path: str) -> bool:
         or normalized.startswith(FULL_RUN_PREFIXES)
         or normalized.startswith(UTIL_GENAI_PREFIX)
     )
+
+
+def _is_generated_loongsuite_workflow(path: str) -> bool:
+    normalized = path.strip("/")
+    return (
+        re.fullmatch(
+            r"\.github/workflows/loongsuite_(?:lint|misc|test)_\d+\.yml",
+            normalized,
+        )
+        is not None
+    )
+
+
+def _tox_diff(base_ref: str) -> str:
+    if "LOONGSUITE_TOX_DIFF" in os.environ:
+        return os.environ["LOONGSUITE_TOX_DIFF"]
+
+    if not _git_ref_exists(base_ref):
+        subprocess.run(
+            ["git", "fetch", "--no-tags", "--depth=1", "origin", base_ref],
+            check=True,
+        )
+
+    completed = subprocess.run(
+        [
+            "git",
+            "diff",
+            "--unified=0",
+            f"{base_ref}...HEAD",
+            "--",
+            TOX_LOONGSUITE_INI_PATH,
+        ],
+        check=True,
+        encoding="utf-8",
+        stdout=subprocess.PIPE,
+    )
+    return completed.stdout
+
+
+def _changed_tox_lines(diff_text: str) -> list[str]:
+    lines = []
+    for line in diff_text.splitlines():
+        if not line.startswith(("+", "-")) or line.startswith(("+++", "---")):
+            continue
+
+        content = line[1:].strip()
+        if not content or content.startswith(";"):
+            continue
+
+        lines.append(content)
+
+    return lines
+
+
+def _package_mentions(text: str) -> set[str]:
+    return {
+        match.group("package") for match in PACKAGE_MENTION_RE.finditer(text)
+    }
+
+
+def _packages_from_text(text: str, known_packages: set[str]) -> set[str]:
+    return _package_mentions(text) & known_packages
+
+
+def _packages_from_tox_changes(
+    base_ref: str,
+    known_packages: set[str],
+) -> tuple[set[str], list[str]]:
+    packages = set()
+    unscoped_lines = []
+
+    for line in _changed_tox_lines(_tox_diff(base_ref)):
+        if "util-genai" in _package_mentions(line):
+            unscoped_lines.append(line)
+            continue
+
+        line_packages = _packages_from_text(line, known_packages)
+        if line_packages:
+            packages.update(line_packages)
+        else:
+            unscoped_lines.append(line)
+
+    return packages, unscoped_lines
 
 
 def _write_outputs(outputs: dict[str, str]) -> None:
@@ -217,9 +307,19 @@ def _detect_outputs() -> dict[str, str]:
 
     packages: set[str] = set()
     unknown_packages: set[str] = set()
+    tox_changed = False
     changed_files = _changed_files(event)
     if not changed_files:
         return _full_outputs("unable to compute changed files", degraded=True)
+    tox_base_sha = None
+    if any(
+        changed_file.strip("/") == TOX_LOONGSUITE_INI_PATH
+        for changed_file in changed_files
+    ):
+        try:
+            tox_base_sha = _pull_request_base_sha(event)
+        except RuntimeError as exc:
+            return _full_outputs(str(exc), degraded=True)
 
     known_packages = _known_loongsuite_packages()
     if not known_packages:
@@ -229,6 +329,14 @@ def _detect_outputs() -> dict[str, str]:
         )
 
     for changed_file in changed_files:
+        normalized = changed_file.strip("/")
+        if _is_generated_loongsuite_workflow(normalized):
+            continue
+
+        if normalized == TOX_LOONGSUITE_INI_PATH:
+            tox_changed = True
+            continue
+
         if _requires_full_run(changed_file):
             return _full_outputs(
                 f"shared LoongSuite file changed: {changed_file}"
@@ -242,6 +350,17 @@ def _detect_outputs() -> dict[str, str]:
             unknown_packages.add(package)
         else:
             packages.add(package)
+
+    if tox_changed:
+        tox_packages, unscoped_lines = _packages_from_tox_changes(
+            tox_base_sha,
+            known_packages,
+        )
+        if unscoped_lines:
+            return _full_outputs(
+                "shared tox-loongsuite.ini change: " + unscoped_lines[0]
+            )
+        packages.update(tox_packages)
 
     if unknown_packages:
         package_list = ", ".join(sorted(unknown_packages))

--- a/.github/scripts/detect_loongsuite_changes.py
+++ b/.github/scripts/detect_loongsuite_changes.py
@@ -1,23 +1,25 @@
 #!/usr/bin/env python3
+"""Detect changed LoongSuite packages for generated GitHub Actions jobs.
+
+Inputs come from the GitHub Actions environment:
+- GITHUB_EVENT_NAME and GITHUB_EVENT_PATH describe the current event.
+- LOONGSUITE_CHANGED_FILES can inject a newline-separated file list in tests.
+- GITHUB_OUTPUT receives full/packages/degraded/reason outputs.
+"""
+
 from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 
 FULL_RUN_LABELS = {"prepare-release", "backport"}
-FULL_RUN_PREFIXES = (
+FULL_RUN_FILES = {
     ".github/scripts/detect_loongsuite_changes.py",
     ".github/workflows/generate_workflows_loongsuite.py",
-    ".github/workflows/generate_workflows_lib/src/generate_workflows_lib/",
-    ".github/workflows/loongsuite_",
-    "loongsuite-distro/",
-    "loongsuite-site-bootstrap/",
-    "scripts/loongsuite/",
-)
-FULL_RUN_FILES = {
     ".pre-commit-config.yaml",
     ".pylintrc",
     "dev-requirements.txt",
@@ -31,8 +33,20 @@ FULL_RUN_FILES = {
     "tox-uv.toml",
     "uv.lock",
 }
+FULL_RUN_PREFIXES = (
+    ".github/scripts/tests/",
+    ".github/workflows/generate_workflows_lib/src/generate_workflows_lib/",
+    ".github/workflows/loongsuite_",
+    ".github/workflows/loongsuite-",
+    "loongsuite-distro/",
+    "loongsuite-site-bootstrap/",
+    "scripts/loongsuite/",
+)
 UTIL_GENAI_PREFIX = "util/opentelemetry-util-genai/"
 LOONGSUITE_INSTRUMENTATION_PREFIX = "instrumentation-loongsuite/"
+DOC_ONLY_SUFFIXES = (".md", ".rst")
+REPO_ROOT = Path.cwd()
+TOX_LOONGSUITE_INI = REPO_ROOT / "tox-loongsuite.ini"
 
 
 def _load_event() -> dict:
@@ -49,6 +63,12 @@ def _load_event() -> dict:
 
 
 def _run_git_diff(base_ref: str) -> list[str]:
+    if not _git_ref_exists(base_ref):
+        subprocess.run(
+            ["git", "fetch", "--no-tags", "--depth=1", "origin", base_ref],
+            check=True,
+        )
+
     completed = subprocess.run(
         ["git", "diff", "--name-only", f"{base_ref}...HEAD"],
         check=True,
@@ -56,19 +76,27 @@ def _run_git_diff(base_ref: str) -> list[str]:
         stdout=subprocess.PIPE,
     )
     return [
-        line.strip()
-        for line in completed.stdout.splitlines()
-        if line.strip()
+        line.strip() for line in completed.stdout.splitlines() if line.strip()
     ]
 
 
+def _git_ref_exists(ref: str) -> bool:
+    return (
+        subprocess.run(
+            ["git", "cat-file", "-e", ref],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
 def _changed_files(event: dict) -> list[str]:
-    changed_files = os.environ.get("LOONGSUITE_CHANGED_FILES")
-    if changed_files:
+    if "LOONGSUITE_CHANGED_FILES" in os.environ:
+        changed_files = os.environ["LOONGSUITE_CHANGED_FILES"]
         return [
-            line.strip()
-            for line in changed_files.splitlines()
-            if line.strip()
+            line.strip() for line in changed_files.splitlines() if line.strip()
         ]
 
     pull_request = event.get("pull_request", {})
@@ -96,7 +124,7 @@ def _is_release_pull_request(event: dict) -> bool:
     return base_ref.startswith("release/") or head_ref.startswith("release/")
 
 
-def _package_for_path(path: str) -> str | None:
+def _loongsuite_package_from_path(path: str) -> str | None:
     normalized = path.strip("/")
     if not normalized.startswith(LOONGSUITE_INSTRUMENTATION_PREFIX):
         return None
@@ -110,6 +138,33 @@ def _package_for_path(path: str) -> str | None:
         return package
 
     return None
+
+
+def _known_loongsuite_packages() -> set[str]:
+    text = TOX_LOONGSUITE_INI.read_text(encoding="utf-8")
+    packages = set()
+    for match in re.finditer(
+        r"(?:test|lint)-(?P<package>"
+        r"(?:loongsuite-instrumentation-[A-Za-z0-9-]+|util-genai))",
+        text,
+    ):
+        packages.add(match.group("package").rstrip("-"))
+
+    return packages
+
+
+def _is_doc_only_package_path(path: str) -> bool:
+    package_path = PurePosixPath(path.strip("/"))
+    if len(package_path.parts) <= 2:
+        return False
+
+    relative_parts = package_path.parts[2:]
+    filename = relative_parts[-1]
+    if filename.startswith("CHANGELOG"):
+        return True
+    if filename.endswith(DOC_ONLY_SUFFIXES):
+        return True
+    return "docs" in relative_parts
 
 
 def _requires_full_run(path: str) -> bool:
@@ -131,54 +186,98 @@ def _write_outputs(outputs: dict[str, str]) -> None:
             output_file.write(f"{name}={value}\n")
 
 
-def main() -> int:
+def _full_outputs(reason: str, *, degraded: bool = False) -> dict[str, str]:
+    return {
+        "full": "true",
+        "packages": "||",
+        "degraded": str(degraded).lower(),
+        "reason": reason.replace("\n", " "),
+    }
+
+
+def _package_outputs(packages: set[str], reason: str) -> dict[str, str]:
+    package_output = "|" + "|".join(sorted(packages)) + "|"
+    return {
+        "full": "false",
+        "packages": package_output,
+        "degraded": "false",
+        "reason": reason.replace("\n", " "),
+    }
+
+
+def _detect_outputs() -> dict[str, str]:
     event_name = os.environ.get("GITHUB_EVENT_NAME", "")
     event = _load_event()
 
-    full = event_name != "pull_request"
+    if event_name != "pull_request":
+        return _full_outputs("non-pull-request event")
+
+    if _has_full_run_label(event) or _is_release_pull_request(event):
+        return _full_outputs("release or backport pull request")
+
     packages: set[str] = set()
-    reason = "non-pull-request event"
+    unknown_packages: set[str] = set()
+    changed_files = _changed_files(event)
+    if not changed_files:
+        return _full_outputs("unable to compute changed files", degraded=True)
 
-    if not full and (
-        _has_full_run_label(event) or _is_release_pull_request(event)
-    ):
-        full = True
-        reason = "release or backport pull request"
+    known_packages = _known_loongsuite_packages()
+    if not known_packages:
+        return _full_outputs(
+            "unable to determine registered LoongSuite packages",
+            degraded=True,
+        )
 
-    if not full:
-        try:
-            changed_files = _changed_files(event)
-        except (RuntimeError, subprocess.CalledProcessError) as exc:
-            full = True
-            reason = f"could not determine changed files: {exc}"
+    for changed_file in changed_files:
+        if _requires_full_run(changed_file):
+            return _full_outputs(
+                f"shared LoongSuite file changed: {changed_file}"
+            )
+
+        package = _loongsuite_package_from_path(changed_file)
+        if not package or _is_doc_only_package_path(changed_file):
+            continue
+
+        if package not in known_packages:
+            unknown_packages.add(package)
         else:
-            for changed_file in changed_files:
-                if _requires_full_run(changed_file):
-                    full = True
-                    reason = f"shared LoongSuite file changed: {changed_file}"
-                    break
+            packages.add(package)
 
-                package = _package_for_path(changed_file)
-                if package:
-                    packages.add(package)
+    if unknown_packages:
+        package_list = ", ".join(sorted(unknown_packages))
+        print(
+            "::error::Changed LoongSuite package is not registered in "
+            f"tox-loongsuite.ini: {package_list}",
+            file=sys.stderr,
+        )
+        return _full_outputs(
+            f"unknown LoongSuite package changed: {package_list}"
+        )
 
-            if not full:
-                if packages:
-                    reason = "package-scoped LoongSuite change"
-                else:
-                    reason = "no LoongSuite package changes"
+    if packages:
+        return _package_outputs(packages, "package-scoped LoongSuite change")
 
-    package_output = "|" + "|".join(sorted(packages)) + "|"
-    outputs = {
-        "full": str(full).lower(),
-        "packages": package_output,
-        "reason": reason.replace("\n", " "),
-    }
-    _write_outputs(outputs)
+    return _package_outputs(set(), "no LoongSuite package changes")
 
+
+def _print_outputs(outputs: dict[str, str]) -> None:
     print(f"full={outputs['full']}")
     print(f"packages={outputs['packages']}")
+    print(f"degraded={outputs['degraded']}")
     print(f"reason={outputs['reason']}")
+
+
+def main() -> int:
+    try:
+        outputs = _detect_outputs()
+    except Exception as exc:  # noqa: BLE001 - CI must fall back to full run.
+        outputs = _full_outputs(
+            f"unexpected detector failure: {type(exc).__name__}: {exc}",
+            degraded=True,
+        )
+
+    _write_outputs(outputs)
+    _print_outputs(outputs)
 
     return 0
 

--- a/.github/scripts/tests/test_detect_loongsuite_changes.py
+++ b/.github/scripts/tests/test_detect_loongsuite_changes.py
@@ -13,7 +13,14 @@ detect = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(detect)
 
 
-def _run_detector(monkeypatch, tmp_path, changed_files=None, event=None):
+def _run_detector(
+    monkeypatch,
+    tmp_path,
+    changed_files=None,
+    event=None,
+    known_packages=None,
+    tox_diff=None,
+):
     output_path = tmp_path / "github-output"
     monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
     monkeypatch.setenv("GITHUB_OUTPUT", str(output_path))
@@ -32,6 +39,18 @@ def _run_detector(monkeypatch, tmp_path, changed_files=None, event=None):
         monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
     else:
         monkeypatch.delenv("GITHUB_EVENT_PATH", raising=False)
+
+    if known_packages is not None:
+        monkeypatch.setattr(
+            detect,
+            "_known_loongsuite_packages",
+            lambda: set(known_packages),
+        )
+
+    if tox_diff is None:
+        monkeypatch.delenv("LOONGSUITE_TOX_DIFF", raising=False)
+    else:
+        monkeypatch.setenv("LOONGSUITE_TOX_DIFF", tox_diff)
 
     assert detect.main() == 0
 
@@ -97,6 +116,183 @@ def test_unknown_package_falls_back_to_full(monkeypatch, tmp_path, capsys):
     assert outputs["full"] == "true"
     assert "loongsuite-instrumentation-newpkg" in outputs["reason"]
     assert "::error::" in captured.err
+
+
+def test_new_plugin_with_generated_workflows_is_package_scoped(
+    monkeypatch,
+    tmp_path,
+):
+    outputs = _run_detector(
+        monkeypatch,
+        tmp_path,
+        [
+            "instrumentation-loongsuite/"
+            "loongsuite-instrumentation-deepagents/src/package.py",
+            "instrumentation-loongsuite/"
+            "loongsuite-instrumentation-deepagents/tests/test_package.py",
+            "instrumentation-loongsuite/"
+            "loongsuite-instrumentation-langchain/src/package.py",
+            "tox-loongsuite.ini",
+            ".github/workflows/loongsuite_test_0.yml",
+            ".github/workflows/loongsuite_lint_0.yml",
+        ],
+        {"pull_request": {"base": {"sha": "base-sha"}}},
+        {
+            "loongsuite-instrumentation-deepagents",
+            "loongsuite-instrumentation-langchain",
+        },
+        "\n".join(
+            [
+                "+    ; loongsuite-instrumentation-deepagents",
+                "+    py3{10,11,12,13}-test-"
+                "loongsuite-instrumentation-deepagents",
+                "+    lint-loongsuite-instrumentation-deepagents",
+                "+  deepagents: -r {toxinidir}/instrumentation-loongsuite/"
+                "loongsuite-instrumentation-deepagents/tests/"
+                "test-requirements.txt",
+                "+  test-loongsuite-instrumentation-deepagents: pytest "
+                "{toxinidir}/instrumentation-loongsuite/"
+                "loongsuite-instrumentation-deepagents/tests {posargs}",
+            ]
+        ),
+    )
+
+    assert outputs["full"] == "false"
+    assert outputs["packages"] == (
+        "|loongsuite-instrumentation-deepagents|"
+        "loongsuite-instrumentation-langchain|"
+    )
+
+
+def test_generated_workflow_only_change_skips_jobs(monkeypatch, tmp_path):
+    outputs = _run_detector(
+        monkeypatch,
+        tmp_path,
+        [".github/workflows/loongsuite_test_0.yml"],
+    )
+
+    assert outputs["full"] == "false"
+    assert outputs["packages"] == "||"
+
+
+def test_release_workflow_change_runs_full_suite(monkeypatch, tmp_path):
+    outputs = _run_detector(
+        monkeypatch,
+        tmp_path,
+        [".github/workflows/loongsuite-release.yml"],
+    )
+
+    assert outputs["full"] == "true"
+    assert (
+        outputs["reason"] == "shared LoongSuite file changed: "
+        ".github/workflows/loongsuite-release.yml"
+    )
+
+
+def test_unknown_loongsuite_workflow_change_runs_full_suite(
+    monkeypatch,
+    tmp_path,
+):
+    outputs = _run_detector(
+        monkeypatch,
+        tmp_path,
+        [".github/workflows/loongsuite_other_0.yml"],
+    )
+
+    assert outputs["full"] == "true"
+
+
+def test_generated_workflow_name_matching():
+    assert detect._is_generated_loongsuite_workflow(
+        ".github/workflows/loongsuite_test_10.yml"
+    )
+    assert not detect._is_generated_loongsuite_workflow(
+        ".github/workflows/loongsuite_other_0.yml"
+    )
+    assert not detect._is_generated_loongsuite_workflow(
+        ".github/workflows/loongsuite_test_0.yaml"
+    )
+    assert not detect._is_generated_loongsuite_workflow(
+        ".github/workflows/loongsuite-test_0.yml"
+    )
+
+
+def test_tox_only_scoped_change_runs_package_jobs(monkeypatch, tmp_path):
+    outputs = _run_detector(
+        monkeypatch,
+        tmp_path,
+        ["tox-loongsuite.ini"],
+        {"pull_request": {"base": {"sha": "base-sha"}}},
+        {"loongsuite-instrumentation-deepagents"},
+        "\n".join(
+            [
+                "+    py3{10,11,12,13}-test-"
+                "loongsuite-instrumentation-deepagents",
+                "+    lint-loongsuite-instrumentation-deepagents",
+            ]
+        ),
+    )
+
+    assert outputs["full"] == "false"
+    assert outputs["packages"] == "|loongsuite-instrumentation-deepagents|"
+
+
+def test_shared_tox_change_runs_full_suite(monkeypatch, tmp_path):
+    outputs = _run_detector(
+        monkeypatch,
+        tmp_path,
+        ["tox-loongsuite.ini"],
+        {"pull_request": {"base": {"sha": "base-sha"}}},
+        {"loongsuite-instrumentation-crewai"},
+        "+  CORE_REPO_SHA={env:CORE_REPO_SHA:main}",
+    )
+
+    assert outputs["full"] == "true"
+    assert outputs["reason"].startswith("shared tox-loongsuite.ini change:")
+
+
+def test_util_genai_tox_change_runs_full_suite(monkeypatch, tmp_path):
+    outputs = _run_detector(
+        monkeypatch,
+        tmp_path,
+        ["tox-loongsuite.ini"],
+        {"pull_request": {"base": {"sha": "base-sha"}}},
+        {"util-genai"},
+        "+    py3{10,11,12,13}-test-util-genai",
+    )
+
+    assert outputs["full"] == "true"
+    assert outputs["reason"].startswith("shared tox-loongsuite.ini change:")
+
+
+def test_package_mentions_do_not_match_package_prefixes():
+    assert detect._packages_from_text(
+        "lint-loongsuite-instrumentation-langchain-core",
+        {
+            "loongsuite-instrumentation-langchain",
+            "loongsuite-instrumentation-langchain-core",
+        },
+    ) == {"loongsuite-instrumentation-langchain-core"}
+
+
+def test_changed_tox_lines_ignores_headers_comments_and_blanks():
+    diff_text = "\n".join(
+        [
+            "diff --git a/tox-loongsuite.ini b/tox-loongsuite.ini",
+            "--- a/tox-loongsuite.ini",
+            "+++ b/tox-loongsuite.ini",
+            "@@ -1,0 +1,2 @@",
+            "+",
+            "+    ; loongsuite-instrumentation-deepagents",
+            "+    lint-loongsuite-instrumentation-deepagents",
+            "-    lint-loongsuite-instrumentation-langchain",
+        ]
+    )
+
+    assert detect._changed_tox_lines(diff_text) == [
+        "lint-loongsuite-instrumentation-deepagents",
+        "lint-loongsuite-instrumentation-langchain",
+    ]
 
 
 def test_empty_changed_files_is_degraded_full_run(monkeypatch, tmp_path):

--- a/.github/scripts/tests/test_detect_loongsuite_changes.py
+++ b/.github/scripts/tests/test_detect_loongsuite_changes.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).parents[1] / "detect_loongsuite_changes.py"
+SPEC = importlib.util.spec_from_file_location(
+    "detect_loongsuite_changes",
+    SCRIPT_PATH,
+)
+detect = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(detect)
+
+
+def _run_detector(monkeypatch, tmp_path, changed_files=None, event=None):
+    output_path = tmp_path / "github-output"
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "pull_request")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output_path))
+
+    if changed_files is None:
+        monkeypatch.delenv("LOONGSUITE_CHANGED_FILES", raising=False)
+    else:
+        monkeypatch.setenv(
+            "LOONGSUITE_CHANGED_FILES",
+            "\n".join(changed_files),
+        )
+
+    if event is not None:
+        event_path = tmp_path / "event.json"
+        event_path.write_text(json.dumps(event), encoding="utf-8")
+        monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
+    else:
+        monkeypatch.delenv("GITHUB_EVENT_PATH", raising=False)
+
+    assert detect.main() == 0
+
+    return dict(
+        line.split("=", 1)
+        for line in output_path.read_text(encoding="utf-8").splitlines()
+    )
+
+
+def test_scopes_single_package_change(monkeypatch, tmp_path):
+    outputs = _run_detector(
+        monkeypatch,
+        tmp_path,
+        [
+            "instrumentation-loongsuite/"
+            "loongsuite-instrumentation-crewai/src/package.py",
+            "instrumentation-loongsuite/"
+            "loongsuite-instrumentation-crewai/tests/test_package.py",
+        ],
+    )
+
+    assert outputs["full"] == "false"
+    assert outputs["packages"] == "|loongsuite-instrumentation-crewai|"
+    assert outputs["degraded"] == "false"
+
+
+def test_util_genai_change_runs_full_suite(monkeypatch, tmp_path):
+    outputs = _run_detector(
+        monkeypatch,
+        tmp_path,
+        ["util/opentelemetry-util-genai/src/opentelemetry/util/genai/foo.py"],
+    )
+
+    assert outputs["full"] == "true"
+    assert outputs["degraded"] == "false"
+
+
+def test_release_label_runs_full_suite(monkeypatch, tmp_path):
+    outputs = _run_detector(
+        monkeypatch,
+        tmp_path,
+        [
+            "instrumentation-loongsuite/loongsuite-instrumentation-crewai/foo.py"
+        ],
+        {"pull_request": {"labels": [{"name": "prepare-release"}]}},
+    )
+
+    assert outputs["full"] == "true"
+    assert outputs["reason"] == "release or backport pull request"
+
+
+def test_unknown_package_falls_back_to_full(monkeypatch, tmp_path, capsys):
+    outputs = _run_detector(
+        monkeypatch,
+        tmp_path,
+        [
+            "instrumentation-loongsuite/"
+            "loongsuite-instrumentation-newpkg/src/package.py"
+        ],
+    )
+
+    captured = capsys.readouterr()
+    assert outputs["full"] == "true"
+    assert "loongsuite-instrumentation-newpkg" in outputs["reason"]
+    assert "::error::" in captured.err
+
+
+def test_empty_changed_files_is_degraded_full_run(monkeypatch, tmp_path):
+    outputs = _run_detector(monkeypatch, tmp_path, [])
+
+    assert outputs["full"] == "true"
+    assert outputs["degraded"] == "true"
+    assert outputs["reason"] == "unable to compute changed files"
+
+
+def test_package_docs_only_change_skips_package(monkeypatch, tmp_path):
+    outputs = _run_detector(
+        monkeypatch,
+        tmp_path,
+        [
+            "instrumentation-loongsuite/"
+            "loongsuite-instrumentation-crewai/README.md",
+            "instrumentation-loongsuite/"
+            "loongsuite-instrumentation-crewai/CHANGELOG.md",
+        ],
+    )
+
+    assert outputs["full"] == "false"
+    assert outputs["packages"] == "||"
+
+
+def test_unexpected_detector_error_falls_back_to_full(monkeypatch, tmp_path):
+    def broken_changed_files(_event):
+        raise KeyError("boom")
+
+    monkeypatch.setattr(detect, "_changed_files", broken_changed_files)
+    outputs = _run_detector(monkeypatch, tmp_path, None)
+
+    assert outputs["full"] == "true"
+    assert outputs["degraded"] == "true"
+    assert "unexpected detector failure" in outputs["reason"]

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/__init__.py
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/__init__.py
@@ -16,13 +16,15 @@ _tox_lint_env_regex = re_compile(r"lint-(?P<name>[-\w]+)")
 _tox_contrib_env_regex = re_compile(
     r"py39-test-(?P<name>[-\w]+\w)-?(?P<contrib_requirements>\d+)?"
 )
-_loongsuite_test_variant_suffixes = ("-oldest", "-latest", "-legacy")
 
 
-def _get_loongsuite_package_name(name: str) -> str:
-    for suffix in _loongsuite_test_variant_suffixes:
-        if name.endswith(suffix):
-            return name[: -len(suffix)]
+def _get_job_package_name(name: str, package_names=None) -> str:
+    if package_names is None:
+        return name
+
+    for package_name in sorted(package_names, key=len, reverse=True):
+        if name == package_name or name.startswith(f"{package_name}-"):
+            return package_name
 
     return name
 
@@ -52,7 +54,11 @@ def get_tox_envs(tox_ini_path: Path) -> list:
     return core_config_set.load("env_list")
 
 
-def get_test_job_datas(tox_envs: list, operating_systems: list) -> list:
+def get_test_job_datas(
+    tox_envs: list,
+    operating_systems: list,
+    package_names=None,
+) -> list:
     os_alias = {"ubuntu-latest": "Ubuntu", "windows-latest": "Windows"}
 
     python_version_alias = {
@@ -99,7 +105,10 @@ def get_test_job_datas(tox_envs: list, operating_systems: list) -> list:
                         f"{aliased_python_version} "
                         f"{os_alias[operating_system]}"
                     ),
-                    "package": _get_loongsuite_package_name(groups["name"]),
+                    "package": _get_job_package_name(
+                        groups["name"],
+                        package_names,
+                    ),
                     "python_version": aliased_python_version,
                     "tox_env": tox_env,
                     "os": operating_system,
@@ -124,7 +133,9 @@ def get_lint_job_datas(tox_envs: list) -> list:
             {
                 "name": f"{tox_env}",
                 "ui_name": f"{tox_lint_env_match.groupdict()['name']}",
-                "package": tox_lint_env_match.groupdict()["name"],
+                "package": _get_job_package_name(
+                    tox_lint_env_match.groupdict()["name"]
+                ),
                 "tox_env": tox_env,
             }
         )
@@ -286,9 +297,16 @@ def generate_extension_test_workflow(
     loongsuite_envs = get_loongsuite_tox_envs(additional_config_path)
     if not loongsuite_envs:
         return
+    loongsuite_package_names = [
+        job_data["package"] for job_data in get_lint_job_datas(loongsuite_envs)
+    ]
 
     _generate_workflow_with_template(
-        get_test_job_datas(loongsuite_envs, list(operating_systems)),
+        get_test_job_datas(
+            loongsuite_envs,
+            list(operating_systems),
+            loongsuite_package_names,
+        ),
         "loongsuite_test",
         "loongsuite_test",
         workflow_directory_path,

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/__init__.py
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/__init__.py
@@ -16,6 +16,15 @@ _tox_lint_env_regex = re_compile(r"lint-(?P<name>[-\w]+)")
 _tox_contrib_env_regex = re_compile(
     r"py39-test-(?P<name>[-\w]+\w)-?(?P<contrib_requirements>\d+)?"
 )
+_loongsuite_test_variant_suffixes = ("-oldest", "-latest", "-legacy")
+
+
+def _get_loongsuite_package_name(name: str) -> str:
+    for suffix in _loongsuite_test_variant_suffixes:
+        if name.endswith(suffix):
+            return name[: -len(suffix)]
+
+    return name
 
 
 def get_tox_envs(tox_ini_path: Path) -> list:
@@ -90,6 +99,7 @@ def get_test_job_datas(tox_envs: list, operating_systems: list) -> list:
                         f"{aliased_python_version} "
                         f"{os_alias[operating_system]}"
                     ),
+                    "package": _get_loongsuite_package_name(groups["name"]),
                     "python_version": aliased_python_version,
                     "tox_env": tox_env,
                     "os": operating_system,
@@ -114,6 +124,7 @@ def get_lint_job_datas(tox_envs: list) -> list:
             {
                 "name": f"{tox_env}",
                 "ui_name": f"{tox_lint_env_match.groupdict()['name']}",
+                "package": tox_lint_env_match.groupdict()["name"],
                 "tox_env": tox_env,
             }
         )

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/loongsuite_lint.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/loongsuite_lint.yml.j2
@@ -31,10 +31,31 @@ env:
   PIP_EXISTS_ACTION: w
 
 jobs:
+  loongsuite_changes:
+    name: LoongSuite changed packages
+    runs-on: ubuntu-latest
+    outputs:
+      full: ${% raw %}{{ steps.detect.outputs.full }}{% endraw %}
+      packages: ${% raw %}{{ steps.detect.outputs.packages }}{% endraw %}
+      reason: ${% raw %}{{ steps.detect.outputs.reason }}{% endraw %}
+    steps:
+      - name: Checkout repo @ SHA - ${% raw %}{{ github.sha }}{% endraw %}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect LoongSuite changes
+        id: detect
+        run: python .github/scripts/detect_loongsuite_changes.py
+
   {%- for job_data in job_datas %}
 
   {{ job_data.name }}:
     name: LoongSuite {{ job_data.ui_name }}
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|{{ job_data.package }}|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/loongsuite_lint.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/loongsuite_lint.yml.j2
@@ -9,6 +9,7 @@ on:
     - 'release/*'
     - 'otelbot/*'
   pull_request:
+  merge_group:
 
 permissions:
   contents: read
@@ -37,6 +38,7 @@ jobs:
     outputs:
       full: ${% raw %}{{ steps.detect.outputs.full }}{% endraw %}
       packages: ${% raw %}{{ steps.detect.outputs.packages }}{% endraw %}
+      degraded: ${% raw %}{{ steps.detect.outputs.degraded }}{% endraw %}
       reason: ${% raw %}{{ steps.detect.outputs.reason }}{% endraw %}
     steps:
       - name: Checkout repo @ SHA - ${% raw %}{{ github.sha }}{% endraw %}
@@ -44,9 +46,33 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
       - name: Detect LoongSuite changes
         id: detect
-        run: python .github/scripts/detect_loongsuite_changes.py
+        shell: bash
+        run: |
+          detector=.github/scripts/detect_loongsuite_changes.py
+          run_detector() {
+            if ! python "$1"; then
+              echo "::warning::LoongSuite change detector failed; falling back to full CI"
+              {
+                echo "full=true"
+                echo "packages=||"
+                echo "degraded=true"
+                echo "reason=detector command failed"
+              } >> "$GITHUB_OUTPUT"
+            fi
+          }
+          if [[ "${% raw %}{{ github.event_name }}{% endraw %}" == "pull_request" ]] && git cat-file -e "${% raw %}{{ github.event.pull_request.base.sha }}{% endraw %}:$detector" 2>/dev/null; then
+            git show "${% raw %}{{ github.event.pull_request.base.sha }}{% endraw %}:$detector" > /tmp/detect_loongsuite_changes.py
+            run_detector /tmp/detect_loongsuite_changes.py
+          else
+            run_detector "$detector"
+          fi
 
   {%- for job_data in job_datas %}
 

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/loongsuite_misc.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/loongsuite_misc.yml.j2
@@ -9,6 +9,7 @@ on:
     - 'release/*'
     - 'otelbot/*'
   pull_request:
+  merge_group:
 
 permissions:
   contents: read
@@ -78,6 +79,11 @@ jobs:
 
       - name: Run tests
         run: tox -c tox-loongsuite.ini -e {{ job_data }}
+      {%- if job_data == "generate-loongsuite" %}
+
+      - name: Check LoongSuite workflows are up to date
+        run: tox -e generate-workflows && git diff --exit-code -- .github/workflows/loongsuite_*.yml || (echo 'Generated LoongSuite workflows are out of date, run "tox -e generate-workflows" and commit the changes in this PR.' && exit 1)
+      {%- endif %}
       {%- if job_data == "generate-workflows" %}
 
       - name: Check workflows are up to date

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/loongsuite_test.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/loongsuite_test.yml.j2
@@ -9,6 +9,7 @@ on:
     - 'release/*'
     - 'otelbot/*'
   pull_request:
+  merge_group:
 
 permissions:
   contents: read
@@ -37,6 +38,7 @@ jobs:
     outputs:
       full: ${% raw %}{{ steps.detect.outputs.full }}{% endraw %}
       packages: ${% raw %}{{ steps.detect.outputs.packages }}{% endraw %}
+      degraded: ${% raw %}{{ steps.detect.outputs.degraded }}{% endraw %}
       reason: ${% raw %}{{ steps.detect.outputs.reason }}{% endraw %}
     steps:
       - name: Checkout repo @ SHA - ${% raw %}{{ github.sha }}{% endraw %}
@@ -44,9 +46,33 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
       - name: Detect LoongSuite changes
         id: detect
-        run: python .github/scripts/detect_loongsuite_changes.py
+        shell: bash
+        run: |
+          detector=.github/scripts/detect_loongsuite_changes.py
+          run_detector() {
+            if ! python "$1"; then
+              echo "::warning::LoongSuite change detector failed; falling back to full CI"
+              {
+                echo "full=true"
+                echo "packages=||"
+                echo "degraded=true"
+                echo "reason=detector command failed"
+              } >> "$GITHUB_OUTPUT"
+            fi
+          }
+          if [[ "${% raw %}{{ github.event_name }}{% endraw %}" == "pull_request" ]] && git cat-file -e "${% raw %}{{ github.event.pull_request.base.sha }}{% endraw %}:$detector" 2>/dev/null; then
+            git show "${% raw %}{{ github.event.pull_request.base.sha }}{% endraw %}:$detector" > /tmp/detect_loongsuite_changes.py
+            run_detector /tmp/detect_loongsuite_changes.py
+          else
+            run_detector "$detector"
+          fi
 
   {%- for job_data in job_datas %}
 

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/loongsuite_test.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/loongsuite_test.yml.j2
@@ -31,10 +31,31 @@ env:
   PIP_EXISTS_ACTION: w
 
 jobs:
+  loongsuite_changes:
+    name: LoongSuite changed packages
+    runs-on: ubuntu-latest
+    outputs:
+      full: ${% raw %}{{ steps.detect.outputs.full }}{% endraw %}
+      packages: ${% raw %}{{ steps.detect.outputs.packages }}{% endraw %}
+      reason: ${% raw %}{{ steps.detect.outputs.reason }}{% endraw %}
+    steps:
+      - name: Checkout repo @ SHA - ${% raw %}{{ github.sha }}{% endraw %}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect LoongSuite changes
+        id: detect
+        run: python .github/scripts/detect_loongsuite_changes.py
+
   {%- for job_data in job_datas %}
 
   {{ job_data.name }}:
     name: LoongSuite {{ job_data.ui_name }}
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|{{ job_data.package }}|')
     runs-on: {{ job_data.os }}
     timeout-minutes: 30
     steps:

--- a/.github/workflows/loongsuite_lint_0.yml
+++ b/.github/workflows/loongsuite_lint_0.yml
@@ -9,6 +9,7 @@ on:
     - 'release/*'
     - 'otelbot/*'
   pull_request:
+  merge_group:
 
 permissions:
   contents: read
@@ -37,6 +38,7 @@ jobs:
     outputs:
       full: ${{ steps.detect.outputs.full }}
       packages: ${{ steps.detect.outputs.packages }}
+      degraded: ${{ steps.detect.outputs.degraded }}
       reason: ${{ steps.detect.outputs.reason }}
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
@@ -44,9 +46,33 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
       - name: Detect LoongSuite changes
         id: detect
-        run: python .github/scripts/detect_loongsuite_changes.py
+        shell: bash
+        run: |
+          detector=.github/scripts/detect_loongsuite_changes.py
+          run_detector() {
+            if ! python "$1"; then
+              echo "::warning::LoongSuite change detector failed; falling back to full CI"
+              {
+                echo "full=true"
+                echo "packages=||"
+                echo "degraded=true"
+                echo "reason=detector command failed"
+              } >> "$GITHUB_OUTPUT"
+            fi
+          }
+          if [[ "${{ github.event_name }}" == "pull_request" ]] && git cat-file -e "${{ github.event.pull_request.base.sha }}:$detector" 2>/dev/null; then
+            git show "${{ github.event.pull_request.base.sha }}:$detector" > /tmp/detect_loongsuite_changes.py
+            run_detector /tmp/detect_loongsuite_changes.py
+          else
+            run_detector "$detector"
+          fi
 
   lint-loongsuite-instrumentation-agentscope:
     name: LoongSuite loongsuite-instrumentation-agentscope

--- a/.github/workflows/loongsuite_lint_0.yml
+++ b/.github/workflows/loongsuite_lint_0.yml
@@ -31,9 +31,29 @@ env:
   PIP_EXISTS_ACTION: w
 
 jobs:
+  loongsuite_changes:
+    name: LoongSuite changed packages
+    runs-on: ubuntu-latest
+    outputs:
+      full: ${{ steps.detect.outputs.full }}
+      packages: ${{ steps.detect.outputs.packages }}
+      reason: ${{ steps.detect.outputs.reason }}
+    steps:
+      - name: Checkout repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect LoongSuite changes
+        id: detect
+        run: python .github/scripts/detect_loongsuite_changes.py
 
   lint-loongsuite-instrumentation-agentscope:
     name: LoongSuite loongsuite-instrumentation-agentscope
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-agentscope|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -53,6 +73,10 @@ jobs:
 
   lint-loongsuite-instrumentation-dashscope:
     name: LoongSuite loongsuite-instrumentation-dashscope
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-dashscope|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -72,6 +96,10 @@ jobs:
 
   lint-loongsuite-instrumentation-claude-agent-sdk:
     name: LoongSuite loongsuite-instrumentation-claude-agent-sdk
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-claude-agent-sdk|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -91,6 +119,10 @@ jobs:
 
   lint-loongsuite-instrumentation-google-adk:
     name: LoongSuite loongsuite-instrumentation-google-adk
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-google-adk|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -110,6 +142,10 @@ jobs:
 
   lint-loongsuite-instrumentation-langchain:
     name: LoongSuite loongsuite-instrumentation-langchain
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-langchain|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -129,6 +165,10 @@ jobs:
 
   lint-loongsuite-instrumentation-langgraph:
     name: LoongSuite loongsuite-instrumentation-langgraph
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-langgraph|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -148,6 +188,10 @@ jobs:
 
   lint-loongsuite-instrumentation-qwen-agent:
     name: LoongSuite loongsuite-instrumentation-qwen-agent
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-qwen-agent|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -167,6 +211,10 @@ jobs:
 
   lint-loongsuite-instrumentation-mem0:
     name: LoongSuite loongsuite-instrumentation-mem0
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-mem0|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -186,6 +234,10 @@ jobs:
 
   lint-util-genai:
     name: LoongSuite util-genai
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|util-genai|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -205,6 +257,10 @@ jobs:
 
   lint-loongsuite-instrumentation-litellm:
     name: LoongSuite loongsuite-instrumentation-litellm
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-litellm|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -224,6 +280,10 @@ jobs:
 
   lint-loongsuite-instrumentation-crewai:
     name: LoongSuite loongsuite-instrumentation-crewai
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-crewai|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -243,6 +303,10 @@ jobs:
 
   lint-loongsuite-instrumentation-qwenpaw:
     name: LoongSuite loongsuite-instrumentation-qwenpaw
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-qwenpaw|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/loongsuite_misc_0.yml
+++ b/.github/workflows/loongsuite_misc_0.yml
@@ -9,6 +9,7 @@ on:
     - 'release/*'
     - 'otelbot/*'
   pull_request:
+  merge_group:
 
 permissions:
   contents: read
@@ -69,3 +70,6 @@ jobs:
 
       - name: Run tests
         run: tox -c tox-loongsuite.ini -e generate-loongsuite
+
+      - name: Check LoongSuite workflows are up to date
+        run: tox -e generate-workflows && git diff --exit-code -- .github/workflows/loongsuite_*.yml || (echo 'Generated LoongSuite workflows are out of date, run "tox -e generate-workflows" and commit the changes in this PR.' && exit 1)

--- a/.github/workflows/loongsuite_test_0.yml
+++ b/.github/workflows/loongsuite_test_0.yml
@@ -31,9 +31,29 @@ env:
   PIP_EXISTS_ACTION: w
 
 jobs:
+  loongsuite_changes:
+    name: LoongSuite changed packages
+    runs-on: ubuntu-latest
+    outputs:
+      full: ${{ steps.detect.outputs.full }}
+      packages: ${{ steps.detect.outputs.packages }}
+      reason: ${{ steps.detect.outputs.reason }}
+    steps:
+      - name: Checkout repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect LoongSuite changes
+        id: detect
+        run: python .github/scripts/detect_loongsuite_changes.py
 
   py310-test-loongsuite-instrumentation-agentscope-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-agentscope-oldest 3.10 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-agentscope|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -53,6 +73,10 @@ jobs:
 
   py310-test-loongsuite-instrumentation-agentscope-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-agentscope-latest 3.10 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-agentscope|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -72,6 +96,10 @@ jobs:
 
   py311-test-loongsuite-instrumentation-agentscope-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-agentscope-oldest 3.11 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-agentscope|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -91,6 +119,10 @@ jobs:
 
   py311-test-loongsuite-instrumentation-agentscope-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-agentscope-latest 3.11 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-agentscope|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -110,6 +142,10 @@ jobs:
 
   py312-test-loongsuite-instrumentation-agentscope-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-agentscope-oldest 3.12 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-agentscope|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -129,6 +165,10 @@ jobs:
 
   py312-test-loongsuite-instrumentation-agentscope-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-agentscope-latest 3.12 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-agentscope|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -148,6 +188,10 @@ jobs:
 
   py313-test-loongsuite-instrumentation-agentscope-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-agentscope-oldest 3.13 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-agentscope|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -167,6 +211,10 @@ jobs:
 
   py313-test-loongsuite-instrumentation-agentscope-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-agentscope-latest 3.13 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-agentscope|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -186,6 +234,10 @@ jobs:
 
   py39-test-loongsuite-instrumentation-dashscope-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-dashscope-oldest 3.9 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-dashscope|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -205,6 +257,10 @@ jobs:
 
   py39-test-loongsuite-instrumentation-dashscope-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-dashscope-latest 3.9 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-dashscope|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -224,6 +280,10 @@ jobs:
 
   py310-test-loongsuite-instrumentation-dashscope-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-dashscope-oldest 3.10 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-dashscope|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -243,6 +303,10 @@ jobs:
 
   py310-test-loongsuite-instrumentation-dashscope-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-dashscope-latest 3.10 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-dashscope|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -262,6 +326,10 @@ jobs:
 
   py311-test-loongsuite-instrumentation-dashscope-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-dashscope-oldest 3.11 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-dashscope|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -281,6 +349,10 @@ jobs:
 
   py311-test-loongsuite-instrumentation-dashscope-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-dashscope-latest 3.11 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-dashscope|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -300,6 +372,10 @@ jobs:
 
   py312-test-loongsuite-instrumentation-dashscope-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-dashscope-oldest 3.12 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-dashscope|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -319,6 +395,10 @@ jobs:
 
   py312-test-loongsuite-instrumentation-dashscope-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-dashscope-latest 3.12 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-dashscope|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -338,6 +418,10 @@ jobs:
 
   py313-test-loongsuite-instrumentation-dashscope-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-dashscope-oldest 3.13 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-dashscope|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -357,6 +441,10 @@ jobs:
 
   py313-test-loongsuite-instrumentation-dashscope-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-dashscope-latest 3.13 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-dashscope|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -376,6 +464,10 @@ jobs:
 
   py310-test-loongsuite-instrumentation-claude-agent-sdk-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-claude-agent-sdk-oldest 3.10 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-claude-agent-sdk|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -395,6 +487,10 @@ jobs:
 
   py310-test-loongsuite-instrumentation-claude-agent-sdk-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-claude-agent-sdk-latest 3.10 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-claude-agent-sdk|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -414,6 +510,10 @@ jobs:
 
   py311-test-loongsuite-instrumentation-claude-agent-sdk-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-claude-agent-sdk-oldest 3.11 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-claude-agent-sdk|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -433,6 +533,10 @@ jobs:
 
   py311-test-loongsuite-instrumentation-claude-agent-sdk-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-claude-agent-sdk-latest 3.11 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-claude-agent-sdk|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -452,6 +556,10 @@ jobs:
 
   py312-test-loongsuite-instrumentation-claude-agent-sdk-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-claude-agent-sdk-oldest 3.12 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-claude-agent-sdk|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -471,6 +579,10 @@ jobs:
 
   py312-test-loongsuite-instrumentation-claude-agent-sdk-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-claude-agent-sdk-latest 3.12 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-claude-agent-sdk|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -490,6 +602,10 @@ jobs:
 
   py313-test-loongsuite-instrumentation-claude-agent-sdk-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-claude-agent-sdk-oldest 3.13 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-claude-agent-sdk|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -509,6 +625,10 @@ jobs:
 
   py313-test-loongsuite-instrumentation-claude-agent-sdk-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-claude-agent-sdk-latest 3.13 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-claude-agent-sdk|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -528,6 +648,10 @@ jobs:
 
   py39-test-loongsuite-instrumentation-google-adk-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-google-adk-oldest 3.9 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-google-adk|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -547,6 +671,10 @@ jobs:
 
   py39-test-loongsuite-instrumentation-google-adk-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-google-adk-latest 3.9 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-google-adk|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -566,6 +694,10 @@ jobs:
 
   py310-test-loongsuite-instrumentation-google-adk-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-google-adk-oldest 3.10 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-google-adk|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -585,6 +717,10 @@ jobs:
 
   py310-test-loongsuite-instrumentation-google-adk-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-google-adk-latest 3.10 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-google-adk|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -604,6 +740,10 @@ jobs:
 
   py311-test-loongsuite-instrumentation-google-adk-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-google-adk-oldest 3.11 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-google-adk|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -623,6 +763,10 @@ jobs:
 
   py311-test-loongsuite-instrumentation-google-adk-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-google-adk-latest 3.11 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-google-adk|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -642,6 +786,10 @@ jobs:
 
   py312-test-loongsuite-instrumentation-google-adk-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-google-adk-oldest 3.12 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-google-adk|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -661,6 +809,10 @@ jobs:
 
   py312-test-loongsuite-instrumentation-google-adk-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-google-adk-latest 3.12 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-google-adk|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -680,6 +832,10 @@ jobs:
 
   py313-test-loongsuite-instrumentation-google-adk-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-google-adk-oldest 3.13 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-google-adk|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -699,6 +855,10 @@ jobs:
 
   py313-test-loongsuite-instrumentation-google-adk-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-google-adk-latest 3.13 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-google-adk|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -718,6 +878,10 @@ jobs:
 
   py39-test-loongsuite-instrumentation-langchain-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-langchain-oldest 3.9 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-langchain|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -737,6 +901,10 @@ jobs:
 
   py39-test-loongsuite-instrumentation-langchain-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-langchain-latest 3.9 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-langchain|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -756,6 +924,10 @@ jobs:
 
   py310-test-loongsuite-instrumentation-langchain-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-langchain-oldest 3.10 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-langchain|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -775,6 +947,10 @@ jobs:
 
   py310-test-loongsuite-instrumentation-langchain-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-langchain-latest 3.10 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-langchain|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -794,6 +970,10 @@ jobs:
 
   py311-test-loongsuite-instrumentation-langchain-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-langchain-oldest 3.11 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-langchain|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -813,6 +993,10 @@ jobs:
 
   py311-test-loongsuite-instrumentation-langchain-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-langchain-latest 3.11 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-langchain|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -832,6 +1016,10 @@ jobs:
 
   py312-test-loongsuite-instrumentation-langchain-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-langchain-oldest 3.12 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-langchain|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -851,6 +1039,10 @@ jobs:
 
   py312-test-loongsuite-instrumentation-langchain-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-langchain-latest 3.12 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-langchain|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -870,6 +1062,10 @@ jobs:
 
   py313-test-loongsuite-instrumentation-langchain-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-langchain-oldest 3.13 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-langchain|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -889,6 +1085,10 @@ jobs:
 
   py313-test-loongsuite-instrumentation-langchain-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-langchain-latest 3.13 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-langchain|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -908,6 +1108,10 @@ jobs:
 
   py39-test-loongsuite-instrumentation-langgraph-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-langgraph-oldest 3.9 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-langgraph|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -927,6 +1131,10 @@ jobs:
 
   py39-test-loongsuite-instrumentation-langgraph-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-langgraph-latest 3.9 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-langgraph|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -946,6 +1154,10 @@ jobs:
 
   py310-test-loongsuite-instrumentation-langgraph-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-langgraph-oldest 3.10 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-langgraph|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -965,6 +1177,10 @@ jobs:
 
   py310-test-loongsuite-instrumentation-langgraph-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-langgraph-latest 3.10 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-langgraph|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -984,6 +1200,10 @@ jobs:
 
   py311-test-loongsuite-instrumentation-langgraph-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-langgraph-oldest 3.11 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-langgraph|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1003,6 +1223,10 @@ jobs:
 
   py311-test-loongsuite-instrumentation-langgraph-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-langgraph-latest 3.11 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-langgraph|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1022,6 +1246,10 @@ jobs:
 
   py312-test-loongsuite-instrumentation-langgraph-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-langgraph-oldest 3.12 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-langgraph|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1041,6 +1269,10 @@ jobs:
 
   py312-test-loongsuite-instrumentation-langgraph-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-langgraph-latest 3.12 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-langgraph|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1060,6 +1292,10 @@ jobs:
 
   py313-test-loongsuite-instrumentation-langgraph-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-langgraph-oldest 3.13 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-langgraph|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1079,6 +1315,10 @@ jobs:
 
   py313-test-loongsuite-instrumentation-langgraph-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-langgraph-latest 3.13 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-langgraph|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1098,6 +1338,10 @@ jobs:
 
   py39-test-loongsuite-instrumentation-qwen-agent-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-qwen-agent-oldest 3.9 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-qwen-agent|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1117,6 +1361,10 @@ jobs:
 
   py39-test-loongsuite-instrumentation-qwen-agent-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-qwen-agent-latest 3.9 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-qwen-agent|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1136,6 +1384,10 @@ jobs:
 
   py310-test-loongsuite-instrumentation-qwen-agent-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-qwen-agent-oldest 3.10 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-qwen-agent|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1155,6 +1407,10 @@ jobs:
 
   py310-test-loongsuite-instrumentation-qwen-agent-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-qwen-agent-latest 3.10 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-qwen-agent|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1174,6 +1430,10 @@ jobs:
 
   py311-test-loongsuite-instrumentation-qwen-agent-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-qwen-agent-oldest 3.11 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-qwen-agent|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1193,6 +1453,10 @@ jobs:
 
   py311-test-loongsuite-instrumentation-qwen-agent-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-qwen-agent-latest 3.11 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-qwen-agent|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1212,6 +1476,10 @@ jobs:
 
   py312-test-loongsuite-instrumentation-qwen-agent-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-qwen-agent-oldest 3.12 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-qwen-agent|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1231,6 +1499,10 @@ jobs:
 
   py312-test-loongsuite-instrumentation-qwen-agent-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-qwen-agent-latest 3.12 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-qwen-agent|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1250,6 +1522,10 @@ jobs:
 
   py313-test-loongsuite-instrumentation-qwen-agent-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-qwen-agent-oldest 3.13 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-qwen-agent|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1269,6 +1545,10 @@ jobs:
 
   py313-test-loongsuite-instrumentation-qwen-agent-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-qwen-agent-latest 3.13 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-qwen-agent|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1288,6 +1568,10 @@ jobs:
 
   py310-test-loongsuite-instrumentation-mem0-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-mem0-oldest 3.10 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-mem0|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1307,6 +1591,10 @@ jobs:
 
   py310-test-loongsuite-instrumentation-mem0-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-mem0-latest 3.10 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-mem0|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1326,6 +1614,10 @@ jobs:
 
   py311-test-loongsuite-instrumentation-mem0-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-mem0-oldest 3.11 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-mem0|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1345,6 +1637,10 @@ jobs:
 
   py311-test-loongsuite-instrumentation-mem0-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-mem0-latest 3.11 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-mem0|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1364,6 +1660,10 @@ jobs:
 
   py312-test-loongsuite-instrumentation-mem0-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-mem0-oldest 3.12 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-mem0|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1383,6 +1683,10 @@ jobs:
 
   py312-test-loongsuite-instrumentation-mem0-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-mem0-latest 3.12 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-mem0|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1402,6 +1706,10 @@ jobs:
 
   py313-test-loongsuite-instrumentation-mem0-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-mem0-oldest 3.13 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-mem0|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1421,6 +1729,10 @@ jobs:
 
   py313-test-loongsuite-instrumentation-mem0-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-mem0-latest 3.13 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-mem0|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1440,6 +1752,10 @@ jobs:
 
   py39-test-util-genai_ubuntu-latest:
     name: LoongSuite util-genai 3.9 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|util-genai|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1459,6 +1775,10 @@ jobs:
 
   py310-test-util-genai_ubuntu-latest:
     name: LoongSuite util-genai 3.10 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|util-genai|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1478,6 +1798,10 @@ jobs:
 
   py311-test-util-genai_ubuntu-latest:
     name: LoongSuite util-genai 3.11 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|util-genai|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1497,6 +1821,10 @@ jobs:
 
   py312-test-util-genai_ubuntu-latest:
     name: LoongSuite util-genai 3.12 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|util-genai|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1516,6 +1844,10 @@ jobs:
 
   py313-test-util-genai_ubuntu-latest:
     name: LoongSuite util-genai 3.13 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|util-genai|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1535,6 +1867,10 @@ jobs:
 
   py314-test-util-genai_ubuntu-latest:
     name: LoongSuite util-genai 3.14 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|util-genai|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1554,6 +1890,10 @@ jobs:
 
   pypy3-test-util-genai_ubuntu-latest:
     name: LoongSuite util-genai pypy-3.9 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|util-genai|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1573,6 +1913,10 @@ jobs:
 
   py310-test-loongsuite-instrumentation-litellm_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-litellm 3.10 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-litellm|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1592,6 +1936,10 @@ jobs:
 
   py311-test-loongsuite-instrumentation-litellm_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-litellm 3.11 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-litellm|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1611,6 +1959,10 @@ jobs:
 
   py312-test-loongsuite-instrumentation-litellm_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-litellm 3.12 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-litellm|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1630,6 +1982,10 @@ jobs:
 
   py313-test-loongsuite-instrumentation-litellm_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-litellm 3.13 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-litellm|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1649,6 +2005,10 @@ jobs:
 
   py310-test-loongsuite-instrumentation-crewai_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-crewai 3.10 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-crewai|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1668,6 +2028,10 @@ jobs:
 
   py311-test-loongsuite-instrumentation-crewai_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-crewai 3.11 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-crewai|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1687,6 +2051,10 @@ jobs:
 
   py312-test-loongsuite-instrumentation-crewai_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-crewai 3.12 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-crewai|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1706,6 +2074,10 @@ jobs:
 
   py313-test-loongsuite-instrumentation-crewai_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-crewai 3.13 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-crewai|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1725,6 +2097,10 @@ jobs:
 
   py310-test-loongsuite-instrumentation-qwenpaw-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-qwenpaw-latest 3.10 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-qwenpaw|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1744,6 +2120,10 @@ jobs:
 
   py310-test-loongsuite-instrumentation-qwenpaw-legacy_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-qwenpaw-legacy 3.10 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-qwenpaw|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1763,6 +2143,10 @@ jobs:
 
   py311-test-loongsuite-instrumentation-qwenpaw-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-qwenpaw-latest 3.11 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-qwenpaw|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1782,6 +2166,10 @@ jobs:
 
   py311-test-loongsuite-instrumentation-qwenpaw-legacy_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-qwenpaw-legacy 3.11 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-qwenpaw|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1801,6 +2189,10 @@ jobs:
 
   py312-test-loongsuite-instrumentation-qwenpaw-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-qwenpaw-latest 3.12 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-qwenpaw|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1820,6 +2212,10 @@ jobs:
 
   py312-test-loongsuite-instrumentation-qwenpaw-legacy_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-qwenpaw-legacy 3.12 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-qwenpaw|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1839,6 +2235,10 @@ jobs:
 
   py313-test-loongsuite-instrumentation-qwenpaw-latest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-qwenpaw-latest 3.13 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-qwenpaw|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -1858,6 +2258,10 @@ jobs:
 
   py313-test-loongsuite-instrumentation-qwenpaw-legacy_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-qwenpaw-legacy 3.13 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|loongsuite-instrumentation-qwenpaw|')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/loongsuite_test_0.yml
+++ b/.github/workflows/loongsuite_test_0.yml
@@ -9,6 +9,7 @@ on:
     - 'release/*'
     - 'otelbot/*'
   pull_request:
+  merge_group:
 
 permissions:
   contents: read
@@ -37,6 +38,7 @@ jobs:
     outputs:
       full: ${{ steps.detect.outputs.full }}
       packages: ${{ steps.detect.outputs.packages }}
+      degraded: ${{ steps.detect.outputs.degraded }}
       reason: ${{ steps.detect.outputs.reason }}
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
@@ -44,9 +46,33 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
       - name: Detect LoongSuite changes
         id: detect
-        run: python .github/scripts/detect_loongsuite_changes.py
+        shell: bash
+        run: |
+          detector=.github/scripts/detect_loongsuite_changes.py
+          run_detector() {
+            if ! python "$1"; then
+              echo "::warning::LoongSuite change detector failed; falling back to full CI"
+              {
+                echo "full=true"
+                echo "packages=||"
+                echo "degraded=true"
+                echo "reason=detector command failed"
+              } >> "$GITHUB_OUTPUT"
+            fi
+          }
+          if [[ "${{ github.event_name }}" == "pull_request" ]] && git cat-file -e "${{ github.event.pull_request.base.sha }}:$detector" 2>/dev/null; then
+            git show "${{ github.event.pull_request.base.sha }}:$detector" > /tmp/detect_loongsuite_changes.py
+            run_detector /tmp/detect_loongsuite_changes.py
+          else
+            run_detector "$detector"
+          fi
 
   py310-test-loongsuite-instrumentation-agentscope-oldest_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-agentscope-oldest 3.10 Ubuntu
@@ -1910,6 +1936,29 @@ jobs:
 
       - name: Run tests
         run: tox -c tox-loongsuite.ini -e pypy3-test-util-genai -- -ra
+
+  py311-test-detect-loongsuite-changes_ubuntu-latest:
+    name: LoongSuite detect-loongsuite-changes 3.11 Ubuntu
+    needs: loongsuite_changes
+    if: |
+      needs.loongsuite_changes.outputs.full == 'true' ||
+      contains(needs.loongsuite_changes.outputs.packages, '|detect-loongsuite-changes|')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repo @ SHA - ${{ github.sha }}
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install tox
+        run: pip install tox-uv
+
+      - name: Run tests
+        run: tox -c tox-loongsuite.ini -e py311-test-detect-loongsuite-changes -- -ra
 
   py310-test-loongsuite-instrumentation-litellm_ubuntu-latest:
     name: LoongSuite loongsuite-instrumentation-litellm 3.10 Ubuntu

--- a/tox-loongsuite.ini
+++ b/tox-loongsuite.ini
@@ -61,6 +61,9 @@ envlist =
     pypy3-test-util-genai
     lint-util-genai
 
+    ; LoongSuite CI scripts
+    py311-test-detect-loongsuite-changes
+
     ; license header
     check-license-header
 
@@ -143,6 +146,8 @@ deps =
   util-genai: -r {toxinidir}/util/opentelemetry-util-genai/test-requirements.txt
   util-genai: {toxinidir}/util/opentelemetry-util-genai
 
+  detect-loongsuite-changes: pytest
+
   litellm: {[testenv]test_deps}
   litellm: -r {toxinidir}/instrumentation-loongsuite/loongsuite-instrumentation-litellm/tests/test-requirements.txt
 
@@ -209,6 +214,8 @@ commands =
 
   test-util-genai: pytest {toxinidir}/util/opentelemetry-util-genai/tests {posargs}
   lint-util-genai: sh -c "cd util && pylint --rcfile ../.pylintrc opentelemetry-util-genai"
+
+  test-detect-loongsuite-changes: pytest {toxinidir}/.github/scripts/tests/test_detect_loongsuite_changes.py {posargs}
 
   test-loongsuite-instrumentation-litellm: pytest {toxinidir}/instrumentation-loongsuite/loongsuite-instrumentation-litellm/tests {posargs}
   lint-loongsuite-instrumentation-litellm: python -m ruff check {toxinidir}/instrumentation-loongsuite/loongsuite-instrumentation-litellm


### PR DESCRIPTION
# Description

This PR scopes LoongSuite lint and test jobs to the changed LoongSuite package on pull requests. It adds a lightweight change-detection job that keeps full LoongSuite CI for release/backport PRs, util-genai changes, shared CI/build configuration changes, unknown package directories, unknown LoongSuite workflow files, and degraded detector states, while allowing package PRs to run only their relevant lint/test matrix.

It also supports new-plugin PRs that update `tox-loongsuite.ini` and regenerated `.github/workflows/loongsuite_{lint,test,misc}_*.yml` files: generated workflow files are ignored by the detector, and tox diff lines are scoped only when every meaningful changed line maps to a registered LoongSuite package. For example, a deepagents plugin PR that also touches langchain code is scoped to deepagents and langchain jobs instead of the full LoongSuite matrix.

Fixes # (N/A)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] `tox -e precommit`
- [x] `tox -e generate-workflows`
- [x] `tox -c tox-loongsuite.ini -e py311-test-detect-loongsuite-changes`
- [x] `python3 -m py_compile .github/scripts/detect_loongsuite_changes.py .github/scripts/tests/test_detect_loongsuite_changes.py .github/workflows/generate_workflows_lib/src/generate_workflows_lib/__init__.py`
- [x] `python3 -c 'import yaml, sys; [yaml.safe_load(open(p)) for p in sys.argv[1:]]' .github/workflows/loongsuite_test_0.yml .github/workflows/loongsuite_lint_0.yml .github/workflows/loongsuite_misc_0.yml`
- [x] Added and ran detector coverage for package-scoped plugin changes, new-plugin tox registration changes, generated workflow skips, unknown workflow full-run fallback, util-genai full-run fallback, unknown package fallback, empty diff fallback, docs-only package changes, and detector error fallback.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR:
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
