### PR TITLE
fix(agno): remove pydantic runtime dependency

### DIFF
--- a/instrumentation-loongsuite/loongsuite-instrumentation-agno/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agno/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Removed
+
+- Remove the direct `pydantic` runtime dependency from Agno instrumentation.
+
 ## Version 0.6.0 (2026-06-03)
 
 ### Removed

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agno/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agno/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
   "opentelemetry-instrumentation >= 0.58b0",
   "opentelemetry-semantic-conventions >= 0.58b0",
   "opentelemetry-util-genai",
-  "pydantic",
   "wrapt >= 1.17.3, < 2.0.0",
 ]
 

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agno/src/opentelemetry/instrumentation/agno/utils.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agno/src/opentelemetry/instrumentation/agno/utils.py
@@ -18,8 +18,6 @@ import json
 from dataclasses import asdict, is_dataclass
 from typing import Any, Mapping, Sequence
 
-from pydantic import BaseModel
-
 from opentelemetry.util.genai.extended_semconv.gen_ai_extended_attributes import (
     GEN_AI_SESSION_ID,
     GEN_AI_USER_ID,
@@ -62,8 +60,17 @@ def _to_dict(value: Any) -> dict[str, Any] | None:
         return None
     if isinstance(value, Mapping):
         return dict(value)
-    if isinstance(value, BaseModel):
-        return value.model_dump(mode="json")
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        try:
+            return model_dump(mode="json")
+        except TypeError:
+            try:
+                return model_dump()
+            except Exception:
+                return None
+        except Exception:
+            return None
     if is_dataclass(value):
         return asdict(value)
     to_dict = getattr(value, "to_dict", None)

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agno/tests/test_agno.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agno/tests/test_agno.py
@@ -324,6 +324,43 @@ def test_concurrent_runs_do_not_drop_spans(
     assert len(model_spans) == 3
 
 
+@pytest.mark.parametrize("content_capture_mode", [None, "NO_CONTENT"])
+def test_content_capture_mode_does_not_gate_span_creation(
+    monkeypatch,
+    span_exporter: InMemorySpanExporter,
+    tracer_provider: trace_api.TracerProvider,
+    content_capture_mode: str | None,
+):
+    AgnoInstrumentor().uninstrument()
+    if hasattr(get_extended_telemetry_handler, "_default_handler"):
+        delattr(get_extended_telemetry_handler, "_default_handler")
+    span_exporter.clear()
+
+    env_var = "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"
+    if content_capture_mode is None:
+        monkeypatch.delenv(env_var, raising=False)
+    else:
+        monkeypatch.setenv(env_var, content_capture_mode)
+
+    AgnoInstrumentor().instrument(tracer_provider=tracer_provider)
+
+    agent = Agent(name="NoContentAgent", model=EchoModel(), tools=[])
+    response = agent.run("Say hello without content")
+
+    assert response.content == "hello"
+    spans = _spans_by_name(span_exporter)
+    assert "invoke_agent NoContentAgent" in spans
+    assert "chat echo-model" in spans
+
+    agent_attrs = spans["invoke_agent NoContentAgent"].attributes
+    model_attrs = spans["chat echo-model"].attributes
+    assert agent_attrs["gen_ai.span.kind"] == "AGENT"
+    assert model_attrs["gen_ai.span.kind"] == "LLM"
+    assert "gen_ai.input.messages" not in agent_attrs
+    assert "gen_ai.output.messages" not in agent_attrs
+    assert "gen_ai.output.messages" not in model_attrs
+
+
 def test_async_function_call_emits_tool_span(
     span_exporter: InMemorySpanExporter,
 ):
@@ -506,6 +543,39 @@ def test_tool_result_messages_do_not_duplicate_text_parts():
     assert parts[0].type == "tool_call_response"
     assert parts[0].id == "call_1"
     assert parts[0].response == {"temperature": 21}
+
+
+def test_model_dump_objects_are_serialized_without_pydantic_base_class():
+    class ModelDumpToolCall:
+        def model_dump(self, mode="json"):
+            assert mode == "json"
+            return {
+                "id": "call_1",
+                "function": {
+                    "name": "get_weather",
+                    "arguments": '{"city":"Hangzhou"}',
+                },
+            }
+
+    messages = convert_agent_input(
+        [
+            SimpleNamespace(
+                role="assistant",
+                content=None,
+                tool_calls=[ModelDumpToolCall()],
+            )
+        ]
+    )
+
+    parts = messages[0].parts
+    tool_calls = [
+        part for part in parts if getattr(part, "type", None) == "tool_call"
+    ]
+
+    assert len(tool_calls) == 1
+    assert tool_calls[0].id == "call_1"
+    assert tool_calls[0].name == "get_weather"
+    assert tool_calls[0].arguments == {"city": "Hangzhou"}
 
 
 def test_missing_finish_reason_is_not_reported():


### PR DESCRIPTION
# Description

This PR removes the direct `pydantic` runtime dependency from `loongsuite-instrumentation-agno` and adds an Agno-side regression test proving that message-content capture mode does not gate span creation.

`origin/main` already has the Agno 2.x instrumentation migrated to `opentelemetry-util-genai` in `d741321e feat(agno): adapt instrumentation for Agno 2`. This PR is the remaining dependency-isolation and regression-test follow-up on top of that migration. The residual issue is that the Agno instrumentation package still declares `pydantic` as a normal dependency and directly imports `BaseModel`, which can make probe installation or pre-cache environments pull Python-ABI-specific `pydantic-core` wheels even when the target application has not installed Agno.

The change keeps support for Pydantic-style objects by using `model_dump()` duck typing instead of importing `pydantic.BaseModel`, and adds a focused test for that conversion path.

Fixes # (N/A; no public issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `python3 <loongsuite-github-pipeline>/scripts/check_loongsuite_pr_readiness.py --repo .`
- [x] `tox -e precommit`
- [x] `tox -c tox-loongsuite.ini -e py310-test-loongsuite-instrumentation-agno`
- [x] `tox -c tox-loongsuite.ini -e lint-loongsuite-instrumentation-agno`
- [x] `tox -c tox-loongsuite.ini -e py310-test-loongsuite-instrumentation-agno -- -k content_capture_mode_does_not_gate_span_creation`
- [x] Built the Agno wheel and inspected `METADATA`; normal runtime dependencies no longer include `pydantic`, `pydantic-core`, or `agno`.
- [x] Installed the rebuilt wheel into a Python 3.10 environment without Agno/Pydantic and imported the Agno instrumentor and utility module successfully.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR:
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated

## Validation Evidence

### Spec and Scope

- Linked issue/spec: No public issue; requested as direct dependency-isolation fix for Agno instrumentation.
- Base migration: Agno already uses `opentelemetry-util-genai` on `origin/main` via `d741321e feat(agno): adapt instrumentation for Agno 2`.
- Changed surface: `loongsuite-instrumentation-agno` dependency metadata, Agno serialization utility, and focused tests.
- Rebase base: latest `origin/main` at PR preparation time.

### Local Checks

| Check | Command | Result | Notes |
| --- | --- | --- | --- |
| Static readiness | `python3 <loongsuite-github-pipeline>/scripts/check_loongsuite_pr_readiness.py --repo .` | pass | LoongSuite static PR readiness checks passed. |
| Precommit | `tox -e precommit` | pass | Ruff, ruff-format, uv-lock, and rstcheck passed. |
| Content capture regression | `tox -c tox-loongsuite.ini -e py310-test-loongsuite-instrumentation-agno -- -k content_capture_mode_does_not_gate_span_creation` | pass | 2 passed. Unset and `NO_CONTENT` still create AGENT/LLM spans while omitting message content attributes. |
| Focused tests | `tox -c tox-loongsuite.ini -e py310-test-loongsuite-instrumentation-agno` | pass | 20 passed. Covers sync, streaming, async, concurrency, tool, content-capture modes, error, and serialization paths. |
| Focused lint | `tox -c tox-loongsuite.ini -e lint-loongsuite-instrumentation-agno` | pass | Agno package ruff check passed. |
| Wheel metadata | `uv build --wheel --out-dir <tmpdir>/loongsuite-agno-rebased-dist instrumentation-loongsuite/loongsuite-instrumentation-agno` | pass | Normal `Requires-Dist` contains OTel/util-genai/wrapt only; Agno remains in extras. |
| No-pydantic import | Install rebuilt wheel plus local OTel/util-genai packages in a clean Python 3.10 environment | pass | `agno`, `pydantic`, and `pydantic_core` were absent; Agno instrumentor import and `model_dump()` duck typing succeeded. |

### CI

- GitHub checks: not run yet; PR is being created after local validation.
- Known unrelated failures: none known.
