### PR TITLE
chore: post-release 0.7.0 - archive changelogs & bump dev versions

### DIFF
--- a/CHANGELOG-loongsuite.md
+++ b/CHANGELOG-loongsuite.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.7.0 (2026-07-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.6.0 (2026-06-03)
 
 ### Changed

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.7.0 (2026-07-03)
+
 ### Added
 
 - Add version-aware AgentScope v2 middleware instrumentation while preserving

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0.dev"
+__version__ = "0.8.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agno/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agno/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.7.0 (2026-07-03)
+
 ### Removed
 
 - Remove the direct `pydantic` runtime dependency from Agno instrumentation.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agno/src/opentelemetry/instrumentation/agno/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agno/src/opentelemetry/instrumentation/agno/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0.dev"
+__version__ = "0.8.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-algotune/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-algotune/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.7.0 (2026-07-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.6.0 (2026-06-03)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-algotune/src/opentelemetry/instrumentation/algotune/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-algotune/src/opentelemetry/instrumentation/algotune/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0.dev"
+__version__ = "0.8.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-autogen/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-autogen/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.7.0 (2026-07-03)
+
 ### Added
 
 - Add Microsoft AutoGen 0.7.x AgentChat instrumentation.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-autogen/src/opentelemetry/instrumentation/autogen/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-autogen/src/opentelemetry/instrumentation/autogen/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0.dev"
+__version__ = "0.8.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-bfclv4/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-bfclv4/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.7.0 (2026-07-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.6.0 (2026-06-03)
 
 ### Added

--- a/instrumentation-loongsuite/loongsuite-instrumentation-bfclv4/src/opentelemetry/instrumentation/bfclv4/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-bfclv4/src/opentelemetry/instrumentation/bfclv4/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0.dev"
+__version__ = "0.8.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.7.0 (2026-07-03)
+
 ### Added
 
 - Capture `gen_ai.skill.name`, `gen_ai.skill.id`, `gen_ai.skill.description`

--- a/instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/src/opentelemetry/instrumentation/claude_agent_sdk/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/src/opentelemetry/instrumentation/claude_agent_sdk/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0.dev"
+__version__ = "0.8.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-claw-eval/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-claw-eval/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.7.0 (2026-07-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.6.0 (2026-06-03)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-claw-eval/src/opentelemetry/instrumentation/claw_eval/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-claw-eval/src/opentelemetry/instrumentation/claw_eval/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0.dev"
+__version__ = "0.8.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-crewai/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-crewai/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.7.0 (2026-07-03)
+
 ### Fixed
 
 - Keep the authentication-failure test deterministic by using fake provider

--- a/instrumentation-loongsuite/loongsuite-instrumentation-crewai/src/opentelemetry/instrumentation/crewai/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-crewai/src/opentelemetry/instrumentation/crewai/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0.dev"
+__version__ = "0.8.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.7.0 (2026-07-03)
+
 ### Fixed
 
 - Capture image and video URI outputs from `MultiModalConversation` responses.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/src/opentelemetry/instrumentation/dashscope/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/src/opentelemetry/instrumentation/dashscope/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0.dev"
+__version__ = "0.8.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-deepagents/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-deepagents/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.7.0 (2026-07-03)
+
 ### Added
 
 - Initial DeepAgents instrumentation that marks `create_deep_agent` graphs so

--- a/instrumentation-loongsuite/loongsuite-instrumentation-deepagents/src/opentelemetry/instrumentation/deepagents/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-deepagents/src/opentelemetry/instrumentation/deepagents/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0.dev"
+__version__ = "0.8.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-dify/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-dify/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.7.0 (2026-07-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.6.0 (2026-06-03)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-dify/src/opentelemetry/instrumentation/dify/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-dify/src/opentelemetry/instrumentation/dify/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0.dev"
+__version__ = "0.8.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.7.0 (2026-07-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.6.0 (2026-06-03)
 
 ### Changed

--- a/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/src/opentelemetry/instrumentation/google_adk/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/src/opentelemetry/instrumentation/google_adk/version.py
@@ -14,4 +14,4 @@
 
 """Version information for OpenTelemetry Google ADK Instrumentation."""
 
-__version__ = "0.7.0.dev"
+__version__ = "0.8.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.7.0 (2026-07-03)
+
 ### Fixed
 
 - Create Hermes `ENTRY` spans for platform-less `AIAgent` calls by mirroring

--- a/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/src/opentelemetry/instrumentation/hermes_agent/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/src/opentelemetry/instrumentation/hermes_agent/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0.dev"
+__version__ = "0.8.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-langchain/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-langchain/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.7.0 (2026-07-03)
+
 ### Added
 
 - Detect DeepAgents skill loads from `read_file` tool calls that read a

--- a/instrumentation-loongsuite/loongsuite-instrumentation-langchain/src/opentelemetry/instrumentation/langchain/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-langchain/src/opentelemetry/instrumentation/langchain/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0.dev"
+__version__ = "0.8.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.7.0 (2026-07-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.6.0 (2026-06-03)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/src/opentelemetry/instrumentation/langgraph/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-langgraph/src/opentelemetry/instrumentation/langgraph/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0.dev"
+__version__ = "0.8.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-litellm/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-litellm/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.7.0 (2026-07-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.6.0 (2026-06-03)
 
 ### Changed

--- a/instrumentation-loongsuite/loongsuite-instrumentation-litellm/src/opentelemetry/instrumentation/litellm/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-litellm/src/opentelemetry/instrumentation/litellm/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0.dev"
+__version__ = "0.8.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-mcp/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-mcp/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.7.0 (2026-07-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.6.0 (2026-06-03)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-mcp/src/opentelemetry/instrumentation/mcp/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-mcp/src/opentelemetry/instrumentation/mcp/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0.dev"
+__version__ = "0.8.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-mem0/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-mem0/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.7.0 (2026-07-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.6.0 (2026-06-03)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-mem0/src/opentelemetry/instrumentation/mem0/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-mem0/src/opentelemetry/instrumentation/mem0/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0.dev"
+__version__ = "0.8.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-microsoft-agent-framework/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-microsoft-agent-framework/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.7.0 (2026-07-03)
+
 ### Added
 
 - Add Microsoft Agent Framework instrumentation aligned with LoongSuite GenAI semantic conventions.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-microsoft-agent-framework/src/opentelemetry/instrumentation/microsoft_agent_framework/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-microsoft-agent-framework/src/opentelemetry/instrumentation/microsoft_agent_framework/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0.dev"
+__version__ = "0.8.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-minisweagent/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-minisweagent/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.7.0 (2026-07-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.6.0 (2026-06-03)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-minisweagent/src/opentelemetry/instrumentation/minisweagent/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-minisweagent/src/opentelemetry/instrumentation/minisweagent/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0.dev"
+__version__ = "0.8.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-openhands/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-openhands/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.7.0 (2026-07-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.6.0 (2026-06-03)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-openhands/src/opentelemetry/instrumentation/openhands/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-openhands/src/opentelemetry/instrumentation/openhands/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0.dev"
+__version__ = "0.8.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.7.0 (2026-07-03)
+
 ### Fixed
 
 - Record token usage from Qwen-Agent DashScope response metadata on streaming

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/src/opentelemetry/instrumentation/qwen_agent/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0.dev"
+__version__ = "0.8.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.7.0 (2026-07-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.6.0 (2026-06-03)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/src/opentelemetry/instrumentation/qwenpaw/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/src/opentelemetry/instrumentation/qwenpaw/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0.dev"
+__version__ = "0.8.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-slop-code/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-slop-code/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.7.0 (2026-07-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.6.0 (2026-06-03)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-slop-code/src/opentelemetry/instrumentation/slop_code/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-slop-code/src/opentelemetry/instrumentation/slop_code/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0.dev"
+__version__ = "0.8.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-terminus2/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-terminus2/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.7.0 (2026-07-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.6.0 (2026-06-03)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-terminus2/src/opentelemetry/instrumentation/terminus2/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-terminus2/src/opentelemetry/instrumentation/terminus2/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0.dev"
+__version__ = "0.8.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-vita/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-vita/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.7.0 (2026-07-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.6.0 (2026-06-03)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-vita/src/opentelemetry/instrumentation/vita/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-vita/src/opentelemetry/instrumentation/vita/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0.dev"
+__version__ = "0.8.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-webarena/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-webarena/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.7.0 (2026-07-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.6.0 (2026-06-03)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-webarena/src/opentelemetry/instrumentation/webarena/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-webarena/src/opentelemetry/instrumentation/webarena/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0.dev"
+__version__ = "0.8.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-widesearch/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-widesearch/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.7.0 (2026-07-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.6.0 (2026-06-03)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-widesearch/src/opentelemetry/instrumentation/widesearch/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-widesearch/src/opentelemetry/instrumentation/widesearch/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0.dev"
+__version__ = "0.8.0.dev"

--- a/instrumentation-loongsuite/loongsuite-instrumentation-wildtool/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-wildtool/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.7.0 (2026-07-03)
+
+There are no changelog entries for this release.
+
 ## Version 0.6.0 (2026-06-03)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-wildtool/src/opentelemetry/instrumentation/wildtool/version.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-wildtool/src/opentelemetry/instrumentation/wildtool/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0.dev"
+__version__ = "0.8.0.dev"

--- a/loongsuite-distro/src/loongsuite/distro/version.py
+++ b/loongsuite-distro/src/loongsuite/distro/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0.dev"
+__version__ = "0.8.0.dev"

--- a/loongsuite-site-bootstrap/src/loongsuite_site_bootstrap/version.py
+++ b/loongsuite-site-bootstrap/src/loongsuite_site_bootstrap/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.7.0.dev"
+__version__ = "0.8.0.dev"

--- a/util/opentelemetry-util-genai/CHANGELOG-loongsuite.md
+++ b/util/opentelemetry-util-genai/CHANGELOG-loongsuite.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Version 0.7.0 (2026-07-03)
+
 ### Added
 
 - Propagate agent name through the `gen_ai.agent.name` Baggage key during


### PR DESCRIPTION
## Post-release updates for loongsuite-python 0.7.0

Housekeeping after the `0.7.0` release:

- Archive `Unreleased` changelog entries under `Version 0.7.0 (2026-07-03)`.
- Bump LoongSuite package dev versions from `0.7.0.dev` to `0.8.0.dev`.

Validation:

- `tox -e precommit`
- `git diff --check`
