### PR TITLE
fix: capture DashScope multimodal media outputs

### DIFF
--- a/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Capture image and video URI outputs from `MultiModalConversation` responses.
+
 ## Version 0.6.0 (2026-06-03)
 
 ### Fixed

--- a/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/src/opentelemetry/instrumentation/dashscope/utils/multimodal.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/src/opentelemetry/instrumentation/dashscope/utils/multimodal.py
@@ -351,12 +351,32 @@ def _extract_multimodal_output_messages(response: Any) -> List[OutputMessage]:
                                             type="text",
                                         )
                                     )
+                                # Image content
+                                elif "image" in item:
+                                    parts.append(
+                                        Uri(
+                                            uri=item["image"],
+                                            modality="image",
+                                            mime_type=None,
+                                            type="uri",
+                                        )
+                                    )
                                 # Audio content (when modalities includes "audio")
                                 elif "audio" in item:
                                     parts.append(
                                         Uri(
                                             uri=item["audio"],
                                             modality="audio",
+                                            mime_type=None,
+                                            type="uri",
+                                        )
+                                    )
+                                # Video content
+                                elif "video" in item:
+                                    parts.append(
+                                        Uri(
+                                            uri=item["video"],
+                                            modality="video",
                                             mime_type=None,
                                             type="uri",
                                         )

--- a/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/tests/test_multimodal_conversation.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/tests/test_multimodal_conversation.py
@@ -14,14 +14,56 @@
 
 """Tests for MultiModalConversation instrumentation."""
 
+import json
+from types import SimpleNamespace
 from typing import Optional
 
 import pytest
 from dashscope import MultiModalConversation
 
+from opentelemetry.instrumentation._semconv import (
+    OTEL_SEMCONV_STABILITY_OPT_IN,
+    _OpenTelemetrySemanticConventionStability,
+)
+from opentelemetry.instrumentation.dashscope.utils.multimodal import (
+    _extract_multimodal_output_messages,
+    _update_invocation_from_multimodal_response,
+)
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
 )
+from opentelemetry.util.genai.environment_variables import (
+    OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT,
+)
+from opentelemetry.util.genai.handler import TelemetryHandler
+from opentelemetry.util.genai.types import LLMInvocation, Text, Uri
+
+
+def _make_multimodal_response(content, finish_reason="stop"):
+    return SimpleNamespace(
+        output=SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content=content),
+                    finish_reason=finish_reason,
+                )
+            ]
+        )
+    )
+
+
+@pytest.fixture(scope="function")
+def content_capture_env(monkeypatch):
+    _OpenTelemetrySemanticConventionStability._initialized = False
+    monkeypatch.setenv(
+        OTEL_SEMCONV_STABILITY_OPT_IN, "gen_ai_latest_experimental"
+    )
+    monkeypatch.setenv(
+        OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT, "SPAN_ONLY"
+    )
+    _OpenTelemetrySemanticConventionStability._initialize()
+    yield
+    _OpenTelemetrySemanticConventionStability._initialized = False
 
 
 def _safe_getattr(obj, attr, default=None):
@@ -118,6 +160,96 @@ def _assert_multimodal_span_attributes(
         assert ttft_ns > 0, (
             f"time_to_first_token should be positive, got {ttft_ns}"
         )
+
+
+@pytest.mark.parametrize(
+    ("content_key", "url", "modality"),
+    [
+        ("image", "https://example.com/a.png", "image"),
+        ("audio", "https://example.com/a.wav", "audio"),
+        ("video", "https://example.com/a.mp4", "video"),
+    ],
+)
+def test_extract_multimodal_output_messages_with_uri_content(
+    content_key, url, modality
+):
+    """Test output message extraction for media URI content."""
+    messages = _extract_multimodal_output_messages(
+        _make_multimodal_response([{content_key: url}])
+    )
+
+    assert len(messages) == 1
+    assert messages[0].role == "assistant"
+    assert messages[0].finish_reason == "stop"
+    assert len(messages[0].parts) == 1
+
+    part = messages[0].parts[0]
+    assert isinstance(part, Uri)
+    assert part.uri == url
+    assert part.modality == modality
+    assert part.mime_type is None
+    assert part.type == "uri"
+
+
+def test_extract_multimodal_output_messages_with_text_and_image_content():
+    """Test output message extraction preserves mixed text and image parts."""
+    image_url = "https://example.com/generated.png"
+    messages = _extract_multimodal_output_messages(
+        _make_multimodal_response([{"text": "ok"}, {"image": image_url}])
+    )
+
+    assert len(messages) == 1
+    assert messages[0].role == "assistant"
+    assert messages[0].finish_reason == "stop"
+    assert len(messages[0].parts) == 2
+
+    text_part = messages[0].parts[0]
+    assert isinstance(text_part, Text)
+    assert text_part.content == "ok"
+    assert text_part.type == "text"
+
+    image_part = messages[0].parts[1]
+    assert isinstance(image_part, Uri)
+    assert image_part.uri == image_url
+    assert image_part.modality == "image"
+    assert image_part.mime_type is None
+    assert image_part.type == "uri"
+
+
+def test_multimodal_image_output_messages_written_to_span(
+    content_capture_env, tracer_provider, span_exporter
+):
+    """Test image output URI is written to gen_ai.output.messages."""
+    image_url = "https://example.com/generated.png"
+    response = _make_multimodal_response([{"image": image_url}])
+    invocation = LLMInvocation(request_model="wan2.7-image")
+    invocation.provider = "dashscope"
+
+    _update_invocation_from_multimodal_response(invocation, response)
+
+    handler = TelemetryHandler(tracer_provider=tracer_provider)
+    handler.start_llm(invocation)
+    handler.stop_llm(invocation)
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    output_messages = json.loads(
+        spans[0].attributes[GenAIAttributes.GEN_AI_OUTPUT_MESSAGES]
+    )
+    assert output_messages == [
+        {
+            "role": "assistant",
+            "parts": [
+                {
+                    "mime_type": None,
+                    "modality": "image",
+                    "uri": image_url,
+                    "type": "uri",
+                }
+            ],
+            "finish_reason": "stop",
+        }
+    ]
 
 
 @pytest.mark.vcr()


### PR DESCRIPTION
# Description

This PR updates DashScope `MultiModalConversation` output parsing so media URLs returned in response content are captured as output URI parts. Image and video content items now become `Uri` parts in `gen_ai.output.messages`, matching the existing text/audio handling and allowing downstream multimodal processing to see generated media outputs.

Fixes # (N/A)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] `git diff --check`
- [x] `python -m pytest instrumentation-loongsuite/loongsuite-instrumentation-dashscope/tests/test_multimodal_conversation.py -q`
- [x] `python -m pytest instrumentation-loongsuite/loongsuite-instrumentation-dashscope/tests/test_image_synthesis.py -q`
- [x] `python -m ruff check instrumentation-loongsuite/loongsuite-instrumentation-dashscope`
- [x] `python "$PIPELINE_SKILL_DIR/scripts/check_loongsuite_pr_readiness.py" --repo .`
- [x] `tox -e precommit`
- [x] `tox -c tox-loongsuite.ini -e py313-test-loongsuite-instrumentation-dashscope-oldest,py313-test-loongsuite-instrumentation-dashscope-latest`

## Validation Evidence

### Spec and Scope
- Linked issue/spec: N/A; local bug report for DashScope `MultiModalConversation` image output capture.
- Approved spec/comment: User requested direct implementation for `response.output.choices[0].message.content = [{"image": "..."}]`.
- Changed surface: `loongsuite-instrumentation-dashscope` output message extraction and tests.

### Local Checks
| Check | Command | Result | Notes |
| --- | --- | --- | --- |
| Static readiness | `python "$PIPELINE_SKILL_DIR/scripts/check_loongsuite_pr_readiness.py" --repo .` | pass | LoongSuite static readiness checks passed. |
| Precommit | `tox -e precommit` | pass | Completed repository precommit gate. |
| Focused tests | `tox -c tox-loongsuite.ini -e py313-test-loongsuite-instrumentation-dashscope-oldest,py313-test-loongsuite-instrumentation-dashscope-latest` | pass | Both environments reported 51 passed, 4 skipped. |
| Focused lint | `tox -c tox-loongsuite.ini -e lint-loongsuite-instrumentation-dashscope` | blocked | Environment dependency download stalled; direct `python -m ruff check instrumentation-loongsuite/loongsuite-instrumentation-dashscope` passed. |
| Claude review | Local Codex-Claude review loop | pass | No blocking findings remained after review/fix/re-review. |
| Privacy scan | scan changed files for local paths, bearer tokens, API keys, and secret-looking keys | pass | No hits in changed files. |

### Real E2E Matrix
| Scenario | Status | Command or Demo | Evidence |
| --- | --- | --- | --- |
| non-streaming | pass | Live DashScope `MultiModalConversation.call(model="wan2.7-image")` smoke | Real response returned image content and local span contained `gen_ai.output.messages` with `modality=image` URI. |
| streaming | pass | `tox -c tox-loongsuite.ini -e py313-test-loongsuite-instrumentation-dashscope-oldest,py313-test-loongsuite-instrumentation-dashscope-latest` | Existing streaming multimodal tests passed in both focused environments. |
| concurrency | blocked | Not run for this narrow output-parser fix | Run a bounded two-call DashScope smoke before marking ready if concurrency evidence is required. |
| agent/tool/ReAct | N/A | DashScope SDK media output parser has no agent/tool surface | Not an agent framework integration. |
| tool-heavy | N/A | DashScope SDK media output parser has no tool-calling surface | Not a tool orchestration integration. |
| error path | pass | Focused DashScope tox suites | Existing error-handling tests passed in both focused environments. |

### Telemetry and Weaver
| Check | Status | Command or Artifact | Notes |
| --- | --- | --- | --- |
| Span tree / span kinds | pass | Live DashScope smoke plus ARMS readback | ARMS readback confirmed a `chat wan2.7-image` LLM span with image URI in `gen_ai.output.messages`. |
| Content capture modes | pass | Focused unit test with `SPAN_ONLY`; existing no-content tests in DashScope suite | New test asserts image URI is written when content capture is enabled; existing no-content tests continue to pass. |
| Concurrency isolation | blocked | Not run | Run a bounded concurrent smoke before ready-for-review if required. |
| Weaver live-check | blocked | `weaver registry live-check -r <loongsuite-semantic-conventions-registry> --advice-profile loongsuite-genai ...` | Not run in this draft preparation; ARMS readback was used for telemetry evidence. |

### CI
- GitHub checks: pending PR creation.
- Known unrelated failures: none identified.
- Follow-up needed: rerun focused lint tox and Weaver live-check before moving this PR out of draft if maintainers require those gates.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR:
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
