### PR TITLE
fix: silence GenAI audio optional dependency import warning

### DIFF
--- a/util/opentelemetry-util-genai/CHANGELOG.md
+++ b/util/opentelemetry-util-genai/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Avoid import-time warnings when optional audio dependencies for PCM16-to-WAV conversion are not installed.
+
 ## Version 0.3b0 (2026-02-20)
 
 - Add `gen_ai.tool_definitions` to completion hook ([#4181](https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4181))

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_multimodal_upload/pre_uploader.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_multimodal_upload/pre_uploader.py
@@ -78,12 +78,6 @@ except ImportError:
 
 _logger = logging.getLogger(__name__)
 
-# Log warning if audio libraries are not available
-if not _audio_libs_available:
-    _logger.warning(
-        "numpy or soundfile not available, PCM16 to WAV conversion will be skipped"
-    )
-
 # Supported modality types for pre-upload (derived from Modality type)
 _SUPPORTED_MODALITIES = get_args(Modality)
 
@@ -591,9 +585,6 @@ class MultimodalPreUploader(PreUploader):
             Byte data in WAV format, None if conversion fails
         """
         if not _audio_libs_available or np is None or sf is None:
-            _logger.warning(
-                "Cannot convert PCM16 to WAV: numpy or soundfile not available"
-            )
             return None
 
         try:

--- a/util/opentelemetry-util-genai/tests/_multimodal_upload/test_pre_uploader_audio.py
+++ b/util/opentelemetry-util-genai/tests/_multimodal_upload/test_pre_uploader_audio.py
@@ -18,6 +18,10 @@ Focuses on testing the _detect_audio_format method's ability to recognize variou
 and audio format conversion (e.g., PCM16 to WAV)
 """
 
+import os
+import subprocess
+import sys
+import textwrap
 from pathlib import Path
 from unittest.mock import patch
 
@@ -64,6 +68,55 @@ class TestAudioFormatDetection:
 
         with open(filepath, "rb") as file_obj:
             return file_obj.read()
+
+    @staticmethod
+    def test_import_without_audio_libs_does_not_write_to_standard_streams():
+        """Missing optional audio libs should not emit import-time output."""
+        project_root = Path(__file__).parents[4]
+        util_genai_src = Path(__file__).parents[2] / "src"
+        instrumentation_src = (
+            project_root / "opentelemetry-instrumentation" / "src"
+        )
+        env = os.environ.copy()
+        pythonpath_parts = [
+            str(util_genai_src),
+            str(instrumentation_src),
+            env.get("PYTHONPATH", ""),
+        ]
+        env["PYTHONPATH"] = os.pathsep.join(
+            part for part in pythonpath_parts if part
+        )
+
+        script = textwrap.dedent(
+            """
+            import importlib.abc
+            import logging
+            import sys
+
+            class BlockAudioLibs(importlib.abc.MetaPathFinder):
+                def find_spec(self, fullname, path=None, target=None):
+                    if fullname == "numpy" or fullname.startswith("numpy."):
+                        raise ImportError(fullname)
+                    if fullname == "soundfile" or fullname.startswith("soundfile."):
+                        raise ImportError(fullname)
+                    return None
+
+            sys.meta_path.insert(0, BlockAudioLibs())
+            logging.basicConfig(level=logging.WARNING, stream=sys.stdout)
+            import opentelemetry.util.genai._multimodal_upload.pre_uploader  # noqa: F401
+            """
+        )
+
+        completed = subprocess.run(
+            [sys.executable, "-c", script],
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        assert completed.stdout == ""
+        assert completed.stderr == ""
 
     # ========== Edge Case Tests ==========
 
@@ -173,6 +226,53 @@ class TestAudioFormatDetection:
         else:
             # If library unavailable, should keep original format
             assert uploads[0].content_type == pcm_mime_type
+
+    @staticmethod
+    def test_pcm16_conversion_missing_audio_libs_logs_single_warning(
+        caplog,
+    ):
+        """Missing optional audio libs should only log the actual conversion skip."""
+        with (
+            patch(
+                "opentelemetry.util.genai._multimodal_upload.pre_uploader._audio_libs_available",
+                False,
+            ),
+            patch(
+                "opentelemetry.util.genai._multimodal_upload.pre_uploader.np",
+                None,
+            ),
+            patch(
+                "opentelemetry.util.genai._multimodal_upload.pre_uploader.sf",
+                None,
+            ),
+        ):
+            pre_uploader = MultimodalPreUploader(base_path="/tmp/test_upload")
+            part = Blob(
+                content=b"\x00\x01" * 1000,
+                mime_type="audio/pcm16",
+                modality="audio",
+            )
+            input_messages = [InputMessage(role="user", parts=[part])]
+
+            with caplog.at_level(
+                "WARNING",
+                logger=(
+                    "opentelemetry.util.genai._multimodal_upload.pre_uploader"
+                ),
+            ):
+                uploads = pre_uploader.pre_upload(
+                    span_context=None,
+                    start_time_utc_nano=1000000000000000000,
+                    input_messages=input_messages,
+                    output_messages=None,
+                )
+
+        assert len(uploads) == 1
+        assert uploads[0].content_type == "audio/pcm16"
+        warning_messages = [record.getMessage() for record in caplog.records]
+        assert warning_messages == [
+            "Failed to convert PCM16 to WAV, using original format"
+        ]
 
     @staticmethod
     def test_pcm16_conversion_disabled_by_default():


### PR DESCRIPTION
# Description

Fixes #217.

This removes the import-time warning from `opentelemetry.util.genai._multimodal_upload.pre_uploader` when optional audio conversion dependencies (`numpy` or `soundfile`) are not installed. The PCM16-to-WAV conversion path still logs a single warning when conversion is actually attempted and cannot be performed.

The change is intentionally scoped to `loongsuite-otel-util-genai`. `loongsuite-site-bootstrap` is out of scope because its stdout success line already has the `LOONGSUITE_PYTHON_SITE_BOOTSTRAP_LOG_SUCCESS=False` mitigation in the released package.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] `python -m ruff check util/opentelemetry-util-genai/src/opentelemetry/util/genai/_multimodal_upload/pre_uploader.py util/opentelemetry-util-genai/tests/_multimodal_upload/test_pre_uploader_audio.py util/opentelemetry-util-genai/CHANGELOG.md`
- [x] `PYTHONPATH=util/opentelemetry-util-genai/src:opentelemetry-instrumentation/src python -m pytest util/opentelemetry-util-genai/tests/_multimodal_upload/test_pre_uploader_audio.py -q`
- [x] `PYTHONPATH=util/opentelemetry-util-genai/src:opentelemetry-instrumentation/src python -m pytest util/opentelemetry-util-genai/tests -q`
- [x] Temporary QwenPaw 1.1.12 + DashScope `qwen3-max` real API smoke comparing release util against this PR util overlay; release emitted the reported warning, PR overlay did not.
- [x] Temporary QwenPaw instrumentation pytest run with QwenPaw 1.1.12 and this PR util overlay.
- [x] `tox -e precommit`

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR:
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated

## Validation Evidence

### Spec and Scope
- Linked issue/spec: #217
- Approved spec/comment: direct bug fix request; `loongsuite-site-bootstrap` explicitly excluded from this PR because the released 0.6.1 package already supports `LOONGSUITE_PYTHON_SITE_BOOTSTRAP_LOG_SUCCESS=False`.
- Changed surface: `loongsuite-otel-util-genai` multimodal pre-uploader optional audio dependency handling.

### Local Checks
| Check | Command | Result | Notes |
| --- | --- | --- | --- |
| Static readiness | `python "$PIPELINE_SKILL_DIR/scripts/check_loongsuite_pr_readiness.py" --repo .` | pass | Warned that no instrumentation plugin directory changed; expected for shared util-only change. |
| Precommit | `tox -e precommit` | pass | First run reformatted one test file; rerun passed. |
| Focused tests | `PYTHONPATH=util/opentelemetry-util-genai/src:opentelemetry-instrumentation/src python -m pytest util/opentelemetry-util-genai/tests/_multimodal_upload/test_pre_uploader_audio.py -q` | pass | 16 passed. |
| Full util tests | `PYTHONPATH=util/opentelemetry-util-genai/src:opentelemetry-instrumentation/src python -m pytest util/opentelemetry-util-genai/tests -q` | pass | 270 passed, 1 skipped (OSS credentials not set). |
| QwenPaw focused tests | `LOONGSUITE_PYTHON_SITE_BOOTSTRAP=False PYTHONPATH=instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/src:util/opentelemetry-util-genai/src:opentelemetry-instrumentation/src python -m pytest instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/tests util/opentelemetry-util-genai/tests/_multimodal_upload/test_pre_uploader_audio.py -q` | pass | 29 passed in a temporary QwenPaw environment. |
| Claude review | `claude_team_review.py review . --backend review ...` | pass | One non-blocking suggestion about exact test assertion disputed; exact assertion is intentional to prevent duplicate warning regression. |
| Privacy scan | `git diff \| rg -n "sk-[A-Za-z0-9]\|DASHSCOPE_API_KEY\|OPENAI_API_KEY\|ANTHROPIC_API_KEY\|Bearer [A-Za-z0-9]\|/Users/sipercai\|/tmp/codex-claude-review\|private trace\|trace_id\|traceId" \|\| true` | pass | No matches. |

### Real E2E Matrix
| Scenario | Status | Command or Demo | Evidence |
| --- | --- | --- | --- |
| non-streaming | pass | Temporary QwenPaw 1.1.12 + DashScope `qwen3-max` `AgentRunner.query_handler` smoke with release util and PR util overlay. | Release util stderr started with `numpy or soundfile not available...`; PR util overlay removed that line. Both runs completed with `real_api_chunks=5 last=True`. |
| streaming | pass | Same QwenPaw async generator smoke. | The runner yielded streamed chunks and completed successfully with PR util overlay. |
| concurrency | N/A | Import-time warning side effect is process startup behavior; no shared mutable runtime path changed. | Covered by subprocess import regression with optional audio libs blocked. |
| agent/tool/ReAct | N/A | This PR does not change QwenPaw/AgentScope agent or tool instrumentation. | QwenPaw runner smoke was used only to validate the customer startup path. |
| tool-heavy | N/A | No tool execution behavior changed. | Not applicable to optional audio dependency import logging. |
| error path | pass | `test_pcm16_conversion_missing_audio_libs_logs_single_warning` | Missing audio libs during actual PCM16 conversion produce exactly one conversion-skip warning and keep original `audio/pcm16` content type. |

### Telemetry and Weaver
| Check | Status | Command or Artifact | Notes |
| --- | --- | --- | --- |
| Span tree / span kinds | N/A | N/A | No GenAI span creation, attributes, parent-child relationships, or exporter behavior changed. |
| Content capture modes | N/A | N/A | No content-capture semantics changed. |
| Concurrency isolation | N/A | N/A | No trace/context propagation or shared runtime telemetry state changed. |
| Weaver live-check | N/A | N/A | No telemetry sample shape changed; this PR only removes import-time optional dependency logging. |

### CI
- GitHub checks: not available until the branch is pushed and PR is opened.
- Known unrelated failures: none.
- Follow-up needed: inspect CI after PR creation.
