### PR TITLE
feat(crewai): add GenAI util instrumentation

### DIFF
--- a/instrumentation-loongsuite/loongsuite-instrumentation-crewai/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-crewai/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Breaking
+
+- Align CrewAI GenAI span names with `opentelemetry-util-genai`
+  extended semantic conventions. `gen_ai.operation.name` now reports
+  `enter`, `invoke_agent`, or `execute_tool`; the CrewAI framework operation
+  is reported in `gen_ai.crewai.operation` instead.
+- Replace the legacy `gen_ai.system=crewai` attribute with
+  `gen_ai.provider.name=crewai`.
+- Use the current content-capture environment values:
+  `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental` and
+  `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=SPAN_ONLY`.
+
+### Changed
+
+- Migrate CrewAI entry, task, agent, and tool spans to
+  `opentelemetry-util-genai` `ExtendedTelemetryHandler`.
+- Keep instrumentation post-processing failures from changing successful
+  CrewAI calls into user-visible errors, avoid duplicate nested agent spans,
+  and gate content-like CrewAI task and agent attributes behind util-genai
+  content capture controls.
+
+### Added
+
+- Add a real CrewAI smoke example covering sync, streaming, and concurrent
+  calls for local otel-gui and Robin/ARMS verification.
+
 ## Version 0.5.0 (2026-05-11)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-crewai/README.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-crewai/README.md
@@ -44,6 +44,72 @@ crew = Crew(
 result = crew.kickoff()
 ```
 
+## Telemetry
+
+This instrumentation uses `ExtendedTelemetryHandler` from
+`opentelemetry-util-genai` and emits:
+
+- `enter_ai_application_system` spans for `Crew.kickoff` and Flow kickoff
+  entry points (`gen_ai.span.kind=ENTRY`, `gen_ai.operation.name=enter`)
+- `invoke_agent` spans for CrewAI task and agent execution
+  (`gen_ai.span.kind=AGENT`, `gen_ai.operation.name=invoke_agent`)
+- `execute_tool` spans for CrewAI tool execution
+  (`gen_ai.span.kind=TOOL`, `gen_ai.operation.name=execute_tool`)
+
+CrewAI-specific framework details are kept in `gen_ai.crewai.*` attributes,
+such as `gen_ai.crewai.operation`, while GenAI message content capture follows
+the shared util-genai controls. Message content capture is disabled by default;
+set both environment variables below before process start to capture
+`gen_ai.input.messages`, `gen_ai.output.messages`, system instructions, and
+content-like CrewAI fields such as task descriptions or agent backstories:
+
+```bash
+export OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental
+export OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=SPAN_ONLY
+```
+
+CrewAI has its own cloud tracing path. Set `CREWAI_TRACING_ENABLED=false` when
+you only want LoongSuite/OpenTelemetry instrumentation for a process.
+
+## Smoke Examples
+
+When running from a source checkout, the `examples/crewai_smoke.py` script
+exercises real non-streaming, streaming, and concurrent CrewAI calls. It reads
+credentials from `DASHSCOPE_API_KEY` or `OPENAI_API_KEY` and defaults to
+DashScope's OpenAI-compatible endpoint. When only `DASHSCOPE_API_KEY` is set,
+the example also sets `OPENAI_API_KEY`, `OPENAI_API_BASE`, and
+`DASHSCOPE_API_BASE` in the current process so CrewAI and LiteLLM can use the
+OpenAI-compatible DashScope endpoint consistently.
+Set `CREWAI_SMOKE_MODEL=openai/qwen-turbo` when validating tool-call paths
+through LiteLLM's OpenAI-compatible DashScope provider.
+
+```bash
+loongsuite-instrument python \
+  instrumentation-loongsuite/loongsuite-instrumentation-crewai/examples/crewai_smoke.py \
+  --mode sync
+
+loongsuite-instrument python \
+  instrumentation-loongsuite/loongsuite-instrumentation-crewai/examples/crewai_smoke.py \
+  --mode stream
+
+loongsuite-instrument python \
+  instrumentation-loongsuite/loongsuite-instrumentation-crewai/examples/crewai_smoke.py \
+  --mode concurrent --concurrency 3
+```
+
+For local otel-gui verification, direct OTLP traces to the local backend and
+let the example configure an HTTP exporter:
+
+```bash
+export OTEL_SERVICE_NAME=loongsuite-crewai-smoke
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://127.0.0.1:5173/v1/traces
+export CREWAI_SMOKE_MANUAL_INSTRUMENT=true
+export CREWAI_SMOKE_CONFIGURE_OTLP=true
+
+python instrumentation-loongsuite/loongsuite-instrumentation-crewai/examples/crewai_smoke.py \
+  --mode concurrent --concurrency 3
+```
+
 ## Supported Versions
 
 - CrewAI >= 0.80.0
@@ -52,4 +118,3 @@ result = crew.kickoff()
 
 - [CrewAI Documentation](https://docs.crewai.com/)
 - [OpenTelemetry Python Documentation](https://opentelemetry-python.readthedocs.io/)
-

--- a/instrumentation-loongsuite/loongsuite-instrumentation-crewai/examples/crewai_smoke.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-crewai/examples/crewai_smoke.py
@@ -1,0 +1,209 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Real CrewAI smoke scenarios for LoongSuite GenAI telemetry."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any
+
+import crewai
+from crewai import Agent, Crew, Task
+from crewai.tools.base_tool import BaseTool
+
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+    OTLPSpanExporter,
+)
+from opentelemetry.instrumentation.crewai import CrewAIInstrumentor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+DEFAULT_DASHSCOPE_BASE_URL = (
+    "https://dashscope.aliyuncs.com/compatible-mode/v1"
+)
+_TRACER_PROVIDER = None
+
+
+class WordCountTool(BaseTool):
+    """Small deterministic tool to make TOOL spans easy to verify."""
+
+    name: str = "word_count"
+    description: str = "Count words in a short text string."
+
+    def _run(self, text: str) -> str:
+        words = [part for part in str(text).split() if part]
+        return f"word_count={len(words)}"
+
+
+def _api_key() -> str:
+    value = os.getenv("DASHSCOPE_API_KEY") or os.getenv("OPENAI_API_KEY")
+    if not value:
+        raise RuntimeError(
+            "Set DASHSCOPE_API_KEY or OPENAI_API_KEY before running "
+            "the CrewAI smoke example."
+        )
+    return value
+
+
+def _llm(streaming: bool) -> Any:
+    api_key = _api_key()
+    base_url = os.getenv("DASHSCOPE_API_BASE") or os.getenv(
+        "OPENAI_API_BASE", DEFAULT_DASHSCOPE_BASE_URL
+    )
+    model = os.getenv("CREWAI_SMOKE_MODEL", "dashscope/qwen-turbo")
+
+    os.environ.setdefault("OPENAI_API_KEY", api_key)
+    os.environ.setdefault("OPENAI_API_BASE", base_url)
+    os.environ.setdefault("DASHSCOPE_API_BASE", base_url)
+    os.environ.setdefault("CREWAI_TRACING_ENABLED", "false")
+
+    llm_cls = getattr(crewai, "LLM", None)
+    if llm_cls is None:
+        return model
+
+    try:
+        return llm_cls(
+            model=model,
+            api_key=api_key,
+            base_url=base_url,
+            stream=streaming,
+            temperature=0,
+        )
+    except TypeError:
+        return llm_cls(
+            model=model,
+            api_key=api_key,
+            base_url=base_url,
+            temperature=0,
+        )
+
+
+def _consume_result(result: Any) -> str:
+    if not isinstance(result, str) and hasattr(result, "__iter__"):
+        chunks = []
+        for chunk in result:
+            content = getattr(chunk, "content", chunk)
+            if content is not None:
+                chunks.append(str(content))
+        final_result = getattr(result, "result", None)
+        if final_result is not None:
+            return str(getattr(final_result, "raw", final_result))
+        return "".join(chunks)
+
+    return str(getattr(result, "raw", result))
+
+
+def run_crew(run_id: int, *, streaming: bool) -> str:
+    word_count = WordCountTool()
+    agent = Agent(
+        role=f"CrewAI Telemetry Analyst {run_id}",
+        goal="Use tools and write concise telemetry validation summaries.",
+        backstory="You are validating LoongSuite CrewAI OpenTelemetry spans.",
+        verbose=False,
+        llm=_llm(streaming),
+        tools=[word_count],
+    )
+    task = Task(
+        description=(
+            "Use the word_count tool exactly once on the text "
+            f"'CrewAI telemetry smoke run {run_id}', then answer with the "
+            "tool result and one short sentence."
+        ),
+        expected_output="The tool result plus one short sentence.",
+        agent=agent,
+    )
+    crew = Crew(agents=[agent], tasks=[task], verbose=False, stream=streaming)
+    result = crew.kickoff(
+        inputs={
+            "session_id": f"crewai-smoke-{run_id}",
+            "user_id": "loongsuite-smoke",
+            "streaming": streaming,
+        }
+    )
+    return _consume_result(result)
+
+
+def _maybe_manual_instrument() -> None:
+    if os.getenv("CREWAI_SMOKE_MANUAL_INSTRUMENT", "").lower() not in (
+        "1",
+        "true",
+        "yes",
+    ):
+        return
+    tracer_provider = _maybe_configure_otlp()
+    CrewAIInstrumentor().instrument(tracer_provider=tracer_provider)
+
+
+def _maybe_configure_otlp() -> Any:
+    global _TRACER_PROVIDER  # pylint: disable=global-statement
+
+    if os.getenv("CREWAI_SMOKE_CONFIGURE_OTLP", "").lower() not in (
+        "1",
+        "true",
+        "yes",
+    ):
+        return None
+
+    if _TRACER_PROVIDER is not None:
+        return _TRACER_PROVIDER
+
+    resource = Resource.create(
+        {"service.name": os.getenv("OTEL_SERVICE_NAME", "crewai-smoke")}
+    )
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+    trace.set_tracer_provider(provider)
+    _TRACER_PROVIDER = provider
+    return provider
+
+
+def _flush_traces() -> None:
+    if _TRACER_PROVIDER is not None:
+        _TRACER_PROVIDER.force_flush()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--mode",
+        choices=("sync", "stream", "concurrent"),
+        default="sync",
+    )
+    parser.add_argument("--concurrency", type=int, default=3)
+    args = parser.parse_args()
+
+    _maybe_manual_instrument()
+
+    if args.mode == "concurrent":
+        with ThreadPoolExecutor(max_workers=args.concurrency) as pool:
+            futures = [
+                pool.submit(run_crew, index, streaming=index % 2 == 0)
+                for index in range(args.concurrency)
+            ]
+            for future in as_completed(futures):
+                print(future.result())
+        _flush_traces()
+        return
+
+    print(run_crew(0, streaming=args.mode == "stream"))
+    _flush_traces()
+
+
+if __name__ == "__main__":
+    main()

--- a/instrumentation-loongsuite/loongsuite-instrumentation-crewai/examples/crewai_smoke.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-crewai/examples/crewai_smoke.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import argparse
 import os
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from importlib import import_module
 from typing import Any
 
 import crewai
@@ -26,9 +27,6 @@ from crewai import Agent, Crew, Task
 from crewai.tools.base_tool import BaseTool
 
 from opentelemetry import trace
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
-    OTLPSpanExporter,
-)
 from opentelemetry.instrumentation.crewai import CrewAIInstrumentor
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
@@ -163,11 +161,24 @@ def _maybe_configure_otlp() -> Any:
     if _TRACER_PROVIDER is not None:
         return _TRACER_PROVIDER
 
+    try:
+        exporter_module = import_module(
+            "opentelemetry.exporter.otlp.proto.http.trace_exporter"
+        )
+    except ImportError as exc:
+        raise RuntimeError(
+            "Install opentelemetry-exporter-otlp-proto-http to use "
+            "CREWAI_SMOKE_CONFIGURE_OTLP=true, or unset "
+            "CREWAI_SMOKE_CONFIGURE_OTLP for the default smoke run."
+        ) from exc
+
     resource = Resource.create(
         {"service.name": os.getenv("OTEL_SERVICE_NAME", "crewai-smoke")}
     )
     provider = TracerProvider(resource=resource)
-    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+    provider.add_span_processor(
+        BatchSpanProcessor(exporter_module.OTLPSpanExporter())
+    )
     trace.set_tracer_provider(provider)
     _TRACER_PROVIDER = provider
     return provider

--- a/instrumentation-loongsuite/loongsuite-instrumentation-crewai/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-crewai/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "LoongSuite CrewAI instrumentation"
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.10,<4"
+requires-python = ">=3.10"
 authors = [
   { name = "Zhiyong Liu", email = "liuzhiyong.lzy@alibaba-inc.com" },
   { name = "OpenTelemetry Authors", email = "cncf-opentelemetry-contributors@lists.cncf.io" },
@@ -21,13 +21,14 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
   "opentelemetry-api >= 1.37.0",
   "opentelemetry-instrumentation >= 0.58b0",
   "opentelemetry-semantic-conventions >= 0.58b0",
   "wrapt >= 1.0.0, < 2.0.0",
-  "opentelemetry-util-genai >= 0.3b0.dev0",
+  "opentelemetry-util-genai",
 ]
 
 [project.optional-dependencies]
@@ -53,4 +54,3 @@ include = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/opentelemetry"]
-

--- a/instrumentation-loongsuite/loongsuite-instrumentation-crewai/src/opentelemetry/instrumentation/crewai/__init__.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-crewai/src/opentelemetry/instrumentation/crewai/__init__.py
@@ -12,38 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-OpenTelemetry CrewAI Instrumentation (Optimized)
+"""OpenTelemetry instrumentation for CrewAI."""
 
-"""
+from __future__ import annotations
 
 import logging
+from contextvars import ContextVar, Token
 from typing import Any, Collection
 
 from wrapt import wrap_function_wrapper
 
-from opentelemetry import trace as trace_api
-
-# Import hook system for decoupled extensions
 from opentelemetry.instrumentation.crewai.package import _instruments
 from opentelemetry.instrumentation.crewai.utils import (
-    OP_NAME_AGENT,
     OP_NAME_CREW,
-    OP_NAME_TASK,
-    OP_NAME_TOOL,
+    OP_NAME_FLOW,
     GenAIHookHelper,
-    extract_agent_inputs,
-    extract_tool_inputs,
-    to_input_message,
-    to_output_message,
+    apply_usage_metrics,
+    create_agent_invocation,
+    create_entry_invocation,
+    create_task_invocation,
+    create_tool_invocation,
+    to_output_messages,
+    usage_metric_attributes,
 )
+from opentelemetry.instrumentation.crewai.version import __version__
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.utils import unwrap
-from opentelemetry.semconv._incubating.attributes import gen_ai_attributes
-from opentelemetry.trace import SpanKind, Status, StatusCode
-from opentelemetry.util.genai.extended_semconv import (
-    gen_ai_extended_attributes,
-)
+from opentelemetry.trace import Status, StatusCode
+from opentelemetry.util.genai.extended_handler import ExtendedTelemetryHandler
+from opentelemetry.util.genai.types import Error
 
 try:
     import crewai.agent
@@ -53,319 +50,795 @@ try:
     import crewai.tools.tool_usage
 
     _CREWAI_LOADED = True
-except (ImportError, Exception):
+except ImportError:
     _CREWAI_LOADED = False
 
 logger = logging.getLogger(__name__)
+_ENTRY_DEPTH: ContextVar[int] = ContextVar("crewai_entry_depth", default=0)
+_TASK_DEPTH: ContextVar[int] = ContextVar("crewai_task_depth", default=0)
+
+
+def _set_ok(invocation: Any) -> None:
+    span = getattr(invocation, "span", None)
+    if span is not None:
+        span.set_status(Status(StatusCode.OK))
+
+
+def _record_exception(invocation: Any, exc: BaseException) -> None:
+    span = getattr(invocation, "span", None)
+    if span is not None and span.is_recording():
+        span.record_exception(exc)
+
+
+def _error(exc: BaseException) -> Error:
+    return Error(message=str(exc) or type(exc).__name__, type=type(exc))
+
+
+def _safe_handler_call(action: str, method: Any, *args: Any) -> bool:
+    try:
+        method(*args)
+        return True
+    except Exception as exc:
+        logger.warning(
+            "CrewAI instrumentation handler %s failed: %s",
+            action,
+            exc,
+            exc_info=True,
+        )
+        return False
+
+
+def _safe_build_invocation(
+    action: str, factory: Any, *args: Any, **kwargs: Any
+) -> Any:
+    try:
+        return factory(*args, **kwargs)
+    except Exception as exc:
+        logger.warning(
+            "CrewAI instrumentation %s invocation build failed: %s",
+            action,
+            exc,
+            exc_info=True,
+        )
+        return None
+
+
+def _safe_post_process(action: str, callback: Any) -> None:
+    try:
+        callback()
+    except Exception as exc:
+        logger.warning(
+            "CrewAI instrumentation %s post-processing failed: %s",
+            action,
+            exc,
+            exc_info=True,
+        )
+
+
+def _input_from_call(args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
+    if "inputs" in kwargs:
+        inputs = kwargs["inputs"]
+        return {} if inputs is None else inputs
+    if args and (args[0] is None or isinstance(args[0], dict)):
+        return {} if args[0] is None else args[0]
+    return {}
+
+
+def _call_arg(
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    index: int,
+    name: str,
+    default: Any = None,
+) -> Any:
+    if len(args) > index:
+        return args[index]
+    return kwargs.get(name, default)
+
+
+def _looks_like_tool(value: Any) -> bool:
+    return bool(getattr(value, "name", None)) and bool(
+        getattr(value, "description", None)
+    )
+
+
+def _looks_like_tool_calling(value: Any) -> bool:
+    if isinstance(value, dict):
+        return "arguments" in value or "tool_input" in value
+    return (
+        getattr(value, "arguments", None) is not None
+        or getattr(value, "tool_name", None) is not None
+        or getattr(value, "tool_call_id", None) is not None
+    )
+
+
+def _tool_call_from_call(
+    args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> tuple[Any, Any]:
+    tool = kwargs.get("tool")
+    calling = kwargs.get("calling") or kwargs.get("tool_calling")
+
+    if tool is None:
+        for candidate in args:
+            if _looks_like_tool(candidate):
+                tool = candidate
+                break
+    if calling is None:
+        for candidate in args:
+            if candidate is tool:
+                continue
+            if _looks_like_tool_calling(candidate):
+                calling = candidate
+                break
+
+    return tool or _call_arg(args, kwargs, 0, "tool"), calling
+
+
+def _tool_call_arguments(instance: Any, calling: Any) -> Any:
+    arguments = getattr(calling, "arguments", None)
+    if arguments is None and isinstance(calling, dict):
+        arguments = calling.get("arguments") or calling.get("tool_input")
+    if arguments is not None:
+        return arguments
+
+    action = getattr(instance, "action", None)
+    if action is None:
+        return None
+    return getattr(action, "tool_input", None)
+
+
+def _agent_usage_sources(agent: Any) -> tuple[Any, ...]:
+    if agent is None:
+        return ()
+    return (
+        getattr(agent, "_token_process", None),
+        getattr(agent, "llm", None),
+    )
+
+
+def _crew_usage_sources(instance: Any) -> tuple[Any, ...]:
+    agents = getattr(instance, "agents", None)
+    if not isinstance(agents, (list, tuple)):
+        return ()
+    sources: list[Any] = []
+    for agent in agents:
+        sources.extend(_agent_usage_sources(agent))
+    return tuple(sources)
+
+
+def _should_skip_entry(instance: Any) -> bool:
+    return _ENTRY_DEPTH.get() > 0 or getattr(instance, "stream", False) is True
+
+
+def _enter_entry() -> Token[int]:
+    return _ENTRY_DEPTH.set(_ENTRY_DEPTH.get() + 1)
+
+
+def _enter_task() -> Token[int]:
+    return _TASK_DEPTH.set(_TASK_DEPTH.get() + 1)
+
+
+def _result_content(result: Any) -> Any:
+    if isinstance(result, (str, bytes, bytearray)):
+        return result
+    if hasattr(result, "result"):
+        try:
+            return result.result
+        except Exception:
+            pass
+    return result
+
+
+def _finish_entry_success(
+    handler: ExtendedTelemetryHandler,
+    invocation: Any,
+    started: bool,
+    result: Any,
+    instance: Any,
+) -> None:
+    def post_process() -> None:
+        invocation.output_messages = to_output_messages(
+            "assistant", _result_content(result)
+        )
+        invocation.attributes.update(
+            usage_metric_attributes(
+                result, instance, *_crew_usage_sources(instance)
+            )
+        )
+        _set_ok(invocation)
+
+    _safe_post_process("entry success", post_process)
+    if started:
+        _safe_handler_call("stop_entry", handler.stop_entry, invocation)
+
+
+def _fail_entry(
+    handler: ExtendedTelemetryHandler,
+    invocation: Any,
+    started: bool,
+    exc: BaseException,
+) -> None:
+    if not started:
+        return
+    _record_exception(invocation, exc)
+    _safe_handler_call(
+        "fail_entry",
+        handler.fail_entry,
+        invocation,
+        _error(exc),
+    )
+
+
+def _finish_agent_success(
+    handler: ExtendedTelemetryHandler,
+    invocation: Any,
+    started: bool,
+    result: Any,
+    *usage_sources: Any,
+) -> None:
+    def post_process() -> None:
+        invocation.output_messages = to_output_messages(
+            "assistant", _result_content(result)
+        )
+        apply_usage_metrics(invocation, result, *usage_sources)
+        _set_ok(invocation)
+
+    _safe_post_process("agent success", post_process)
+    if started:
+        _safe_handler_call(
+            "stop_invoke_agent",
+            handler.stop_invoke_agent,
+            invocation,
+        )
+
+
+def _fail_agent(
+    handler: ExtendedTelemetryHandler,
+    invocation: Any,
+    started: bool,
+    exc: BaseException,
+) -> None:
+    if not started:
+        return
+    _record_exception(invocation, exc)
+    _safe_handler_call(
+        "fail_invoke_agent",
+        handler.fail_invoke_agent,
+        invocation,
+        _error(exc),
+    )
+
+
+def _is_tool_parsing_error(instance: Any) -> bool:
+    if not instance:
+        return False
+    run_attempts = getattr(instance, "_run_attempts", None)
+    max_parsing_attempts = getattr(instance, "_max_parsing_attempts", None)
+    return bool(
+        max_parsing_attempts
+        and run_attempts
+        and run_attempts > max_parsing_attempts
+    )
+
+
+def _finish_tool_success(
+    handler: ExtendedTelemetryHandler,
+    invocation: Any,
+    started: bool,
+    result: Any,
+    instance: Any,
+    tool: Any,
+) -> None:
+    error: RuntimeError | None = None
+
+    def post_process() -> None:
+        nonlocal error
+        invocation.tool_call_result = result
+        if _is_tool_parsing_error(instance):
+            error = RuntimeError(
+                "CrewAI tool parsing attempts exceeded for "
+                f"{getattr(tool, 'name', 'unknown_tool')}: "
+                f"{getattr(instance, '_run_attempts', None)}/"
+                f"{getattr(instance, '_max_parsing_attempts', None)}"
+            )
+            _record_exception(invocation, error)
+        else:
+            _set_ok(invocation)
+
+    _safe_post_process("tool success", post_process)
+    if not started:
+        return
+    if error is not None:
+        _safe_handler_call(
+            "fail_execute_tool",
+            handler.fail_execute_tool,
+            invocation,
+            _error(error),
+        )
+    else:
+        _safe_handler_call(
+            "stop_execute_tool",
+            handler.stop_execute_tool,
+            invocation,
+        )
+
+
+def _fail_tool(
+    handler: ExtendedTelemetryHandler,
+    invocation: Any,
+    started: bool,
+    exc: BaseException,
+) -> None:
+    if not started:
+        return
+    _record_exception(invocation, exc)
+    _safe_handler_call(
+        "fail_execute_tool",
+        handler.fail_execute_tool,
+        invocation,
+        _error(exc),
+    )
+
+
+def _wrap_stream_result(
+    result: Any,
+    on_success: Any,
+    on_error: Any,
+    cleanup: Any,
+) -> bool:
+    sync_iterator = getattr(result, "_sync_iterator", None)
+    async_iterator = getattr(result, "_async_iterator", None)
+
+    if sync_iterator is not None:
+
+        def iterate():
+            try:
+                for chunk in sync_iterator:
+                    yield chunk
+            except Exception as exc:
+                on_error(exc)
+                raise
+            else:
+                on_success(result)
+            finally:
+                cleanup()
+
+        result._sync_iterator = iterate()
+        return True
+
+    if async_iterator is not None:
+
+        async def async_iterate():
+            try:
+                async for chunk in async_iterator:
+                    yield chunk
+            except Exception as exc:
+                on_error(exc)
+                raise
+            else:
+                on_success(result)
+            finally:
+                cleanup()
+
+        result._async_iterator = async_iterate()
+        return True
+
+    return False
+
+
+def _run_entry_sync(
+    handler: ExtendedTelemetryHandler,
+    operation_name: str,
+    wrapped: Any,
+    instance: Any,
+    args: Any,
+    kwargs: Any,
+) -> Any:
+    if _should_skip_entry(instance):
+        return wrapped(*args, **kwargs)
+
+    def build_invocation() -> Any:
+        return create_entry_invocation(
+            instance,
+            _input_from_call(args, kwargs),
+            operation_name,
+        )
+
+    invocation = _safe_build_invocation(operation_name, build_invocation)
+    if invocation is None:
+        return wrapped(*args, **kwargs)
+
+    token = _enter_entry()
+    started = _safe_handler_call(
+        "start_entry", handler.start_entry, invocation
+    )
+    cleanup_done = False
+
+    def cleanup() -> None:
+        nonlocal cleanup_done
+        if cleanup_done:
+            return
+        cleanup_done = True
+        _ENTRY_DEPTH.reset(token)
+
+    try:
+        result = wrapped(*args, **kwargs)
+    except Exception as exc:
+        try:
+            _fail_entry(handler, invocation, started, exc)
+        finally:
+            cleanup()
+        raise
+
+    if _wrap_stream_result(
+        result,
+        lambda stream_result: _finish_entry_success(
+            handler, invocation, started, stream_result, instance
+        ),
+        lambda exc: _fail_entry(handler, invocation, started, exc),
+        cleanup,
+    ):
+        return result
+
+    try:
+        _finish_entry_success(handler, invocation, started, result, instance)
+        return result
+    finally:
+        cleanup()
+
+
+async def _run_entry_async(
+    handler: ExtendedTelemetryHandler,
+    operation_name: str,
+    wrapped: Any,
+    instance: Any,
+    args: Any,
+    kwargs: Any,
+) -> Any:
+    if _should_skip_entry(instance):
+        return await wrapped(*args, **kwargs)
+
+    def build_invocation() -> Any:
+        return create_entry_invocation(
+            instance,
+            _input_from_call(args, kwargs),
+            operation_name,
+        )
+
+    invocation = _safe_build_invocation(operation_name, build_invocation)
+    if invocation is None:
+        return await wrapped(*args, **kwargs)
+
+    token = _enter_entry()
+    started = _safe_handler_call(
+        "start_entry", handler.start_entry, invocation
+    )
+    cleanup_done = False
+
+    def cleanup() -> None:
+        nonlocal cleanup_done
+        if cleanup_done:
+            return
+        cleanup_done = True
+        _ENTRY_DEPTH.reset(token)
+
+    try:
+        result = await wrapped(*args, **kwargs)
+    except Exception as exc:
+        try:
+            _fail_entry(handler, invocation, started, exc)
+        finally:
+            cleanup()
+        raise
+
+    if _wrap_stream_result(
+        result,
+        lambda stream_result: _finish_entry_success(
+            handler, invocation, started, stream_result, instance
+        ),
+        lambda exc: _fail_entry(handler, invocation, started, exc),
+        cleanup,
+    ):
+        return result
+
+    try:
+        _finish_entry_success(handler, invocation, started, result, instance)
+        return result
+    finally:
+        cleanup()
 
 
 class CrewAIInstrumentor(BaseInstrumentor):
-    """
-    An instrumentor for CrewAI framework.
+    """Instrumentor for the CrewAI framework."""
 
-    """
+    def __init__(self) -> None:
+        super().__init__()
+        self._handler: ExtendedTelemetryHandler | None = None
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
     def _instrument(self, **kwargs: Any) -> None:
-        """Instrument CrewAI framework."""
         tracer_provider = kwargs.get("tracer_provider")
-        tracer = trace_api.get_tracer(
-            __name__,
-            "",
+        meter_provider = kwargs.get("meter_provider")
+        logger_provider = kwargs.get("logger_provider")
+
+        self._handler = ExtendedTelemetryHandler(
             tracer_provider=tracer_provider,
+            meter_provider=meter_provider,
+            logger_provider=logger_provider,
         )
 
-        genai_helper = GenAIHookHelper()
-
-        # Wrap Crew.kickoff (CHAIN span)
-        try:
-            wrap_function_wrapper(
-                module="crewai.crew",
-                name="Crew.kickoff",
-                wrapper=_CrewKickoffWrapper(tracer, genai_helper),
-            )
-        except Exception as e:
-            logger.warning(f"Could not wrap Crew.kickoff: {e}")
-
-        # Wrap Flow.kickoff_async (CHAIN span)
-        try:
-            wrap_function_wrapper(
-                module="crewai.flow.flow",
-                name="Flow.kickoff_async",
-                wrapper=_FlowKickoffAsyncWrapper(tracer, genai_helper),
-            )
-        except Exception as e:
-            logger.debug(f"Could not wrap Flow.kickoff_async: {e}")
-
-        # Wrap Agent.execute_task (AGENT span)
-        try:
-            wrap_function_wrapper(
-                module="crewai.agent",
-                name="Agent.execute_task",
-                wrapper=_AgentExecuteTaskWrapper(tracer, genai_helper),
-            )
-        except Exception as e:
-            logger.warning(f"Could not wrap Agent.execute_task: {e}")
-
-        # Wrap Task.execute_sync (TASK span)
-        try:
-            wrap_function_wrapper(
-                module="crewai.task",
-                name="Task.execute_sync",
-                wrapper=_TaskExecuteSyncWrapper(tracer, genai_helper),
-            )
-        except Exception as e:
-            logger.warning(f"Could not wrap Task.execute_sync: {e}")
-
-        # Wrap ToolUsage._use (TOOL span)
-        try:
-            wrap_function_wrapper(
-                module="crewai.tools.tool_usage",
-                name="ToolUsage._use",
-                wrapper=_ToolUseWrapper(tracer, genai_helper),
-            )
-        except Exception as e:
-            logger.debug(f"Could not wrap ToolUsage._use: {e}")
+        for module, name, wrapper in (
+            (
+                "crewai.crew",
+                "Crew.kickoff",
+                _CrewKickoffWrapper(self._handler),
+            ),
+            (
+                "crewai.crew",
+                "Crew.kickoff_async",
+                _CrewKickoffAsyncWrapper(self._handler),
+            ),
+            (
+                "crewai.flow.flow",
+                "Flow.kickoff",
+                _FlowKickoffWrapper(self._handler),
+            ),
+            (
+                "crewai.flow.flow",
+                "Flow.kickoff_async",
+                _FlowKickoffAsyncWrapper(self._handler),
+            ),
+            (
+                "crewai.agent",
+                "Agent.execute_task",
+                _AgentExecuteTaskWrapper(self._handler),
+            ),
+            (
+                "crewai.task",
+                "Task.execute_sync",
+                _TaskExecuteSyncWrapper(self._handler),
+            ),
+            (
+                "crewai.tools.tool_usage",
+                "ToolUsage._use",
+                _ToolUseWrapper(self._handler),
+            ),
+        ):
+            try:
+                wrap_function_wrapper(
+                    module=module, name=name, wrapper=wrapper
+                )
+            except Exception as exc:
+                logger.warning("Could not wrap %s: %s", name, exc)
 
     def _uninstrument(self, **kwargs: Any) -> None:
-        """Uninstrument CrewAI framework."""
+        del kwargs
         if not _CREWAI_LOADED:
             logger.debug(
                 "CrewAI modules were not available for uninstrumentation."
             )
+            self._handler = None
             return
-        try:
-            unwrap(crewai.crew.Crew, "kickoff")
-            unwrap(crewai.flow.flow.Flow, "kickoff_async")
-            unwrap(crewai.agent.Agent, "execute_task")
-            unwrap(crewai.task.Task, "execute_sync")
-            unwrap(crewai.tools.tool_usage.ToolUsage, "_use")
 
-        except Exception as e:
-            logger.debug(f"Error during uninstrumenting: {e}")
+        for target, method_name in (
+            (crewai.crew.Crew, "kickoff"),
+            (crewai.crew.Crew, "kickoff_async"),
+            (crewai.flow.flow.Flow, "kickoff"),
+            (crewai.flow.flow.Flow, "kickoff_async"),
+            (crewai.agent.Agent, "execute_task"),
+            (crewai.task.Task, "execute_sync"),
+            (crewai.tools.tool_usage.ToolUsage, "_use"),
+        ):
+            try:
+                unwrap(target, method_name)
+            except Exception as exc:
+                logger.debug(
+                    "Could not unwrap %s.%s: %s",
+                    getattr(target, "__name__", target),
+                    method_name,
+                    exc,
+                )
+
+        self._handler = None
 
 
 class _CrewKickoffWrapper:
-    """
-    Wrapper for Crew.kickoff method to create CHAIN span.
-    """
+    """Wrap ``Crew.kickoff`` as a util-genai Entry span."""
 
-    def __init__(self, tracer: trace_api.Tracer, helper: GenAIHookHelper):
-        self._tracer = tracer
-        self._helper = helper
+    def __init__(self, handler: ExtendedTelemetryHandler):
+        self._handler = handler
 
-    def __call__(self, wrapped, instance, args, kwargs):
-        """Wrap Crew.kickoff to create CHAIN span."""
-        inputs = kwargs.get("inputs", {})
-        crew_name = getattr(instance, "name", None) or "crew.kickoff"
+    def __call__(self, wrapped: Any, instance: Any, args: Any, kwargs: Any):
+        return _run_entry_sync(
+            self._handler, OP_NAME_CREW, wrapped, instance, args, kwargs
+        )
 
-        genai_inputs = to_input_message("user", inputs)
 
-        with self._tracer.start_as_current_span(
-            name=crew_name,
-            kind=SpanKind.INTERNAL,
-            attributes={
-                gen_ai_attributes.GEN_AI_OPERATION_NAME: OP_NAME_CREW,
-                gen_ai_attributes.GEN_AI_SYSTEM: "crewai",
-                gen_ai_extended_attributes.GEN_AI_SPAN_KIND: gen_ai_extended_attributes.GenAiSpanKindValues.AGENT.value,
-            },
-        ) as span:
-            try:
-                result = wrapped(*args, **kwargs)
+class _CrewKickoffAsyncWrapper:
+    """Wrap ``Crew.kickoff_async`` as a util-genai Entry span."""
 
-                output_val = (
-                    result.raw if hasattr(result, "raw") else str(result)
-                )
-                genai_outputs = to_output_message("assistant", output_val)
+    def __init__(self, handler: ExtendedTelemetryHandler):
+        self._handler = handler
 
-                self._helper.on_completion(span, genai_inputs, genai_outputs)
-                span.set_status(Status(StatusCode.OK))
-                return result
-            except Exception as e:
-                span.record_exception(e)
-                span.set_status(Status(StatusCode.ERROR))
-                self._helper.on_completion(span, genai_inputs, [])
-                raise
+    async def __call__(
+        self, wrapped: Any, instance: Any, args: Any, kwargs: Any
+    ):
+        return await _run_entry_async(
+            self._handler, OP_NAME_CREW, wrapped, instance, args, kwargs
+        )
+
+
+class _FlowKickoffWrapper:
+    """Wrap ``Flow.kickoff`` as a util-genai Entry span."""
+
+    def __init__(self, handler: ExtendedTelemetryHandler):
+        self._handler = handler
+
+    def __call__(self, wrapped: Any, instance: Any, args: Any, kwargs: Any):
+        return _run_entry_sync(
+            self._handler, OP_NAME_FLOW, wrapped, instance, args, kwargs
+        )
 
 
 class _FlowKickoffAsyncWrapper:
-    """Wrapper for Flow.kickoff_async method to create CHAIN span."""
+    """Wrap ``Flow.kickoff_async`` as a util-genai Entry span."""
 
-    def __init__(self, tracer: trace_api.Tracer, helper: GenAIHookHelper):
-        self._tracer = tracer
-        self._helper = helper
+    def __init__(self, handler: ExtendedTelemetryHandler):
+        self._handler = handler
 
-    async def __call__(self, wrapped, instance, args, kwargs):
-        """Wrap Flow.kickoff_async to create CHAIN span."""
-        inputs = kwargs.get("inputs", {})
-        flow_name = getattr(instance, "name", None) or "flow.kickoff"
-
-        genai_inputs = to_input_message("user", inputs)
-
-        with self._tracer.start_as_current_span(
-            name=flow_name,
-            kind=SpanKind.INTERNAL,
-            attributes={
-                gen_ai_attributes.GEN_AI_OPERATION_NAME: OP_NAME_CREW,
-                gen_ai_attributes.GEN_AI_SYSTEM: "crewai",
-                gen_ai_extended_attributes.GEN_AI_SPAN_KIND: gen_ai_extended_attributes.GenAiSpanKindValues.AGENT.value,
-            },
-        ) as span:
-            try:
-                result = await wrapped(*args, **kwargs)
-                genai_outputs = to_output_message("assistant", result)
-                self._helper.on_completion(span, genai_inputs, genai_outputs)
-                span.set_status(Status(StatusCode.OK))
-                return result
-            except Exception as e:
-                span.record_exception(e)
-                span.set_status(Status(StatusCode.ERROR))
-                self._helper.on_completion(span, genai_inputs, [])
-                raise
+    async def __call__(
+        self, wrapped: Any, instance: Any, args: Any, kwargs: Any
+    ):
+        return await _run_entry_async(
+            self._handler, OP_NAME_FLOW, wrapped, instance, args, kwargs
+        )
 
 
 class _AgentExecuteTaskWrapper:
-    """Wrapper for Agent.execute_task method to create AGENT span."""
+    """Wrap ``Agent.execute_task`` as a util-genai invoke_agent span."""
 
-    def __init__(self, tracer: trace_api.Tracer, helper: GenAIHookHelper):
-        self._tracer = tracer
-        self._helper = helper
+    def __init__(self, handler: ExtendedTelemetryHandler):
+        self._handler = handler
 
-    def __call__(self, wrapped, instance, args, kwargs):
-        """Wrap Agent.execute_task to create AGENT span."""
-        task = args[0] if args else kwargs.get("task")
-        context = kwargs.get("context", "")
-        tools = kwargs.get("tools", [])
-        agent_role = getattr(instance, "role", "agent")
+    def __call__(self, wrapped: Any, instance: Any, args: Any, kwargs: Any):
+        if _TASK_DEPTH.get() > 0:
+            return wrapped(*args, **kwargs)
 
-        span_name = f"Agent.{agent_role}"
+        task = _call_arg(args, kwargs, 0, "task")
+        context = _call_arg(args, kwargs, 1, "context", "")
+        tools = _call_arg(args, kwargs, 2, "tools", [])
+        invocation = _safe_build_invocation(
+            "agent",
+            create_agent_invocation,
+            instance,
+            task,
+            context,
+            tools,
+        )
+        if invocation is None:
+            return wrapped(*args, **kwargs)
 
-        genai_inputs = extract_agent_inputs(task, context, tools)
+        started = _safe_handler_call(
+            "start_invoke_agent", self._handler.start_invoke_agent, invocation
+        )
+        try:
+            result = wrapped(*args, **kwargs)
+        except Exception as exc:
+            _fail_agent(self._handler, invocation, started, exc)
+            raise
 
-        with self._tracer.start_as_current_span(
-            name=span_name,
-            kind=SpanKind.INTERNAL,
-            attributes={
-                gen_ai_attributes.GEN_AI_OPERATION_NAME: OP_NAME_AGENT,
-                gen_ai_attributes.GEN_AI_SYSTEM: "crewai",
-                "gen_ai.agent.name": agent_role,
-                gen_ai_extended_attributes.GEN_AI_SPAN_KIND: gen_ai_extended_attributes.GenAiSpanKindValues.AGENT.value,
-            },
-        ) as span:
-            try:
-                result = wrapped(*args, **kwargs)
-
-                genai_outputs = to_output_message("assistant", result)
-
-                self._helper.on_completion(span, genai_inputs, genai_outputs)
-                span.set_status(Status(StatusCode.OK))
-                return result
-            except Exception as e:
-                span.record_exception(e)
-                span.set_status(Status(StatusCode.ERROR))
-                self._helper.on_completion(span, genai_inputs, [])
-                raise
+        _finish_agent_success(
+            self._handler,
+            invocation,
+            started,
+            result,
+            instance,
+            *_agent_usage_sources(instance),
+            getattr(instance, "crew", None),
+        )
+        return result
 
 
 class _TaskExecuteSyncWrapper:
-    """Wrapper for Task.execute_sync method to create TASK span."""
+    """Wrap ``Task.execute_sync`` as a util-genai invoke_agent span."""
 
-    def __init__(self, tracer: trace_api.Tracer, helper: GenAIHookHelper):
-        self._tracer = tracer
-        self._helper = helper
+    def __init__(self, handler: ExtendedTelemetryHandler):
+        self._handler = handler
 
-    def __call__(self, wrapped, instance, args, kwargs):
-        """Wrap Task.execute_sync to create TASK span."""
-        task_desc = getattr(instance, "description", "task")
-        span_name = f"Task.{task_desc[:50]}"
+    def __call__(self, wrapped: Any, instance: Any, args: Any, kwargs: Any):
+        agent = _call_arg(args, kwargs, 0, "agent")
+        if agent is None:
+            agent = getattr(instance, "agent", None)
+        invocation = _safe_build_invocation(
+            "task", create_task_invocation, instance, agent
+        )
+        if invocation is None:
+            return wrapped(*args, **kwargs)
 
-        genai_inputs = to_input_message("user", task_desc)
+        started = _safe_handler_call(
+            "start_invoke_agent", self._handler.start_invoke_agent, invocation
+        )
+        task_token = _enter_task()
+        try:
+            result = wrapped(*args, **kwargs)
+        except Exception as exc:
+            _fail_agent(self._handler, invocation, started, exc)
+            raise
+        finally:
+            _TASK_DEPTH.reset(task_token)
 
-        with self._tracer.start_as_current_span(
-            name=span_name,
-            kind=SpanKind.INTERNAL,
-            attributes={
-                gen_ai_attributes.GEN_AI_OPERATION_NAME: OP_NAME_TASK,
-                gen_ai_attributes.GEN_AI_SYSTEM: "crewai",
-                gen_ai_extended_attributes.GEN_AI_SPAN_KIND: gen_ai_extended_attributes.GenAiSpanKindValues.AGENT.value,
-            },
-        ) as span:
-            try:
-                result = wrapped(*args, **kwargs)
-                genai_outputs = to_output_message("assistant", result)
-                self._helper.on_completion(span, genai_inputs, genai_outputs)
-                span.set_status(Status(StatusCode.OK))
-                return result
-            except Exception as e:
-                span.record_exception(e)
-                span.set_status(Status(StatusCode.ERROR))
-                self._helper.on_completion(span, genai_inputs, [])
-                raise
+        _finish_agent_success(
+            self._handler,
+            invocation,
+            started,
+            result,
+            instance,
+            agent,
+            *_agent_usage_sources(agent),
+            getattr(agent, "crew", None),
+        )
+        return result
 
 
 class _ToolUseWrapper:
-    """Wrapper for ToolUsage._use method to create TOOL span."""
+    """Wrap ``ToolUsage._use`` as a util-genai execute_tool span."""
 
-    def __init__(self, tracer: trace_api.Tracer, helper: GenAIHookHelper):
-        self._tracer = tracer
-        self._helper = helper
+    def __init__(self, handler: ExtendedTelemetryHandler):
+        self._handler = handler
 
-    def __call__(self, wrapped, instance, args, kwargs):
-        """Wrap ToolUsage._use to create TOOL span."""
-        tool = args[0] if args else kwargs.get("tool")
-        tool_name = (
-            getattr(tool, "name", "unknown_tool") if tool else "unknown_tool"
+    def __call__(self, wrapped: Any, instance: Any, args: Any, kwargs: Any):
+        try:
+            tool, tool_calling = _tool_call_from_call(args, kwargs)
+            tool_call_arguments = _tool_call_arguments(instance, tool_calling)
+        except Exception as exc:
+            logger.warning(
+                "CrewAI instrumentation tool invocation build failed: %s",
+                exc,
+                exc_info=True,
+            )
+            return wrapped(*args, **kwargs)
+
+        invocation = _safe_build_invocation(
+            "tool",
+            create_tool_invocation,
+            tool,
+            tool_calling,
+            tool_call_arguments=tool_call_arguments,
         )
+        if invocation is None:
+            return wrapped(*args, **kwargs)
 
-        tool_calling = args[1] if len(args) > 1 else kwargs.get("tool_calling")
-        arguments = (
-            getattr(tool_calling, "arguments", {}) if tool_calling else {}
+        started = _safe_handler_call(
+            "start_execute_tool", self._handler.start_execute_tool, invocation
         )
-        genai_inputs = extract_tool_inputs(tool_name, arguments)
+        try:
+            result = wrapped(*args, **kwargs)
+        except Exception as exc:
+            _fail_tool(self._handler, invocation, started, exc)
+            raise
 
-        with self._tracer.start_as_current_span(
-            name=f"Tool.{tool_name}",
-            kind=SpanKind.INTERNAL,
-            attributes={
-                gen_ai_attributes.GEN_AI_OPERATION_NAME: OP_NAME_TOOL,
-                gen_ai_attributes.GEN_AI_SYSTEM: "crewai",
-                gen_ai_attributes.GEN_AI_TOOL_NAME: tool_name,
-                gen_ai_extended_attributes.GEN_AI_SPAN_KIND: gen_ai_extended_attributes.GenAiSpanKindValues.TOOL.value,
-            },
-        ) as span:
-            # Set tool description
-            if tool and hasattr(tool, "description"):
-                span.set_attribute("gen_ai.tool.description", tool.description)
+        _finish_tool_success(
+            self._handler,
+            invocation,
+            started,
+            result,
+            instance,
+            tool,
+        )
+        return result
 
-            try:
-                result = wrapped(*args, **kwargs)
 
-                genai_outputs = to_output_message("tool", result)
-
-                self._helper.on_completion(span, genai_inputs, genai_outputs)
-
-                is_error = False
-                if instance:
-                    _run_attempts = getattr(instance, "_run_attempts", None)
-                    _max_parsing_attempts = getattr(
-                        instance, "_max_parsing_attempts", None
-                    )
-                    if (
-                        _max_parsing_attempts
-                        and _run_attempts
-                        and _run_attempts > _max_parsing_attempts
-                    ):
-                        span.set_status(Status(StatusCode.ERROR))
-                        is_error = True
-
-                if not is_error:
-                    span.set_status(Status(StatusCode.OK))
-
-                return result
-            except Exception as e:
-                span.record_exception(e)
-                span.set_status(Status(StatusCode.ERROR))
-                self._helper.on_completion(span, genai_inputs, [])
-                raise
+__all__ = [
+    "__version__",
+    "CrewAIInstrumentor",
+    "GenAIHookHelper",
+    "_CrewKickoffWrapper",
+    "_CrewKickoffAsyncWrapper",
+    "_FlowKickoffWrapper",
+    "_FlowKickoffAsyncWrapper",
+    "_AgentExecuteTaskWrapper",
+    "_TaskExecuteSyncWrapper",
+    "_ToolUseWrapper",
+]

--- a/instrumentation-loongsuite/loongsuite-instrumentation-crewai/src/opentelemetry/instrumentation/crewai/__init__.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-crewai/src/opentelemetry/instrumentation/crewai/__init__.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import logging
 from contextvars import ContextVar, Token
+from importlib import import_module
 from typing import Any, Collection
 
 from wrapt import wrap_function_wrapper
@@ -42,20 +43,18 @@ from opentelemetry.trace import Status, StatusCode
 from opentelemetry.util.genai.extended_handler import ExtendedTelemetryHandler
 from opentelemetry.util.genai.types import Error
 
-try:
-    import crewai.agent
-    import crewai.crew
-    import crewai.flow.flow
-    import crewai.task
-    import crewai.tools.tool_usage
-
-    _CREWAI_LOADED = True
-except ImportError:
-    _CREWAI_LOADED = False
-
 logger = logging.getLogger(__name__)
 _ENTRY_DEPTH: ContextVar[int] = ContextVar("crewai_entry_depth", default=0)
 _TASK_DEPTH: ContextVar[int] = ContextVar("crewai_task_depth", default=0)
+_CREWAI_UNINSTRUMENT_TARGETS = (
+    ("crewai.crew", "Crew", "kickoff"),
+    ("crewai.crew", "Crew", "kickoff_async"),
+    ("crewai.flow.flow", "Flow", "kickoff"),
+    ("crewai.flow.flow", "Flow", "kickoff_async"),
+    ("crewai.agent", "Agent", "execute_task"),
+    ("crewai.task", "Task", "execute_sync"),
+    ("crewai.tools.tool_usage", "ToolUsage", "_use"),
+)
 
 
 def _set_ok(invocation: Any) -> None:
@@ -113,6 +112,33 @@ def _safe_post_process(action: str, callback: Any) -> None:
             exc,
             exc_info=True,
         )
+
+
+def _uninstrument_targets() -> list[tuple[Any, str]]:
+    targets = []
+    for module_name, class_name, method_name in _CREWAI_UNINSTRUMENT_TARGETS:
+        try:
+            module = import_module(module_name)
+            target = getattr(module, class_name)
+        except ImportError:
+            logger.debug(
+                "CrewAI module %s was not available for uninstrumentation.",
+                module_name,
+                exc_info=True,
+            )
+            continue
+        except Exception as exc:
+            logger.warning(
+                "Could not resolve CrewAI target %s.%s for "
+                "uninstrumentation: %s",
+                module_name,
+                class_name,
+                exc,
+                exc_info=True,
+            )
+            continue
+        targets.append((target, method_name))
+    return targets
 
 
 def _input_from_call(args: tuple[Any, ...], kwargs: dict[str, Any]) -> Any:
@@ -615,22 +641,7 @@ class CrewAIInstrumentor(BaseInstrumentor):
 
     def _uninstrument(self, **kwargs: Any) -> None:
         del kwargs
-        if not _CREWAI_LOADED:
-            logger.debug(
-                "CrewAI modules were not available for uninstrumentation."
-            )
-            self._handler = None
-            return
-
-        for target, method_name in (
-            (crewai.crew.Crew, "kickoff"),
-            (crewai.crew.Crew, "kickoff_async"),
-            (crewai.flow.flow.Flow, "kickoff"),
-            (crewai.flow.flow.Flow, "kickoff_async"),
-            (crewai.agent.Agent, "execute_task"),
-            (crewai.task.Task, "execute_sync"),
-            (crewai.tools.tool_usage.ToolUsage, "_use"),
-        ):
+        for target, method_name in _uninstrument_targets():
             try:
                 unwrap(target, method_name)
             except Exception as exc:

--- a/instrumentation-loongsuite/loongsuite-instrumentation-crewai/src/opentelemetry/instrumentation/crewai/utils.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-crewai/src/opentelemetry/instrumentation/crewai/utils.py
@@ -12,19 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import dataclasses
-import logging
-from typing import Any, Dict, List, Optional
+"""Helpers for building util-genai invocations from CrewAI objects."""
 
-from opentelemetry.semconv._incubating.attributes import gen_ai_attributes
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+from opentelemetry.semconv._incubating.attributes import (
+    gen_ai_attributes as GenAI,
+)
 from opentelemetry.trace import Span
+from opentelemetry.util.genai.extended_types import (
+    EntryInvocation,
+    ExecuteToolInvocation,
+    InvokeAgentInvocation,
+)
 from opentelemetry.util.genai.types import (
     ContentCapturingMode,
+    FunctionToolDefinition,
     InputMessage,
     MessagePart,
     OutputMessage,
     Text,
     ToolCall,
+    ToolDefinition,
 )
 from opentelemetry.util.genai.utils import (
     gen_ai_json_dumps,
@@ -32,26 +44,582 @@ from opentelemetry.util.genai.utils import (
     is_experimental_mode,
 )
 
-logger = logging.getLogger(__name__)
+CREWAI_PROVIDER = "crewai"
+CREWAI_OPERATION = "gen_ai.crewai.operation"
+CREWAI_COMPONENT = "gen_ai.crewai.component"
+CREWAI_TASK_DESCRIPTION = "gen_ai.crewai.task.description"
+CREWAI_TASK_EXPECTED_OUTPUT = "gen_ai.crewai.task.expected_output"
+CREWAI_AGENT_GOAL = "gen_ai.crewai.agent.goal"
+CREWAI_AGENT_BACKSTORY = "gen_ai.crewai.agent.backstory"
+CREWAI_PROCESS = "gen_ai.crewai.process"
+CREWAI_TOOLS_COUNT = "gen_ai.crewai.tools.count"
+CREWAI_USAGE_SUCCESSFUL_REQUESTS = "gen_ai.crewai.usage.successful_requests"
+CREWAI_INPUT_METADATA_KEYS = {
+    "conversation_id",
+    "session_id",
+    "streaming",
+    "thread_id",
+    "user_id",
+}
 
 OP_NAME_CREW = "crew.kickoff"
+OP_NAME_FLOW = "flow.kickoff"
 OP_NAME_AGENT = "agent.execute"
 OP_NAME_TASK = "task.execute"
 OP_NAME_TOOL = "tool.execute"
 
 
+def _stringify(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if hasattr(value, "result"):
+        try:
+            return _stringify(value.result)
+        except Exception:
+            pass
+    raw = getattr(value, "raw", None)
+    if raw is not None:
+        return str(raw)
+    return str(value)
+
+
+def _non_empty_string(value: Any) -> str | None:
+    text = _stringify(value).strip()
+    return text or None
+
+
+def _int_value(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _field_value(value: Any, *names: str) -> Any:
+    for name in names:
+        if isinstance(value, dict) and name in value:
+            return value[name]
+        try:
+            members = vars(value)
+        except TypeError:
+            members = {}
+        if name in members:
+            return members[name]
+        if name not in dir(value):
+            continue
+        try:
+            return getattr(value, name)
+        except AttributeError:
+            pass
+    return None
+
+
+def _should_capture_content() -> bool:
+    if not is_experimental_mode():
+        return False
+    try:
+        return get_content_capturing_mode() in (
+            ContentCapturingMode.SPAN_ONLY,
+            ContentCapturingMode.SPAN_AND_EVENT,
+        )
+    except ValueError:
+        return False
+
+
+def _usage_metrics(value: Any) -> Any:
+    if value is None:
+        return None
+
+    direct = _field_value(value, "token_usage", "usage_metrics", "usage")
+    if direct is not None and direct is not value:
+        return _usage_metrics(direct)
+
+    for method_name in ("get_token_usage_summary", "get_summary"):
+        method = _field_value(value, method_name)
+        if method is None:
+            continue
+        try:
+            summary = method()
+        except Exception:
+            continue
+        if summary is not None and summary is not value:
+            return _usage_metrics(summary)
+
+    has_usage_fields = any(
+        _field_value(value, name) is not None
+        for name in (
+            "prompt_tokens",
+            "input_tokens",
+            "completion_tokens",
+            "output_tokens",
+            "total_tokens",
+        )
+    )
+    return value if has_usage_fields else None
+
+
+def _usage_token_values_from_values(*values: Any) -> dict[str, int]:
+    first_observed: dict[str, int] = {}
+    for value in values:
+        usage_values = _usage_token_values(_usage_metrics(value))
+        if not usage_values:
+            continue
+        if not first_observed:
+            first_observed = usage_values
+        if (usage_values.get("input_tokens") or 0) + (
+            usage_values.get("output_tokens") or 0
+        ) > 0:
+            return usage_values
+    return first_observed
+
+
+def _usage_token_values(usage: Any) -> dict[str, int]:
+    if usage is None:
+        return {}
+
+    values: dict[str, int] = {}
+
+    input_tokens = _int_value(
+        _field_value(usage, "prompt_tokens", "input_tokens")
+    )
+    output_tokens = _int_value(
+        _field_value(usage, "completion_tokens", "output_tokens")
+    )
+    cache_read_tokens = _int_value(
+        _field_value(usage, "cached_prompt_tokens", "cache_read_input_tokens")
+    )
+    cache_creation_tokens = _int_value(
+        _field_value(
+            usage, "cache_creation_tokens", "cache_creation_input_tokens"
+        )
+    )
+    successful_requests = _int_value(
+        _field_value(usage, "successful_requests")
+    )
+    total_tokens = _int_value(_field_value(usage, "total_tokens"))
+
+    prompt_details = _field_value(usage, "prompt_tokens_details")
+    if cache_read_tokens is None and prompt_details is not None:
+        cache_read_tokens = _int_value(
+            _field_value(prompt_details, "cached_tokens")
+        )
+
+    if input_tokens is not None:
+        values["input_tokens"] = input_tokens
+    if output_tokens is not None:
+        values["output_tokens"] = output_tokens
+    if total_tokens is not None:
+        values["total_tokens"] = total_tokens
+    if cache_read_tokens is not None and cache_read_tokens > 0:
+        values["cache_read_input_tokens"] = cache_read_tokens
+    if cache_creation_tokens is not None and cache_creation_tokens > 0:
+        values["cache_creation_input_tokens"] = cache_creation_tokens
+    if successful_requests is not None and successful_requests > 0:
+        values["successful_requests"] = successful_requests
+
+    return values
+
+
+def apply_usage_metrics(invocation: Any, *values: Any) -> None:
+    usage_values = _usage_token_values_from_values(*values)
+    if not usage_values:
+        return
+
+    if "input_tokens" in usage_values:
+        invocation.input_tokens = usage_values["input_tokens"]
+    if "output_tokens" in usage_values:
+        invocation.output_tokens = usage_values["output_tokens"]
+    if "cache_read_input_tokens" in usage_values:
+        invocation.usage_cache_read_input_tokens = usage_values[
+            "cache_read_input_tokens"
+        ]
+    if "cache_creation_input_tokens" in usage_values:
+        invocation.usage_cache_creation_input_tokens = usage_values[
+            "cache_creation_input_tokens"
+        ]
+    if "successful_requests" in usage_values:
+        invocation.attributes[CREWAI_USAGE_SUCCESSFUL_REQUESTS] = usage_values[
+            "successful_requests"
+        ]
+
+
+def usage_metric_attributes(*values: Any) -> dict[str, int]:
+    usage_values = _usage_token_values_from_values(*values)
+    if not usage_values:
+        return {}
+
+    attributes: dict[str, int] = {}
+    input_tokens = usage_values.get("input_tokens")
+    output_tokens = usage_values.get("output_tokens")
+
+    if input_tokens is not None:
+        attributes[GenAI.GEN_AI_USAGE_INPUT_TOKENS] = input_tokens
+    if output_tokens is not None:
+        attributes[GenAI.GEN_AI_USAGE_OUTPUT_TOKENS] = output_tokens
+    if input_tokens is not None or output_tokens is not None:
+        attributes["gen_ai.usage.total_tokens"] = usage_values.get(
+            "total_tokens",
+            (input_tokens or 0) + (output_tokens or 0),
+        )
+    if "cache_read_input_tokens" in usage_values:
+        attributes["gen_ai.usage.cache_read.input_tokens"] = usage_values[
+            "cache_read_input_tokens"
+        ]
+    if "cache_creation_input_tokens" in usage_values:
+        attributes["gen_ai.usage.cache_creation.input_tokens"] = usage_values[
+            "cache_creation_input_tokens"
+        ]
+    if "successful_requests" in usage_values:
+        attributes[CREWAI_USAGE_SUCCESSFUL_REQUESTS] = usage_values[
+            "successful_requests"
+        ]
+    return attributes
+
+
+def _message_parts(*values: Any) -> list[MessagePart]:
+    parts: list[MessagePart] = []
+    for value in values:
+        text = _non_empty_string(value)
+        if text:
+            parts.append(Text(content=text))
+    return parts
+
+
+def to_input_messages(role: str, content: Any) -> list[InputMessage]:
+    parts = _message_parts(content)
+    if not parts:
+        return []
+    return [InputMessage(role=role, parts=parts)]
+
+
+def to_output_messages(
+    role: str, content: Any, finish_reason: str = "stop"
+) -> list[OutputMessage]:
+    parts = _message_parts(content)
+    if not parts:
+        return []
+    return [
+        OutputMessage(
+            role=role,
+            parts=parts,
+            finish_reason=finish_reason,
+        )
+    ]
+
+
+def _tool_parameters(tool: Any) -> Any:
+    args_schema = getattr(tool, "args_schema", None)
+    if args_schema is None:
+        return None
+    if hasattr(args_schema, "model_json_schema"):
+        return args_schema.model_json_schema()
+    if hasattr(args_schema, "schema"):
+        return args_schema.schema()
+    return None
+
+
+def tool_definitions(
+    tools: list[Any] | tuple[Any, ...] | None,
+) -> list[ToolDefinition]:
+    if not tools:
+        return []
+
+    definitions: list[ToolDefinition] = []
+    for tool in tools:
+        name = _non_empty_string(getattr(tool, "name", None))
+        if not name:
+            continue
+        definitions.append(
+            FunctionToolDefinition(
+                name=name,
+                description=_non_empty_string(
+                    getattr(tool, "description", None)
+                ),
+                parameters=_tool_parameters(tool),
+            )
+        )
+    return definitions
+
+
+def _agent_model(agent: Any) -> str | None:
+    llm = getattr(agent, "llm", None)
+    if llm is None:
+        return None
+    for attr in ("model", "model_name", "deployment_name"):
+        value = _non_empty_string(getattr(llm, attr, None))
+        if value:
+            return value
+    return _non_empty_string(llm)
+
+
+def _agent_id(agent: Any) -> str | None:
+    return _non_empty_string(
+        getattr(agent, "key", None) or getattr(agent, "id", None)
+    )
+
+
+def _crew_process(crew: Any) -> str | None:
+    process = getattr(crew, "process", None)
+    value = getattr(process, "value", process)
+    return _non_empty_string(value)
+
+
+def _crew_name(crew: Any, default: str) -> str:
+    return _non_empty_string(getattr(crew, "name", None)) or default
+
+
+def _task_description(task: Any) -> str | None:
+    return _non_empty_string(getattr(task, "description", None))
+
+
+def _task_expected_output(task: Any) -> str | None:
+    return _non_empty_string(getattr(task, "expected_output", None))
+
+
+def _task_agent(task: Any) -> Any:
+    return getattr(task, "agent", None)
+
+
+def _session_id_from_inputs(inputs: Any) -> str | None:
+    if isinstance(inputs, dict):
+        return _non_empty_string(
+            inputs.get("session_id")
+            or inputs.get("conversation_id")
+            or inputs.get("thread_id")
+        )
+    return None
+
+
+def _user_id_from_inputs(inputs: Any) -> str | None:
+    if isinstance(inputs, dict):
+        return _non_empty_string(inputs.get("user_id"))
+    return None
+
+
+def _input_content(inputs: Any) -> Any:
+    if not isinstance(inputs, dict):
+        return inputs
+    return {
+        key: value
+        for key, value in inputs.items()
+        if key not in CREWAI_INPUT_METADATA_KEYS
+    }
+
+
+def create_entry_invocation(
+    instance: Any,
+    inputs: Any,
+    operation_name: str,
+) -> EntryInvocation:
+    attributes: dict[str, Any] = {
+        CREWAI_OPERATION: operation_name,
+        CREWAI_COMPONENT: "crew" if operation_name == OP_NAME_CREW else "flow",
+    }
+
+    process = _crew_process(instance)
+    if process:
+        attributes[CREWAI_PROCESS] = process
+
+    tasks = getattr(instance, "tasks", None)
+    if tasks is not None:
+        try:
+            attributes["gen_ai.crewai.tasks.count"] = len(tasks)
+        except TypeError:
+            pass
+
+    agents = getattr(instance, "agents", None)
+    if agents is not None:
+        try:
+            attributes["gen_ai.crewai.agents.count"] = len(agents)
+        except TypeError:
+            pass
+
+    attributes[GenAI.GEN_AI_PROVIDER_NAME] = CREWAI_PROVIDER
+    attributes[GenAI.GEN_AI_AGENT_NAME] = _crew_name(instance, operation_name)
+
+    return EntryInvocation(
+        session_id=_session_id_from_inputs(inputs),
+        user_id=_user_id_from_inputs(inputs),
+        input_messages=(
+            to_input_messages("user", _input_content(inputs))
+            if _should_capture_content()
+            else []
+        ),
+        attributes=attributes,
+    )
+
+
+def create_task_invocation(
+    task: Any, agent: Any = None
+) -> InvokeAgentInvocation:
+    description = _task_description(task)
+    expected_output = _task_expected_output(task)
+    agent = agent or _task_agent(task)
+    agent_name = _non_empty_string(getattr(agent, "role", None))
+    capture_content = _should_capture_content()
+
+    attributes: dict[str, Any] = {
+        CREWAI_OPERATION: OP_NAME_TASK,
+        CREWAI_COMPONENT: "task",
+    }
+    if description and capture_content:
+        attributes[CREWAI_TASK_DESCRIPTION] = description
+    if expected_output and capture_content:
+        attributes[CREWAI_TASK_EXPECTED_OUTPUT] = expected_output
+    if agent_name:
+        attributes["gen_ai.crewai.task.agent"] = agent_name
+
+    input_parts = (
+        _message_parts(
+            f"Task: {description}" if description else None,
+            f"Expected output: {expected_output}" if expected_output else None,
+        )
+        if capture_content
+        else []
+    )
+
+    return InvokeAgentInvocation(
+        provider=CREWAI_PROVIDER,
+        agent_id=_agent_id(agent),
+        agent_name=agent_name or "task",
+        agent_description=(
+            (description or expected_output) if capture_content else None
+        ),
+        request_model=_agent_model(agent),
+        response_model_name=_agent_model(agent),
+        input_messages=(
+            [InputMessage(role="user", parts=input_parts)]
+            if input_parts
+            else []
+        ),
+        attributes=attributes,
+    )
+
+
+def create_agent_invocation(
+    agent: Any,
+    task: Any,
+    context: Any,
+    tools: list[Any] | tuple[Any, ...] | None,
+) -> InvokeAgentInvocation:
+    role = _non_empty_string(getattr(agent, "role", None)) or "agent"
+    goal = _non_empty_string(getattr(agent, "goal", None))
+    backstory = _non_empty_string(getattr(agent, "backstory", None))
+    description = _task_description(task)
+    capture_content = _should_capture_content()
+
+    attributes: dict[str, Any] = {
+        CREWAI_OPERATION: OP_NAME_AGENT,
+        CREWAI_COMPONENT: "agent",
+    }
+    if goal and capture_content:
+        attributes[CREWAI_AGENT_GOAL] = goal
+    if backstory and capture_content:
+        attributes[CREWAI_AGENT_BACKSTORY] = backstory
+    if tools:
+        attributes[CREWAI_TOOLS_COUNT] = len(tools)
+
+    input_parts = (
+        _message_parts(
+            f"Task: {description}" if description else None,
+            f"Context: {context}" if _non_empty_string(context) else None,
+        )
+        if capture_content
+        else []
+    )
+
+    return InvokeAgentInvocation(
+        provider=CREWAI_PROVIDER,
+        agent_id=_agent_id(agent),
+        agent_name=role,
+        agent_description=goal if capture_content else None,
+        request_model=_agent_model(agent),
+        response_model_name=_agent_model(agent),
+        input_messages=(
+            [InputMessage(role="user", parts=input_parts)]
+            if input_parts
+            else []
+        ),
+        system_instruction=(
+            _message_parts(backstory) if capture_content else None
+        ),
+        tool_definitions=tool_definitions(tools),
+        attributes=attributes,
+    )
+
+
+def _tool_call_id(tool_name: str, tool_calling: Any) -> str:
+    if isinstance(tool_calling, dict):
+        return (
+            _non_empty_string(tool_calling.get("id"))
+            or _non_empty_string(tool_calling.get("tool_call_id"))
+            or tool_name
+        )
+    return (
+        _non_empty_string(getattr(tool_calling, "id", None))
+        or _non_empty_string(getattr(tool_calling, "tool_call_id", None))
+        or tool_name
+    )
+
+
+def _tool_arguments(tool_calling: Any) -> Any:
+    if tool_calling is None:
+        return None
+    if isinstance(tool_calling, dict):
+        return tool_calling.get("arguments") or tool_calling.get("tool_input")
+    return getattr(tool_calling, "arguments", None)
+
+
+def create_tool_invocation(
+    tool: Any,
+    tool_calling: Any,
+    *,
+    tool_call_arguments: Any = None,
+) -> ExecuteToolInvocation:
+    tool_name = (
+        _non_empty_string(getattr(tool, "name", None)) or "unknown_tool"
+    )
+    invocation = ExecuteToolInvocation(
+        provider=CREWAI_PROVIDER,
+        tool_name=tool_name,
+        tool_call_id=_tool_call_id(tool_name, tool_calling),
+        tool_description=_non_empty_string(getattr(tool, "description", None)),
+        tool_type="function",
+        tool_call_arguments=(
+            tool_call_arguments
+            if tool_call_arguments is not None
+            else _tool_arguments(tool_calling)
+        ),
+        attributes={
+            CREWAI_OPERATION: OP_NAME_TOOL,
+            CREWAI_COMPONENT: "tool",
+        },
+    )
+    return invocation
+
+
 class GenAIHookHelper:
+    """Backward-compatible helper for older direct-span tests.
+
+    Runtime instrumentation uses ``ExtendedTelemetryHandler``. This shim remains
+    for external tests that import it directly from previous CrewAI releases.
+    """
+
     def __init__(self, capture_content: bool = True):
         self.capture_content = capture_content
 
     def on_completion(
         self,
         span: Span,
-        inputs: List[InputMessage],
-        outputs: List[OutputMessage],
-        system_instructions: Optional[List[MessagePart]] = None,
-        attributes: Optional[Dict[str, Any]] = None,
-    ):
+        inputs: list[InputMessage],
+        outputs: list[OutputMessage],
+        system_instructions: list[MessagePart] | None = None,
+        attributes: dict[str, Any] | None = None,
+    ) -> None:
         if not self.capture_content or not span.is_recording():
             return
 
@@ -67,19 +635,19 @@ class GenAIHookHelper:
         if should_capture_span:
             if inputs:
                 span.set_attribute(
-                    gen_ai_attributes.GEN_AI_INPUT_MESSAGES,
+                    GenAI.GEN_AI_INPUT_MESSAGES,
                     gen_ai_json_dumps([dataclasses.asdict(i) for i in inputs]),
                 )
             if outputs:
                 span.set_attribute(
-                    gen_ai_attributes.GEN_AI_OUTPUT_MESSAGES,
+                    GenAI.GEN_AI_OUTPUT_MESSAGES,
                     gen_ai_json_dumps(
                         [dataclasses.asdict(o) for o in outputs]
                     ),
                 )
             if system_instructions:
                 span.set_attribute(
-                    gen_ai_attributes.GEN_AI_SYSTEM_INSTRUCTIONS,
+                    GenAI.GEN_AI_SYSTEM_INSTRUCTIONS,
                     gen_ai_json_dumps(
                         [dataclasses.asdict(i) for i in system_instructions]
                     ),
@@ -89,56 +657,12 @@ class GenAIHookHelper:
             span.set_attributes(attributes)
 
 
-def to_input_message(role: str, content: Any) -> List[InputMessage]:
-    if not content:
-        return []
-
-    text_content = content if isinstance(content, str) else str(content)
-
-    return [InputMessage(role=role, parts=[Text(content=text_content)])]
-
-
-def to_output_message(
-    role: str, content: Any, finish_reason: str = "stop"
-) -> List[OutputMessage]:
-    if not content:
-        return []
-
-    text_content = content if isinstance(content, str) else str(content)
-
-    return [
-        OutputMessage(
-            role=role,
-            parts=[Text(content=text_content)],
-            finish_reason=finish_reason,
-        )
-    ]
-
-
-def extract_agent_inputs(
-    task_obj: Any, context: str, tools: List[Any]
-) -> List[InputMessage]:
-    description = getattr(task_obj, "description", "")
-
-    parts = []
-    if description:
-        parts.append(Text(content=f"Task: {description}"))
-    if context:
-        parts.append(Text(content=f"Context: {context}"))
-    if tools:
-        tool_names = [getattr(t, "name", str(t)) for t in tools]
-        parts.append(Text(content=f"Tools Available: {', '.join(tool_names)}"))
-
-    return [InputMessage(role="user", parts=parts)]
-
-
-def extract_tool_inputs(tool_name: str, arguments: Any) -> List[InputMessage]:
+def extract_tool_inputs(tool_name: str, arguments: Any) -> list[InputMessage]:
     args_str = (
         gen_ai_json_dumps(arguments)
         if isinstance(arguments, dict)
         else str(arguments)
     )
-
     return [
         InputMessage(
             role="assistant",

--- a/instrumentation-loongsuite/loongsuite-instrumentation-crewai/tests/test_agent_workflow.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-crewai/tests/test_agent_workflow.py
@@ -67,9 +67,11 @@ class TestAgentWorkflow(TestBase):
 
         os.environ["CREWAI_TRACING_ENABLED"] = "false"
         # Enable experimental mode and content capture for testing
-        os.environ["OTEL_SEMCONV_STABILITY_OPT_IN"] = "gen_ai"
+        os.environ["OTEL_SEMCONV_STABILITY_OPT_IN"] = (
+            "gen_ai_latest_experimental"
+        )
         os.environ["OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"] = (
-            "span_only"
+            "SPAN_ONLY"
         )
 
         if _OpenTelemetrySemanticConventionStability:
@@ -169,17 +171,12 @@ class TestAgentWorkflow(TestBase):
         chain_spans = [
             s
             for s in spans
-            if s.attributes.get("gen_ai.operation.name") == "crew.kickoff"
+            if s.attributes.get("gen_ai.crewai.operation") == "crew.kickoff"
         ]
         task_spans = [
             s
             for s in spans
-            if s.attributes.get("gen_ai.operation.name") == "task.execute"
-        ]
-        agent_spans = [
-            s
-            for s in spans
-            if s.attributes.get("gen_ai.operation.name") == "agent.execute"
+            if s.attributes.get("gen_ai.crewai.operation") == "task.execute"
         ]
 
         # Verify span counts
@@ -191,17 +188,21 @@ class TestAgentWorkflow(TestBase):
             3,
             f"Expected at least 3 TASK spans, got {len(task_spans)}",
         )
-        self.assertGreaterEqual(
-            len(agent_spans),
-            3,
-            f"Expected at least 3 AGENT spans, got {len(agent_spans)}",
-        )
 
         # Verify CHAIN span has proper attributes
         chain_span = chain_spans[0]
-        self.assertEqual(chain_span.attributes.get("gen_ai.system"), "crewai")
         self.assertEqual(
-            chain_span.attributes.get("gen_ai.operation.name"), "crew.kickoff"
+            chain_span.attributes.get("gen_ai.provider.name"), "crewai"
+        )
+        self.assertEqual(
+            chain_span.attributes.get("gen_ai.operation.name"), "enter"
+        )
+        self.assertEqual(
+            chain_span.attributes.get("gen_ai.span.kind"), "ENTRY"
+        )
+        self.assertEqual(
+            chain_span.attributes.get("gen_ai.crewai.operation"),
+            "crew.kickoff",
         )
 
         # Verify result is captured in OpenTelemetry GenAI format
@@ -277,17 +278,17 @@ class TestAgentWorkflow(TestBase):
             len(trace_ids), 1, "All spans should share the same trace ID"
         )
 
-        agent_spans = [
+        task_spans = [
             s
             for s in spans
-            if s.attributes.get("gen_ai.operation.name") == "agent.execute"
+            if s.attributes.get("gen_ai.crewai.operation") == "task.execute"
         ]
 
-        # Should have multiple agent spans for collaboration
+        # Should have multiple task invoke spans for collaboration
         self.assertGreaterEqual(
-            len(agent_spans),
+            len(task_spans),
             2,
-            f"Expected at least 2 AGENT spans, got {len(agent_spans)}",
+            f"Expected at least 2 TASK spans, got {len(task_spans)}",
         )
 
     def test_hierarchical_workflow(self):
@@ -352,7 +353,7 @@ class TestAgentWorkflow(TestBase):
         chain_spans = [
             s
             for s in spans
-            if s.attributes.get("gen_ai.operation.name") == "crew.kickoff"
+            if s.attributes.get("gen_ai.crewai.operation") == "crew.kickoff"
         ]
 
         # Should have CHAIN span for hierarchical workflow

--- a/instrumentation-loongsuite/loongsuite-instrumentation-crewai/tests/test_error_scenarios.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-crewai/tests/test_error_scenarios.py
@@ -74,9 +74,11 @@ class TestErrorScenarios(TestBase):
         os.environ["CREWAI_TRACING_ENABLED"] = "false"
 
         # Enable experimental mode and content capture for testing
-        os.environ["OTEL_SEMCONV_STABILITY_OPT_IN"] = "gen_ai"
+        os.environ["OTEL_SEMCONV_STABILITY_OPT_IN"] = (
+            "gen_ai_latest_experimental"
+        )
         os.environ["OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"] = (
-            "span_only"
+            "SPAN_ONLY"
         )
 
         if _OpenTelemetrySemanticConventionStability:
@@ -173,7 +175,7 @@ class TestErrorScenarios(TestBase):
                     break
 
             # Verify inputs are still there
-            if span.attributes.get("gen_ai.operation.name") in [
+            if span.attributes.get("gen_ai.crewai.operation") in [
                 "task.execute",
                 "agent.execute",
             ]:
@@ -306,7 +308,7 @@ class TestErrorScenarios(TestBase):
         agent_error_spans = [
             s
             for s in error_spans
-            if s.attributes.get("gen_ai.operation.name") == "agent.execute"
+            if s.attributes.get("gen_ai.crewai.operation") == "agent.execute"
         ]
         if agent_error_spans:
             span = agent_error_spans[0]

--- a/instrumentation-loongsuite/loongsuite-instrumentation-crewai/tests/test_flow_kickoff.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-crewai/tests/test_flow_kickoff.py
@@ -25,8 +25,8 @@ This test suite validates the _FlowKickoffAsyncWrapper functionality including:
 import os
 
 # Set environment variables for content capture
-os.environ["OTEL_SEMCONV_STABILITY_OPT_IN"] = "gen_ai"
-os.environ["OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"] = "span_only"
+os.environ["OTEL_SEMCONV_STABILITY_OPT_IN"] = "gen_ai_latest_experimental"
+os.environ["OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"] = "SPAN_ONLY"
 
 # Forcefully enable experimental mode in OpenTelemetry's internal mapping
 try:
@@ -42,15 +42,25 @@ try:
 except (ImportError, AttributeError):
     pass
 
+import asyncio
 import json
 import unittest
-from unittest.mock import AsyncMock, MagicMock
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from opentelemetry.instrumentation.crewai import (
-    GenAIHookHelper,
+    _AgentExecuteTaskWrapper,
+    _CrewKickoffAsyncWrapper,
+    _CrewKickoffWrapper,
     _FlowKickoffAsyncWrapper,
+    _FlowKickoffWrapper,
+    _TaskExecuteSyncWrapper,
+    _ToolUseWrapper,
 )
-from opentelemetry.instrumentation.crewai.utils import gen_ai_json_dumps
+from opentelemetry.instrumentation.crewai.utils import (
+    extract_tool_inputs,
+    gen_ai_json_dumps,
+)
 from opentelemetry.sdk.trace import TracerProvider
 
 # Use SDK tracer for testing
@@ -59,6 +69,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
 )
 from opentelemetry.trace import SpanKind, StatusCode
+from opentelemetry.util.genai.extended_handler import ExtendedTelemetryHandler
 
 
 class TestFlowKickoffAsyncWrapper(unittest.IsolatedAsyncioTestCase):
@@ -72,11 +83,11 @@ class TestFlowKickoffAsyncWrapper(unittest.IsolatedAsyncioTestCase):
         self.tracer_provider.add_span_processor(
             SimpleSpanProcessor(self.memory_exporter)
         )
-        self.tracer = self.tracer_provider.get_tracer(__name__)
-
         # Create wrapper instance
-        self.helper = GenAIHookHelper()
-        self.wrapper = _FlowKickoffAsyncWrapper(self.tracer, self.helper)
+        self.handler = ExtendedTelemetryHandler(
+            tracer_provider=self.tracer_provider
+        )
+        self.wrapper = _FlowKickoffAsyncWrapper(self.handler)
 
     def tearDown(self):
         """Cleanup test resources."""
@@ -84,9 +95,8 @@ class TestFlowKickoffAsyncWrapper(unittest.IsolatedAsyncioTestCase):
 
     def test_wrapper_init(self):
         """Test wrapper initialization."""
-        wrapper = _FlowKickoffAsyncWrapper(self.tracer, self.helper)
-        self.assertEqual(wrapper._tracer, self.tracer)
-        self.assertEqual(wrapper._helper, self.helper)
+        wrapper = _FlowKickoffAsyncWrapper(self.handler)
+        self.assertEqual(wrapper._handler, self.handler)
 
     async def test_basic_flow_kickoff(self):
         """
@@ -118,11 +128,13 @@ class TestFlowKickoffAsyncWrapper(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(spans), 1)
 
         span = spans[0]
-        self.assertEqual(span.name, "test_flow")
+        self.assertEqual(span.name, "enter_ai_application_system")
+        self.assertEqual(span.attributes.get("gen_ai.operation.name"), "enter")
         self.assertEqual(
-            span.attributes.get("gen_ai.operation.name"), "crew.kickoff"
+            span.attributes.get("gen_ai.crewai.operation"), "flow.kickoff"
         )
-        self.assertEqual(span.attributes.get("gen_ai.system"), "crewai")
+        self.assertEqual(span.attributes.get("gen_ai.agent.name"), "test_flow")
+        self.assertEqual(span.attributes.get("gen_ai.provider.name"), "crewai")
 
         output_messages_json = span.attributes.get("gen_ai.output.messages")
         self.assertIsNotNone(output_messages_json)
@@ -153,9 +165,10 @@ class TestFlowKickoffAsyncWrapper(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(spans), 1)
 
         span = spans[0]
-        self.assertEqual(span.name, "flow.kickoff")
+        self.assertEqual(span.name, "enter_ai_application_system")
+        self.assertEqual(span.attributes.get("gen_ai.operation.name"), "enter")
         self.assertEqual(
-            span.attributes.get("gen_ai.operation.name"), "crew.kickoff"
+            span.attributes.get("gen_ai.crewai.operation"), "flow.kickoff"
         )
 
     async def test_flow_kickoff_with_inputs(self):
@@ -245,8 +258,8 @@ class TestFlowKickoffAsyncWrapper(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(spans), 1)
 
         span = spans[0]
-        self.assertEqual(span.name, "error_flow")
-        self.assertEqual(span.attributes.get("gen_ai.system"), "crewai")
+        self.assertEqual(span.name, "enter_ai_application_system")
+        self.assertEqual(span.attributes.get("gen_ai.provider.name"), "crewai")
 
         # Verify exception was recorded in events
         self.assertGreater(len(span.events), 0)
@@ -275,9 +288,10 @@ class TestFlowKickoffAsyncWrapper(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(spans), 1)
 
         span = spans[0]
-        self.assertEqual(span.name, "flow.kickoff")
+        self.assertEqual(span.name, "enter_ai_application_system")
+        self.assertEqual(span.attributes.get("gen_ai.operation.name"), "enter")
         self.assertEqual(
-            span.attributes.get("gen_ai.operation.name"), "crew.kickoff"
+            span.attributes.get("gen_ai.crewai.operation"), "flow.kickoff"
         )
 
     async def test_flow_kickoff_with_complex_result(self):
@@ -370,6 +384,443 @@ class TestFlowKickoffAsyncWrapper(unittest.IsolatedAsyncioTestCase):
 
         span = spans[0]
         self.assertEqual(span.kind, SpanKind.INTERNAL)
+
+
+class TestCrewKickoffWrapper(unittest.TestCase):
+    """Test _CrewKickoffWrapper class."""
+
+    def setUp(self):
+        """Setup test resources."""
+        self.memory_exporter = InMemorySpanExporter()
+        self.tracer_provider = TracerProvider()
+        self.tracer_provider.add_span_processor(
+            SimpleSpanProcessor(self.memory_exporter)
+        )
+        self.handler = ExtendedTelemetryHandler(
+            tracer_provider=self.tracer_provider
+        )
+        self.wrapper = _CrewKickoffWrapper(self.handler)
+
+    def tearDown(self):
+        """Cleanup test resources."""
+        self.memory_exporter.clear()
+
+    def test_crew_kickoff_records_token_usage(self):
+        """Test Crew.kickoff maps CrewAI token_usage onto the entry span."""
+        result = SimpleNamespace(
+            raw="final crew result",
+            token_usage=SimpleNamespace(
+                prompt_tokens=12,
+                completion_tokens=7,
+                total_tokens=19,
+                successful_requests=1,
+            ),
+        )
+        mock_wrapped = MagicMock(return_value=result)
+        crew = SimpleNamespace(
+            name="usage_crew",
+            process=SimpleNamespace(value="sequential"),
+            tasks=[object()],
+            agents=[object()],
+        )
+
+        returned = self.wrapper(
+            mock_wrapped,
+            crew,
+            (),
+            {"inputs": {"session_id": "sess-1", "user_id": "user-1"}},
+        )
+
+        self.assertIs(returned, result)
+        mock_wrapped.assert_called_once_with(
+            inputs={"session_id": "sess-1", "user_id": "user-1"}
+        )
+
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        span = spans[0]
+
+        self.assertEqual(span.name, "enter_ai_application_system")
+        self.assertEqual(span.attributes["gen_ai.operation.name"], "enter")
+        self.assertEqual(
+            span.attributes["gen_ai.crewai.operation"], "crew.kickoff"
+        )
+        self.assertEqual(span.attributes["gen_ai.usage.input_tokens"], 12)
+        self.assertEqual(span.attributes["gen_ai.usage.output_tokens"], 7)
+        self.assertEqual(span.attributes["gen_ai.usage.total_tokens"], 19)
+        self.assertEqual(
+            span.attributes["gen_ai.crewai.usage.successful_requests"], 1
+        )
+        self.assertEqual(span.status.status_code, StatusCode.OK)
+
+    def test_crew_kickoff_uses_next_nonzero_token_usage(self):
+        """Test token usage falls back when the first candidate is empty."""
+        result = SimpleNamespace(
+            raw="final crew result",
+            token_usage=SimpleNamespace(
+                prompt_tokens=0,
+                completion_tokens=0,
+                total_tokens=0,
+            ),
+        )
+        crew = SimpleNamespace(
+            name="usage_crew",
+            process=SimpleNamespace(value="sequential"),
+            tasks=[object()],
+            agents=[object()],
+            token_usage=SimpleNamespace(
+                prompt_tokens=21,
+                completion_tokens=9,
+                total_tokens=30,
+            ),
+        )
+
+        self.wrapper(MagicMock(return_value=result), crew, (), {})
+
+        span = self.memory_exporter.get_finished_spans()[0]
+        self.assertEqual(span.attributes["gen_ai.usage.input_tokens"], 21)
+        self.assertEqual(span.attributes["gen_ai.usage.output_tokens"], 9)
+        self.assertEqual(span.attributes["gen_ai.usage.total_tokens"], 30)
+
+    def test_crew_kickoff_records_zero_token_usage(self):
+        """Test zero token usage is preserved when no nonzero candidate exists."""
+        result = SimpleNamespace(
+            raw="final crew result",
+            token_usage=SimpleNamespace(
+                prompt_tokens=0,
+                completion_tokens=0,
+                total_tokens=0,
+                successful_requests=1,
+            ),
+        )
+        crew = SimpleNamespace(name="usage_crew", tasks=[], agents=[])
+
+        self.wrapper(MagicMock(return_value=result), crew, (), {})
+
+        span = self.memory_exporter.get_finished_spans()[0]
+        self.assertEqual(span.attributes["gen_ai.usage.input_tokens"], 0)
+        self.assertEqual(span.attributes["gen_ai.usage.output_tokens"], 0)
+        self.assertEqual(span.attributes["gen_ai.usage.total_tokens"], 0)
+        self.assertEqual(
+            span.attributes["gen_ai.crewai.usage.successful_requests"], 1
+        )
+
+    def test_streaming_crew_kickoff_defers_to_inner_execution(self):
+        """Test stream=True kickoff traces CrewAI's inner real execution."""
+        crew = SimpleNamespace(
+            name="streaming_crew",
+            stream=True,
+            tasks=[],
+            agents=[],
+        )
+
+        def wrapped_stream(*args, **kwargs):
+            crew.stream = False
+            return self.wrapper(
+                MagicMock(return_value="inner result"), crew, args, kwargs
+            )
+
+        result = self.wrapper(wrapped_stream, crew, (), {})
+
+        self.assertEqual(result, "inner result")
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(
+            spans[0].attributes["gen_ai.crewai.operation"], "crew.kickoff"
+        )
+
+    def test_success_post_processing_failure_does_not_escape(self):
+        """Test telemetry post-processing failures do not fail user calls."""
+        crew = SimpleNamespace(name="safe_crew", tasks=[], agents=[])
+
+        with patch(
+            "opentelemetry.instrumentation.crewai.to_output_messages",
+            side_effect=RuntimeError("post boom"),
+        ):
+            result = self.wrapper(MagicMock(return_value="ok"), crew, (), {})
+
+        self.assertEqual(result, "ok")
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        self.assertNotEqual(spans[0].status.status_code, StatusCode.ERROR)
+
+    def test_entry_invocation_build_failure_preserves_user_call(self):
+        """Test invocation construction failures do not block user code."""
+        wrapped = MagicMock(return_value="ok")
+        crew = SimpleNamespace(name="safe_crew", tasks=[], agents=[])
+
+        with patch(
+            "opentelemetry.instrumentation.crewai.create_entry_invocation",
+            side_effect=RuntimeError("build boom"),
+        ):
+            result = self.wrapper(wrapped, crew, (), {})
+
+        self.assertEqual(result, "ok")
+        wrapped.assert_called_once_with()
+        self.assertEqual(len(self.memory_exporter.get_finished_spans()), 0)
+
+
+class TestEntryNestingGuards(unittest.IsolatedAsyncioTestCase):
+    """Test nested CrewAI entry wrappers emit only one entry span."""
+
+    def setUp(self):
+        self.memory_exporter = InMemorySpanExporter()
+        self.tracer_provider = TracerProvider()
+        self.tracer_provider.add_span_processor(
+            SimpleSpanProcessor(self.memory_exporter)
+        )
+        self.handler = ExtendedTelemetryHandler(
+            tracer_provider=self.tracer_provider
+        )
+
+    async def test_crew_kickoff_async_does_not_double_wrap_sync_kickoff(self):
+        """Test kickoff_async -> kickoff produces one entry span."""
+        sync_wrapper = _CrewKickoffWrapper(self.handler)
+        async_wrapper = _CrewKickoffAsyncWrapper(self.handler)
+
+        async def wrapped_async(*args, **kwargs):
+            return sync_wrapper(
+                MagicMock(return_value="inner result"),
+                SimpleNamespace(name="inner_crew", stream=False),
+                args,
+                kwargs,
+            )
+
+        result = await async_wrapper(
+            wrapped_async,
+            SimpleNamespace(name="outer_crew", stream=False),
+            (),
+            {"inputs": {"session_id": "nested-session"}},
+        )
+
+        self.assertEqual(result, "inner result")
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(
+            spans[0].attributes["gen_ai.agent.name"], "outer_crew"
+        )
+        self.assertEqual(
+            spans[0].attributes["gen_ai.crewai.operation"], "crew.kickoff"
+        )
+
+    def test_flow_kickoff_sync_does_not_double_wrap_async_kickoff(self):
+        """Test Flow.kickoff -> kickoff_async produces one entry span."""
+        sync_wrapper = _FlowKickoffWrapper(self.handler)
+        async_wrapper = _FlowKickoffAsyncWrapper(self.handler)
+
+        def wrapped_sync(*args, **kwargs):
+            async def run_inner():
+                return await async_wrapper(
+                    AsyncMock(return_value="flow result"),
+                    SimpleNamespace(name="inner_flow", stream=False),
+                    args,
+                    kwargs,
+                )
+
+            return asyncio.run(run_inner())
+
+        result = sync_wrapper(
+            wrapped_sync,
+            SimpleNamespace(name="outer_flow", stream=False),
+            (),
+            {"inputs": {"session_id": "flow-session"}},
+        )
+
+        self.assertEqual(result, "flow result")
+        spans = self.memory_exporter.get_finished_spans()
+        self.assertEqual(len(spans), 1)
+        self.assertEqual(
+            spans[0].attributes["gen_ai.agent.name"], "outer_flow"
+        )
+        self.assertEqual(
+            spans[0].attributes["gen_ai.crewai.operation"], "flow.kickoff"
+        )
+
+
+class TestTaskAndToolWrappers(unittest.TestCase):
+    """Test task and tool wrapper compatibility behavior."""
+
+    def setUp(self):
+        self.memory_exporter = InMemorySpanExporter()
+        self.tracer_provider = TracerProvider()
+        self.tracer_provider.add_span_processor(
+            SimpleSpanProcessor(self.memory_exporter)
+        )
+        self.handler = ExtendedTelemetryHandler(
+            tracer_provider=self.tracer_provider
+        )
+
+    def test_task_execute_uses_positional_agent_role_as_agent_name(self):
+        """Test Task.execute_sync(agent=...) uses the runtime agent role."""
+        wrapper = _TaskExecuteSyncWrapper(self.handler)
+        token_process = SimpleNamespace(
+            get_summary=MagicMock(
+                return_value=SimpleNamespace(
+                    prompt_tokens=17,
+                    completion_tokens=5,
+                    total_tokens=22,
+                    successful_requests=1,
+                )
+            )
+        )
+        agent = SimpleNamespace(role="Runtime Agent", llm="qwen-turbo")
+        agent._token_process = token_process
+        task = SimpleNamespace(
+            description="Write a short summary.",
+            expected_output="A short summary.",
+            agent=None,
+        )
+
+        wrapper(MagicMock(return_value="done"), task, (agent,), {})
+
+        span = self.memory_exporter.get_finished_spans()[0]
+        self.assertEqual(span.attributes["gen_ai.agent.name"], "Runtime Agent")
+        self.assertEqual(
+            span.attributes["gen_ai.crewai.operation"], "task.execute"
+        )
+        self.assertEqual(span.attributes["gen_ai.usage.input_tokens"], 17)
+        self.assertEqual(span.attributes["gen_ai.usage.output_tokens"], 5)
+        self.assertEqual(span.attributes["gen_ai.usage.total_tokens"], 22)
+
+    def test_agent_execute_preserves_user_call_when_handler_start_fails(self):
+        """Test instrumentation failures do not block user code."""
+        handler = SimpleNamespace(
+            start_invoke_agent=MagicMock(side_effect=RuntimeError("boom")),
+            stop_invoke_agent=MagicMock(),
+            fail_invoke_agent=MagicMock(),
+        )
+        wrapper = _AgentExecuteTaskWrapper(handler)
+        wrapped = MagicMock(return_value="agent result")
+        agent = SimpleNamespace(role="Runtime Agent", goal="Help", tools=[])
+        task = SimpleNamespace(description="Write a short summary.")
+
+        result = wrapper(wrapped, agent, (task,), {})
+
+        self.assertEqual(result, "agent result")
+        wrapped.assert_called_once_with(task)
+        handler.stop_invoke_agent.assert_not_called()
+        handler.fail_invoke_agent.assert_not_called()
+
+    def test_agent_execute_skips_inside_task_span(self):
+        """Test task execution does not create a duplicate agent span."""
+        task_wrapper = _TaskExecuteSyncWrapper(self.handler)
+        agent_wrapper = _AgentExecuteTaskWrapper(self.handler)
+        agent = SimpleNamespace(role="Runtime Agent", llm="qwen-turbo")
+        task = SimpleNamespace(
+            description="Write a short summary.",
+            expected_output="A short summary.",
+            agent=agent,
+        )
+
+        def wrapped_task(*args, **kwargs):
+            return agent_wrapper(
+                MagicMock(return_value="agent result"),
+                agent,
+                (task,),
+                {},
+            )
+
+        result = task_wrapper(wrapped_task, task, (agent,), {})
+
+        self.assertEqual(result, "agent result")
+        spans = self.memory_exporter.get_finished_spans()
+        task_spans = [
+            span
+            for span in spans
+            if span.attributes.get("gen_ai.crewai.operation") == "task.execute"
+        ]
+        agent_spans = [
+            span
+            for span in spans
+            if span.attributes.get("gen_ai.crewai.operation")
+            == "agent.execute"
+        ]
+        self.assertEqual(len(task_spans), 1)
+        self.assertEqual(len(agent_spans), 0)
+
+    def test_content_capture_disabled_drops_sensitive_task_content(self):
+        """Test content-like fields honor util-genai capture controls."""
+        wrapper = _TaskExecuteSyncWrapper(self.handler)
+        agent = SimpleNamespace(role="Runtime Agent", llm="qwen-turbo")
+        task = SimpleNamespace(
+            description="PII: customer id 123",
+            expected_output="PII: private answer",
+            agent=agent,
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT": "NO_CONTENT"
+            },
+        ):
+            wrapper(MagicMock(return_value="PII: result"), task, (agent,), {})
+
+        span = self.memory_exporter.get_finished_spans()[0]
+        self.assertNotIn("gen_ai.input.messages", span.attributes)
+        self.assertNotIn("gen_ai.output.messages", span.attributes)
+        self.assertNotIn("gen_ai.agent.description", span.attributes)
+        self.assertNotIn("gen_ai.crewai.task.description", span.attributes)
+        self.assertNotIn("gen_ai.crewai.task.expected_output", span.attributes)
+
+    def test_tool_wrapper_marks_parsing_attempt_error(self):
+        """Test parsing-attempt overflow records a failed tool span."""
+        wrapper = _ToolUseWrapper(self.handler)
+        tool = SimpleNamespace(
+            name="failing_tool", description="A deterministic failing tool."
+        )
+        tool_usage = SimpleNamespace(_run_attempts=3, _max_parsing_attempts=2)
+
+        result = wrapper(
+            MagicMock(return_value="partial result"),
+            tool_usage,
+            (tool, SimpleNamespace(arguments={"x": "y"})),
+            {},
+        )
+
+        self.assertEqual(result, "partial result")
+        span = self.memory_exporter.get_finished_spans()[0]
+        self.assertEqual(span.status.status_code.name, "ERROR")
+        self.assertEqual(
+            span.attributes["gen_ai.crewai.operation"], "tool.execute"
+        )
+        self.assertIn(
+            "failing_tool", span.events[0].attributes["exception.message"]
+        )
+
+    def test_tool_wrapper_reads_crewai_use_signature_arguments(self):
+        """Test ToolUsage._use(tool_string, tool, calling) captures arguments."""
+        wrapper = _ToolUseWrapper(self.handler)
+        tool = SimpleNamespace(
+            name="word_count", description="A deterministic tool."
+        )
+        calling = SimpleNamespace(
+            id="call-1",
+            tool_name="word_count",
+            arguments={"text": "CrewAI telemetry"},
+        )
+
+        wrapper(
+            MagicMock(return_value="word_count=2"),
+            SimpleNamespace(),
+            ("word_count({})", tool, calling),
+            {},
+        )
+
+        span = self.memory_exporter.get_finished_spans()[0]
+        self.assertEqual(span.attributes["gen_ai.tool.name"], "word_count")
+        self.assertIn(
+            "CrewAI telemetry",
+            span.attributes["gen_ai.tool.call.arguments"],
+        )
+
+    def test_extract_tool_inputs_keeps_json_string_arguments(self):
+        """Test legacy helper keeps JSON-stringified tool arguments."""
+        messages = extract_tool_inputs("tool_name", {"location": "Hangzhou"})
+
+        tool_call = messages[0].parts[0]
+        self.assertEqual(tool_call.name, "tool_name")
+        self.assertEqual(tool_call.arguments, '{"location":"Hangzhou"}')
 
 
 class TestGenAiJsonDumps(unittest.TestCase):

--- a/instrumentation-loongsuite/loongsuite-instrumentation-crewai/tests/test_prompt_and_memory.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-crewai/tests/test_prompt_and_memory.py
@@ -69,9 +69,11 @@ class TestPromptAndMemory(TestBase):
 
         os.environ["CREWAI_TRACING_ENABLED"] = "false"
         # Enable experimental mode and content capture for testing
-        os.environ["OTEL_SEMCONV_STABILITY_OPT_IN"] = "gen_ai"
+        os.environ["OTEL_SEMCONV_STABILITY_OPT_IN"] = (
+            "gen_ai_latest_experimental"
+        )
         os.environ["OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"] = (
-            "span_only"
+            "SPAN_ONLY"
         )
 
         if _OpenTelemetrySemanticConventionStability:
@@ -145,7 +147,7 @@ class TestPromptAndMemory(TestBase):
         task_spans = [
             s
             for s in spans
-            if s.attributes.get("gen_ai.operation.name") == "task.execute"
+            if s.attributes.get("gen_ai.crewai.operation") == "task.execute"
         ]
         llm_spans = [
             s

--- a/instrumentation-loongsuite/loongsuite-instrumentation-crewai/tests/test_streaming_llm_calls.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-crewai/tests/test_streaming_llm_calls.py
@@ -70,9 +70,11 @@ class TestStreamingLLMCalls(TestBase):
 
         os.environ["CREWAI_TRACING_ENABLED"] = "false"
         # Enable experimental mode and content capture for testing
-        os.environ["OTEL_SEMCONV_STABILITY_OPT_IN"] = "gen_ai"
+        os.environ["OTEL_SEMCONV_STABILITY_OPT_IN"] = (
+            "gen_ai_latest_experimental"
+        )
         os.environ["OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"] = (
-            "span_only"
+            "SPAN_ONLY"
         )
 
         if _OpenTelemetrySemanticConventionStability:
@@ -106,9 +108,9 @@ class TestStreamingLLMCalls(TestBase):
         - Consumes streaming chunks
 
         Verification:
-        - LLM/Agent spans reflect streaming configuration
+        - Task invoke_agent spans reflect streaming configuration
         - Task span captures final output messages from stream
-        - Trace hierarchy (Crew -> Task -> Agent) correctly maintained
+        - Trace hierarchy (Crew -> Task) correctly maintained
         - Standard attributes (gen_ai.system, gen_ai.operation.name, etc.)
         """
         # Create Agent with streaming
@@ -143,17 +145,17 @@ class TestStreamingLLMCalls(TestBase):
         crew_spans = [
             s
             for s in spans
-            if s.attributes.get("gen_ai.operation.name") == "crew.kickoff"
+            if s.attributes.get("gen_ai.crewai.operation") == "crew.kickoff"
         ]
         task_spans = [
             s
             for s in spans
-            if s.attributes.get("gen_ai.operation.name") == "task.execute"
+            if s.attributes.get("gen_ai.crewai.operation") == "task.execute"
         ]
         agent_spans = [
             s
             for s in spans
-            if s.attributes.get("gen_ai.operation.name") == "agent.execute"
+            if s.attributes.get("gen_ai.crewai.operation") == "agent.execute"
         ]
 
         self.assertGreaterEqual(
@@ -162,14 +164,13 @@ class TestStreamingLLMCalls(TestBase):
         self.assertGreaterEqual(
             len(task_spans), 1, "Should capture task.execute"
         )
-        self.assertGreaterEqual(
-            len(agent_spans), 1, "Should capture agent.execute"
+        self.assertEqual(
+            len(agent_spans), 0, "Agent.execute_task should not duplicate Task"
         )
 
         # 2. Verify Span Hierarchy and Trace Continuity
         crew_span = crew_spans[0]
         task_span = task_spans[0]
-        agent_span = agent_spans[0]
 
         # All spans must share the same Trace ID
         trace_id = crew_span.context.trace_id
@@ -180,21 +181,18 @@ class TestStreamingLLMCalls(TestBase):
                 "Trace ID must be consistent across all spans",
             )
 
-        # Verify parent-child relationship (Crew -> Task -> Agent)
+        # Verify parent-child relationship (Crew -> Task)
         self.assertEqual(
             task_span.parent.span_id,
             crew_span.context.span_id,
             "Task should be child of Crew",
         )
-        self.assertEqual(
-            agent_span.parent.span_id,
-            task_span.context.span_id,
-            "Agent should be child of Task",
-        )
 
         # 3. Verify OpenTelemetry GenAI Attributes
-        for s in [crew_span, task_span, agent_span]:
-            self.assertEqual(s.attributes.get("gen_ai.system"), "crewai")
+        for s in [crew_span, task_span]:
+            self.assertEqual(
+                s.attributes.get("gen_ai.provider.name"), "crewai"
+            )
             self.assertIsNotNone(s.attributes.get("gen_ai.operation.name"))
 
         # 4. Verify Content Capture (JSON formatted messages)
@@ -290,10 +288,10 @@ class TestStreamingLLMCalls(TestBase):
             # 4. Verify Input Capture (even on failure)
             # Input messages might be empty for the top-level crew if no inputs were provided,
             # but task and agent spans should always have them.
-            op_name = span.attributes.get("gen_ai.operation.name")
-            if op_name in ["task.execute", "agent.execute"]:
+            crewai_op = span.attributes.get("gen_ai.crewai.operation")
+            if crewai_op in ["task.execute", "agent.execute"]:
                 input_messages = span.attributes.get("gen_ai.input.messages")
                 self.assertIsNotNone(
                     input_messages,
-                    f"Span {op_name} should capture inputs even on failure",
+                    f"Span {crewai_op} should capture inputs even on failure",
                 )

--- a/instrumentation-loongsuite/loongsuite-instrumentation-crewai/tests/test_sync_llm_calls.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-crewai/tests/test_sync_llm_calls.py
@@ -73,9 +73,11 @@ class TestSyncLLMCalls(TestBase):
         os.environ["CREWAI_TRACING_ENABLED"] = "false"
 
         # Enable experimental mode and content capture for testing
-        os.environ["OTEL_SEMCONV_STABILITY_OPT_IN"] = "gen_ai"
+        os.environ["OTEL_SEMCONV_STABILITY_OPT_IN"] = (
+            "gen_ai_latest_experimental"
+        )
         os.environ["OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"] = (
-            "span_only"
+            "SPAN_ONLY"
         )
 
         if _OpenTelemetrySemanticConventionStability:
@@ -111,9 +113,9 @@ class TestSyncLLMCalls(TestBase):
 
         Verification:
         - CHAIN span for Crew.kickoff (gen_ai.operation.name="crew.kickoff")
-        - TASK span for Task execution (gen_ai.operation.name="task.execute")
-        - AGENT span for Agent.execute_task (gen_ai.operation.name="agent.execute")
-        - Verified parent-child relationship (Crew -> Task -> Agent)
+        - one invoke_agent span for Task execution
+        - nested Agent.execute_task does not create a duplicate AGENT span
+        - Verified parent-child relationship (Crew -> Task)
         - Standardized OpenTelemetry GenAI attributes (gen_ai.system, gen_ai.input.messages, etc.)
         """
         # Create Agent
@@ -148,17 +150,17 @@ class TestSyncLLMCalls(TestBase):
         crew_spans = [
             s
             for s in spans
-            if s.attributes.get("gen_ai.operation.name") == "crew.kickoff"
+            if s.attributes.get("gen_ai.crewai.operation") == "crew.kickoff"
         ]
         task_spans = [
             s
             for s in spans
-            if s.attributes.get("gen_ai.operation.name") == "task.execute"
+            if s.attributes.get("gen_ai.crewai.operation") == "task.execute"
         ]
         agent_spans = [
             s
             for s in spans
-            if s.attributes.get("gen_ai.operation.name") == "agent.execute"
+            if s.attributes.get("gen_ai.crewai.operation") == "agent.execute"
         ]
 
         self.assertGreaterEqual(
@@ -167,14 +169,13 @@ class TestSyncLLMCalls(TestBase):
         self.assertGreaterEqual(
             len(task_spans), 1, "Should capture task.execute"
         )
-        self.assertGreaterEqual(
-            len(agent_spans), 1, "Should capture agent.execute"
+        self.assertEqual(
+            len(agent_spans), 0, "Agent.execute_task should not duplicate Task"
         )
 
         # 2. Verify Span Hierarchy and Trace Continuity
         crew_span = crew_spans[0]
         task_span = task_spans[0]
-        agent_span = agent_spans[0]
 
         # All spans must share the same Trace ID
         trace_id = crew_span.context.trace_id
@@ -185,21 +186,18 @@ class TestSyncLLMCalls(TestBase):
                 "Trace ID must be consistent across all spans",
             )
 
-        # Verify parent-child relationship (Crew -> Task -> Agent)
+        # Verify parent-child relationship (Crew -> Task)
         self.assertEqual(
             task_span.parent.span_id,
             crew_span.context.span_id,
             "Task should be child of Crew",
         )
-        self.assertEqual(
-            agent_span.parent.span_id,
-            task_span.context.span_id,
-            "Agent should be child of Task",
-        )
 
         # 3. Verify OpenTelemetry GenAI Attributes
-        for s in [crew_span, task_span, agent_span]:
-            self.assertEqual(s.attributes.get("gen_ai.system"), "crewai")
+        for s in [crew_span, task_span]:
+            self.assertEqual(
+                s.attributes.get("gen_ai.provider.name"), "crewai"
+            )
             self.assertIsNotNone(s.attributes.get("gen_ai.operation.name"))
 
         # 4. Verify Content Capture (JSON formatted messages)
@@ -272,12 +270,12 @@ class TestSyncLLMCalls(TestBase):
         chain_spans = [
             s
             for s in spans
-            if s.attributes.get("gen_ai.operation.name") == "crew.kickoff"
+            if s.attributes.get("gen_ai.crewai.operation") == "crew.kickoff"
         ]
         task_spans = [
             s
             for s in spans
-            if s.attributes.get("gen_ai.operation.name") == "task.execute"
+            if s.attributes.get("gen_ai.crewai.operation") == "task.execute"
         ]
 
         self.assertGreaterEqual(len(chain_spans), 1)
@@ -369,10 +367,10 @@ class TestSyncLLMCalls(TestBase):
             )
 
             # 3. Verify Input Capture (even on failure)
-            op_name = span.attributes.get("gen_ai.operation.name")
-            if op_name in ["task.execute", "agent.execute"]:
+            crewai_op = span.attributes.get("gen_ai.crewai.operation")
+            if crewai_op in ["task.execute", "agent.execute"]:
                 input_messages = span.attributes.get("gen_ai.input.messages")
                 self.assertIsNotNone(
                     input_messages,
-                    f"Span {op_name} should capture inputs even on failure",
+                    f"Span {crewai_op} should capture inputs even on failure",
                 )

--- a/instrumentation-loongsuite/loongsuite-instrumentation-crewai/tests/test_tool_calls.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-crewai/tests/test_tool_calls.py
@@ -23,7 +23,6 @@ in a standardized format.
 """
 
 import ast
-import json
 import operator
 import os
 import sys
@@ -125,9 +124,11 @@ class TestToolCalls(TestBase):
 
         os.environ["CREWAI_TRACING_ENABLED"] = "false"
         # Enable experimental mode and content capture for testing
-        os.environ["OTEL_SEMCONV_STABILITY_OPT_IN"] = "gen_ai"
+        os.environ["OTEL_SEMCONV_STABILITY_OPT_IN"] = (
+            "gen_ai_latest_experimental"
+        )
         os.environ["OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"] = (
-            "span_only"
+            "SPAN_ONLY"
         )
 
         if _OpenTelemetrySemanticConventionStability:
@@ -200,12 +201,12 @@ class TestToolCalls(TestBase):
         tool_spans = [
             s
             for s in spans
-            if s.attributes.get("gen_ai.operation.name") == "tool.execute"
+            if s.attributes.get("gen_ai.crewai.operation") == "tool.execute"
         ]
-        agent_spans = [
+        task_spans = [
             s
             for s in spans
-            if s.attributes.get("gen_ai.operation.name") == "agent.execute"
+            if s.attributes.get("gen_ai.crewai.operation") == "task.execute"
         ]
 
         # Verify TOOL span (if tool wrapper was successful)
@@ -213,23 +214,24 @@ class TestToolCalls(TestBase):
             tool_span = tool_spans[0]
             self.assertEqual(
                 tool_span.attributes.get("gen_ai.operation.name"),
+                "execute_tool",
+            )
+            self.assertEqual(
+                tool_span.attributes.get("gen_ai.crewai.operation"),
                 "tool.execute",
             )
             self.assertEqual(
                 tool_span.attributes.get("gen_ai.tool.name"), "get_weather"
             )
 
-            output_messages_json = tool_span.attributes.get(
-                "gen_ai.output.messages"
-            )
-            self.assertIsNotNone(output_messages_json)
-            output_messages = json.loads(output_messages_json)
+            tool_result = tool_span.attributes.get("gen_ai.tool.call.result")
+            self.assertIsNotNone(tool_result)
             # Weather logic in WeatherTool returns weather string
-            self.assertIn("Sunny", output_messages[0]["parts"][0]["content"])
+            self.assertIn("Sunny", tool_result)
 
-        # Verify AGENT span exists
+        # Verify one task invoke span exists; nested Agent.execute_task is skipped
         self.assertGreaterEqual(
-            len(agent_spans), 1, "Expected at least 1 AGENT span"
+            len(task_spans), 1, "Expected at least 1 TASK span"
         )
 
     def test_agent_with_multiple_tools(self):
@@ -289,7 +291,7 @@ class TestToolCalls(TestBase):
         for tool_span in tool_spans:
             self.assertEqual(
                 tool_span.attributes.get("gen_ai.operation.name"),
-                "tool.execute",
+                "execute_tool",
             )
             self.assertIsNotNone(tool_span.attributes.get("gen_ai.tool.name"))
 
@@ -350,11 +352,14 @@ class TestToolCalls(TestBase):
         tool_spans = [
             s
             for s in spans
-            if s.attributes.get("gen_ai.operation.name") == "tool.execute"
+            if s.attributes.get("gen_ai.crewai.operation") == "tool.execute"
         ]
 
-        # If tool span exists, verify error status
+        self.assertGreaterEqual(
+            len(tool_spans), 1, "Expected at least one TOOL span"
+        )
+
         for tool_span in tool_spans:
-            if tool_span.name.startswith("Tool.failing_tool"):
+            if tool_span.name.startswith("execute_tool failing_tool"):
                 # Should have error status
                 self.assertEqual(tool_span.status.status_code.name, "ERROR")


### PR DESCRIPTION
# Description

This PR updates the LoongSuite CrewAI instrumentation to build GenAI telemetry through `opentelemetry-util-genai`, including Crew/Flow entry spans, agent/task/tool spans, token usage, streaming behavior, and safe instrumentation failure handling. It also adds a real CrewAI smoke example for sync, streaming, and concurrent runs, and refreshes the README and changelog.

Fixes # (N/A)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] `uvx tox -e precommit`
- [x] `uvx tox -c tox-loongsuite.ini -e lint-loongsuite-instrumentation-crewai`
- [x] `uvx tox -c tox-loongsuite.ini -e py312-test-loongsuite-instrumentation-crewai`

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR:
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated

