### PR TITLE
chore: post-release 0.6.0 - archive changelogs & bump dev versions

### DIFF
--- a/CHANGELOG-loongsuite.md
+++ b/CHANGELOG-loongsuite.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.6.0 (2026-06-03)
+
 ### Changed
 
 - Publish LoongSuite GenAI utilities as `loongsuite-otel-util-genai` for new

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.6.0 (2026-06-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.5.0 (2026-05-11)
 
 ### Added

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.0.dev"
+__version__ = "0.7.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/requirements.latest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/requirements.latest.txt
@@ -40,6 +40,7 @@ pytest-asyncio
 pytest-cov
 pytest-vcr>=1.0.2
 vcrpy>=5.1.0
+aiohttp<3.12
 pyyaml>=6.0
 wrapt>=1.17.3,<2.0.0
 

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/requirements.oldest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/requirements.oldest.txt
@@ -21,6 +21,7 @@ pytest-asyncio
 pytest-cov
 pytest-vcr>=1.0.2
 vcrpy>=5.1.0
+aiohttp<3.12
 pyyaml>=6.0
 opentelemetry-api==1.37
 opentelemetry-sdk==1.37

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agno/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agno/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.6.0 (2026-06-03)
+
 ### Removed
 
 - Drop Agno 1.x support and require Agno 2.x public `Agent.run`/`Agent.arun`

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agno/src/opentelemetry/instrumentation/agno/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agno/src/opentelemetry/instrumentation/agno/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.0.dev"
+__version__ = "0.7.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-algotune/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-algotune/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.6.0 (2026-06-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.1.0 (2026-05-28)
 
 ### Added

--- a/instrumentation-loongsuite/loongsuite-instrumentation-algotune/src/opentelemetry/instrumentation/algotune/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-algotune/src/opentelemetry/instrumentation/algotune/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.0.dev"
+__version__ = "0.7.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-bfclv4/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-bfclv4/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.6.0 (2026-06-03)
+
 ### Added
 
 - Initial release of `loongsuite-instrumentation-bfclv4`.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-bfclv4/src/opentelemetry/instrumentation/bfclv4/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-bfclv4/src/opentelemetry/instrumentation/bfclv4/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.0.dev"
+__version__ = "0.7.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.6.0 (2026-06-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.5.0 (2026-05-11)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/src/opentelemetry/instrumentation/claude_agent_sdk/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/src/opentelemetry/instrumentation/claude_agent_sdk/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.0.dev"
+__version__ = "0.7.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-claw-eval/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-claw-eval/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.6.0 (2026-06-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.1.0 (2026-05-28)
 
 ### Added

--- a/instrumentation-loongsuite/loongsuite-instrumentation-claw-eval/src/opentelemetry/instrumentation/claw_eval/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-claw-eval/src/opentelemetry/instrumentation/claw_eval/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.0.dev"
+__version__ = "0.7.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-crewai/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-crewai/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.6.0 (2026-06-03)
+
 ### Breaking
 
 - Align CrewAI GenAI span names with `opentelemetry-util-genai`

--- a/instrumentation-loongsuite/loongsuite-instrumentation-crewai/src/opentelemetry/instrumentation/crewai/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-crewai/src/opentelemetry/instrumentation/crewai/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.0.dev"
+__version__ = "0.7.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-crewai/tests/test-requirements.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-crewai/tests/test-requirements.txt
@@ -35,6 +35,7 @@ openai>=2.0.0
 respx>=0.20.0
 pysqlite3
 vcrpy>=6.0.0
+aiohttp<3.12
 opentelemetry-test-utils
 pytest-recording>=0.13.0
 opentelemetry-api

--- a/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.6.0 (2026-06-03)
+
 ### Fixed
 
 - Fix extraction of `gen_ai.output.messages` for message-format text responses

--- a/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/src/opentelemetry/instrumentation/dashscope/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/src/opentelemetry/instrumentation/dashscope/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.0.dev"
+__version__ = "0.7.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/tests/requirements.latest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/tests/requirements.latest.txt
@@ -39,6 +39,8 @@ pytest==7.4.4
 pytest-asyncio==0.21.0
 pytest-vcr==1.0.2
 vcrpy>=4.2.0
+# Python 3.9 resolves vcrpy 4.x, which is not compatible with urllib3 2.x.
+urllib3<2; python_version < "3.10"
 aiohttp<3.12
 pyyaml>=6.0
 wrapt==1.17.3

--- a/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/tests/requirements.latest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/tests/requirements.latest.txt
@@ -39,10 +39,10 @@ pytest==7.4.4
 pytest-asyncio==0.21.0
 pytest-vcr==1.0.2
 vcrpy>=4.2.0
+aiohttp<3.12
 pyyaml>=6.0
 wrapt==1.17.3
 
 -e opentelemetry-instrumentation
 -e instrumentation-loongsuite/loongsuite-instrumentation-dashscope
 -e util/opentelemetry-util-genai
-

--- a/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/tests/requirements.oldest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/tests/requirements.oldest.txt
@@ -20,6 +20,8 @@ pytest==7.4.4
 pytest-asyncio==0.21.0
 pytest-vcr==1.0.2
 vcrpy>=4.2.0
+# Python 3.9 resolves vcrpy 4.x, which is not compatible with urllib3 2.x.
+urllib3<2; python_version < "3.10"
 aiohttp<3.12
 pyyaml>=6.0
 wrapt==1.17.3

--- a/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/tests/requirements.oldest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/tests/requirements.oldest.txt
@@ -20,6 +20,7 @@ pytest==7.4.4
 pytest-asyncio==0.21.0
 pytest-vcr==1.0.2
 vcrpy>=4.2.0
+aiohttp<3.12
 pyyaml>=6.0
 wrapt==1.17.3
 opentelemetry-exporter-otlp-proto-http~=1.30
@@ -29,4 +30,3 @@ opentelemetry-semantic-conventions==0.58b0
 
 -e instrumentation-loongsuite/loongsuite-instrumentation-dashscope
 -e util/opentelemetry-util-genai
-

--- a/instrumentation-loongsuite/loongsuite-instrumentation-dify/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-dify/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.6.0 (2026-06-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.5.0 (2026-05-11)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-dify/src/opentelemetry/instrumentation/dify/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-dify/src/opentelemetry/instrumentation/dify/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.0.dev"
+__version__ = "0.7.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.6.0 (2026-06-03)
+
 ### Changed
 
 - Route Google ADK `AGENT`, `LLM`, and `TOOL` spans through

--- a/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/src/opentelemetry/instrumentation/google_adk/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/src/opentelemetry/instrumentation/google_adk/version.py
@@ -14,4 +14,4 @@
 
 """Version information for OpenTelemetry Google ADK Instrumentation."""
 
-__version__ = "0.6.0.dev"
+__version__ = "0.7.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/tests/requirements.latest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/tests/requirements.latest.txt
@@ -41,6 +41,7 @@ pytest-asyncio
 pytest-cov
 pytest-vcr>=1.0.2
 vcrpy>=5.1.0
+aiohttp<3.12
 pyyaml>=6.0
 wrapt<2.0.0
 

--- a/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/tests/requirements.oldest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/tests/requirements.oldest.txt
@@ -22,6 +22,7 @@ pytest-asyncio
 pytest-cov
 pytest-vcr>=1.0.2
 vcrpy>=5.1.0
+aiohttp<3.12
 pyyaml>=6.0
 wrapt<2.0.0
 opentelemetry-api==1.37

--- a/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.6.0 (2026-06-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.5.0 (2026-05-11)
 
 ### Added

--- a/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/src/opentelemetry/instrumentation/hermes_agent/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/src/opentelemetry/instrumentation/hermes_agent/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.0.dev"
+__version__ = "0.7.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-langchain/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-langchain/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.6.0 (2026-06-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.5.0 (2026-05-11)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-langchain/src/opentelemetry/instrumentation/langchain/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-langchain/src/opentelemetry/instrumentation/langchain/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.0.dev"
+__version__ = "0.7.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.6.0 (2026-06-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.5.0 (2026-05-11)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/src/opentelemetry/instrumentation/langgraph/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/src/opentelemetry/instrumentation/langgraph/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.0.dev"
+__version__ = "0.7.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-litellm/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-litellm/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.6.0 (2026-06-03)
+
 ### Changed
 
 - Improved LiteLLM GenAI util invocation mapping for positional arguments,

--- a/instrumentation-loongsuite/loongsuite-instrumentation-litellm/src/opentelemetry/instrumentation/litellm/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-litellm/src/opentelemetry/instrumentation/litellm/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.0.dev"
+__version__ = "0.7.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-litellm/tests/test-requirements.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-litellm/tests/test-requirements.txt
@@ -41,6 +41,7 @@ pytest-asyncio
 openai
 opentelemetry-test-utils
 vcrpy
+aiohttp<3.12
 pytest-recording
 
 -e opentelemetry-instrumentation

--- a/instrumentation-loongsuite/loongsuite-instrumentation-mcp/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-mcp/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.6.0 (2026-06-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.5.0 (2026-05-11)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-mcp/src/opentelemetry/instrumentation/mcp/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-mcp/src/opentelemetry/instrumentation/mcp/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.0.dev"
+__version__ = "0.7.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-mem0/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-mem0/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.6.0 (2026-06-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.5.0 (2026-05-11)
 
 ### Fixed

--- a/instrumentation-loongsuite/loongsuite-instrumentation-mem0/src/opentelemetry/instrumentation/mem0/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-mem0/src/opentelemetry/instrumentation/mem0/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.0.dev"
+__version__ = "0.7.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-minisweagent/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-minisweagent/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.6.0 (2026-06-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.1.0 (2026-05-28)
 
 ### Added

--- a/instrumentation-loongsuite/loongsuite-instrumentation-minisweagent/src/opentelemetry/instrumentation/minisweagent/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-minisweagent/src/opentelemetry/instrumentation/minisweagent/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.0.dev"
+__version__ = "0.7.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-minisweagent/tests/test_instrumentor.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-minisweagent/tests/test_instrumentor.py
@@ -47,12 +47,15 @@ class TestImportAndMetadata:
         assert MiniSweAgentInstrumentor is not None
 
     def test_version_string(self):
+        from packaging.version import Version
+
         from opentelemetry.instrumentation.minisweagent.version import (
             __version__,
         )
 
         assert isinstance(__version__, str)
-        assert __version__ == "0.6.0.dev"
+        parsed_version = Version(__version__)
+        assert parsed_version.release
 
     def test_instruments_tuple(self):
         from opentelemetry.instrumentation.minisweagent.package import (

--- a/instrumentation-loongsuite/loongsuite-instrumentation-openhands/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-openhands/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.6.0 (2026-06-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.1.0 (2026-05-28)
 
 ### Added

--- a/instrumentation-loongsuite/loongsuite-instrumentation-openhands/src/opentelemetry/instrumentation/openhands/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-openhands/src/opentelemetry/instrumentation/openhands/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.0.dev"
+__version__ = "0.7.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.6.0 (2026-06-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.5.0 (2026-05-11)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.0.dev"
+__version__ = "0.7.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/requirements.latest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/requirements.latest.txt
@@ -29,6 +29,7 @@ python-dateutil>=2.8.0
 pytest==7.4.4
 pytest-vcr==1.0.2
 vcrpy>=4.2.0
+aiohttp<3.12
 pyyaml>=6.0
 wrapt==1.17.3
 

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/requirements.oldest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/requirements.oldest.txt
@@ -23,6 +23,7 @@ python-dateutil>=2.8.0
 pytest==7.4.4
 pytest-vcr==1.0.2
 vcrpy>=4.2.0
+aiohttp<3.12
 pyyaml>=6.0
 wrapt==1.17.3
 opentelemetry-exporter-otlp-proto-http~=1.30

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.6.0 (2026-06-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.5.0 (2026-05-11)
 
 ### Added

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/src/opentelemetry/instrumentation/qwenpaw/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/src/opentelemetry/instrumentation/qwenpaw/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.0.dev"
+__version__ = "0.7.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-slop-code/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-slop-code/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.6.0 (2026-06-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.5.0.dev (2026-05-28)
 
 ### Added

--- a/instrumentation-loongsuite/loongsuite-instrumentation-slop-code/src/opentelemetry/instrumentation/slop_code/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-slop-code/src/opentelemetry/instrumentation/slop_code/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.0.dev"
+__version__ = "0.7.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-terminus2/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-terminus2/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.6.0 (2026-06-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.1.0 (2026-05-28)
 
 ### Added

--- a/instrumentation-loongsuite/loongsuite-instrumentation-terminus2/src/opentelemetry/instrumentation/terminus2/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-terminus2/src/opentelemetry/instrumentation/terminus2/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.0.dev"
+__version__ = "0.7.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-vita/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-vita/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.6.0 (2026-06-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.5.0.dev (2026-05-28)
 
 ### Added

--- a/instrumentation-loongsuite/loongsuite-instrumentation-vita/src/opentelemetry/instrumentation/vita/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-vita/src/opentelemetry/instrumentation/vita/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.0.dev"
+__version__ = "0.7.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-webarena/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-webarena/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.6.0 (2026-06-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.1.0 (2026-05-28)
 
 ### Added

--- a/instrumentation-loongsuite/loongsuite-instrumentation-webarena/src/opentelemetry/instrumentation/webarena/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-webarena/src/opentelemetry/instrumentation/webarena/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.0.dev"
+__version__ = "0.7.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-widesearch/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-widesearch/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.6.0 (2026-06-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.5.0.dev (2026-05-28)
 
 ### Added

--- a/instrumentation-loongsuite/loongsuite-instrumentation-widesearch/src/opentelemetry/instrumentation/widesearch/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-widesearch/src/opentelemetry/instrumentation/widesearch/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.0.dev"
+__version__ = "0.7.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-wildtool/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-wildtool/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.6.0 (2026-06-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.1.0 (2026-05-28)
 
 ### Added

--- a/instrumentation-loongsuite/loongsuite-instrumentation-wildtool/src/opentelemetry/instrumentation/wildtool/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-wildtool/src/opentelemetry/instrumentation/wildtool/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.0.dev"
+__version__ = "0.7.0.dev"

--- a/loongsuite-distro/src/loongsuite/distro/version.py
+++ b/loongsuite-distro/src/loongsuite/distro/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.0.dev"
+__version__ = "0.7.0.dev"

--- a/loongsuite-site-bootstrap/src/loongsuite_site_bootstrap/version.py
+++ b/loongsuite-site-bootstrap/src/loongsuite_site_bootstrap/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.6.0.dev"
+__version__ = "0.7.0.dev"

--- a/util/opentelemetry-util-genai/CHANGELOG-loongsuite.md
+++ b/util/opentelemetry-util-genai/CHANGELOG-loongsuite.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.6.0 (2026-06-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.5.0 (2026-05-11)
 
 ### Added


### PR DESCRIPTION
## Post-release updates for loongsuite-python-agent 0.6.0

This replaces #211 with a human-authored post-release PR so CLA can validate the signed release owner identity.

- Archive Unreleased changelogs as Version 0.6.0
- Bump instrumentation-loongsuite, loongsuite-distro, and loongsuite-site-bootstrap versions to the next dev iteration