### PR TITLE
fix: capture Claude SDK stream model metadata

### DIFF
--- a/instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Capture Claude Agent SDK default model names from stream metadata when the
+  client options and environment do not provide an explicit model.
+- Fail open LLM spans when Claude Agent SDK streams raise exceptions, preserving
+  parent context cleanup for subsequent calls.
+- Preserve tool-only assistant messages as tool spans without fabricating LLM
+  spans.
+
 ## Version 0.7.0 (2026-07-03)
 
 ### Added

--- a/instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/src/opentelemetry/instrumentation/claude_agent_sdk/patch.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/src/opentelemetry/instrumentation/claude_agent_sdk/patch.py
@@ -106,6 +106,46 @@ def _set_llm_session_id(
     _apply_session_identity(llm_invocation, session_id)
 
 
+def _normalize_model(model: Any) -> Optional[str]:
+    if model is None:
+        return None
+    model_text = str(model).strip()
+    return model_text or None
+
+
+def _is_unknown_model(model: Any) -> bool:
+    model_text = _normalize_model(model)
+    return model_text is None or model_text == "unknown"
+
+
+def _resolve_assistant_model(msg: Any, fallback_model: str) -> str:
+    """Use AssistantMessage.model when options/env did not provide a model."""
+    normalized_fallback = _normalize_model(fallback_model) or "unknown"
+    message_model = _normalize_model(getattr(msg, "model", None))
+    if _is_unknown_model(normalized_fallback) and message_model:
+        return message_model
+    return normalized_fallback
+
+
+def _apply_assistant_model(
+    agent_invocation: InvokeAgentInvocation, model: str
+) -> None:
+    """Late-fill the agent request model once the SDK reveals its default."""
+    if _is_unknown_model(
+        agent_invocation.request_model
+    ) and not _is_unknown_model(model):
+        agent_invocation.request_model = model
+
+
+def _extract_model_from_result_message(msg: Any) -> Optional[str]:
+    model_usage = getattr(msg, "model_usage", None)
+    if not isinstance(model_usage, dict) or not model_usage:
+        return None
+    if len(model_usage) == 1:
+        return _normalize_model(next(iter(model_usage)))
+    return None
+
+
 def _clear_client_managed_runs(
     handler: ExtendedTelemetryHandler,
     client_managed_runs: Dict[str, ExecuteToolInvocation],
@@ -482,6 +522,9 @@ def _process_assistant_message(
     cwd: Optional[str] = None,
 ) -> None:
     """Process AssistantMessage: create LLM turn, extract parts, create tool spans."""
+    message_model = _resolve_assistant_model(msg, model)
+    _apply_assistant_model(agent_invocation, message_model)
+
     parts = _extract_message_parts(msg)
     has_text_content = any(isinstance(p, Text) for p in parts)
     has_tool_calls = any(isinstance(p, ToolCall) for p in parts)
@@ -494,10 +537,11 @@ def _process_assistant_message(
             turn_tracker.close_llm_turn()
 
         message_arrival_time = time.time()
+        finish_reason = "tool_calls" if has_tool_calls else "stop"
 
         turn_tracker.start_llm_turn(
             msg,
-            model,
+            message_model,
             prompt,
             collected_messages,
             provider=infer_provider_from_base_url(),
@@ -506,9 +550,11 @@ def _process_assistant_message(
         )
 
         if parts:
-            turn_tracker.add_assistant_output(parts)
+            turn_tracker.add_assistant_output(parts, finish_reason)
             output_msg = OutputMessage(
-                role="assistant", parts=list(parts), finish_reason="stop"
+                role="assistant",
+                parts=list(parts),
+                finish_reason=finish_reason,
             )
             agent_invocation.output_messages.append(output_msg)
 
@@ -527,14 +573,8 @@ def _process_assistant_message(
                 last_output_msg.parts.extend(parts)
                 last_output_msg.finish_reason = "tool_calls"
             else:
-                turn_tracker.add_assistant_output(parts)
-                output_msg = OutputMessage(
-                    role="assistant",
-                    parts=list(parts),
-                    finish_reason="tool_calls",
-                )
-                turn_tracker.current_llm_invocation.output_messages.append(
-                    output_msg
+                turn_tracker.add_assistant_output(
+                    parts, finish_reason="tool_calls"
                 )
 
         # Only add to collected_messages if not inside a Task
@@ -557,7 +597,8 @@ def _process_assistant_message(
                     {"role": "assistant", "parts": list(parts)}
                 )
 
-    # Close LLM turn before creating tool spans to ensure correct timeline
+    # Close an existing LLM turn before creating tool spans to keep tool spans
+    # under the agent context and avoid leaking the LLM context into tools.
     if has_tool_calls and turn_tracker.current_llm_invocation:
         turn_tracker.close_llm_turn()
 
@@ -749,7 +790,7 @@ def _process_user_message(
 def _process_system_message(
     msg: Any,
     agent_invocation: InvokeAgentInvocation,
-) -> Optional[str]:
+) -> tuple[Optional[str], Optional[str]]:
     """Process SystemMessage: extract session_id and cwd early in the stream.
 
     SystemMessage appears at the beginning of the message stream and contains
@@ -757,7 +798,7 @@ def _process_system_message(
     available for all subsequent spans (cwd is needed to locate project-level
     SKILL.md files for Skill tool telemetry).
 
-    Returns the cwd if present, otherwise ``None``.
+    Returns ``(cwd, model)`` when present.
     """
     if hasattr(msg, "subtype") and msg.subtype == "init":
         if hasattr(msg, "data") and isinstance(msg.data, dict):
@@ -765,9 +806,11 @@ def _process_system_message(
             if session_id:
                 _set_session_id(agent_invocation, session_id)
             cwd = msg.data.get("cwd")
-            if cwd:
-                return str(cwd)
-    return None
+            model = _normalize_model(msg.data.get("model"))
+            if model:
+                _apply_assistant_model(agent_invocation, model)
+            return str(cwd) if cwd else None, model
+    return None, None
 
 
 def _process_stream_event_message(
@@ -794,6 +837,11 @@ def _process_result_message(
     turn_tracker: "AssistantTurnTracker",
 ) -> None:
     """Process ResultMessage: update session_id (fallback), token usage, and close any open LLM turn."""
+
+    result_model = _extract_model_from_result_message(msg)
+    if result_model:
+        _apply_assistant_model(agent_invocation, result_model)
+        turn_tracker.apply_model(result_model)
 
     _set_session_id(agent_invocation, getattr(msg, "session_id", None))
     turn_tracker.set_session_id(agent_invocation.conversation_id)
@@ -846,6 +894,7 @@ async def _process_agent_invocation_stream(
     # cwd captured from SystemMessage.data.cwd, used to locate project-level
     # SKILL.md files for Skill tool telemetry.
     session_cwd: Optional[str] = None
+    current_model = model
     agent_closed = False
 
     def close_agent_successfully() -> None:
@@ -854,20 +903,30 @@ async def _process_agent_invocation_stream(
             handler.stop_invoke_agent(agent_invocation)
             agent_closed = True
 
+    def fail_agent(error: Error) -> None:
+        nonlocal agent_closed
+        if not agent_closed:
+            handler.fail_invoke_agent(agent_invocation, error=error)
+            agent_closed = True
+
     try:
         async for msg in wrapped_stream:
             msg_type = type(msg).__name__
 
             if msg_type == "SystemMessage":
-                cwd = _process_system_message(msg, agent_invocation)
+                cwd, system_model = _process_system_message(
+                    msg, agent_invocation
+                )
                 if cwd:
                     session_cwd = cwd
+                if system_model and _is_unknown_model(current_model):
+                    current_model = system_model
             elif msg_type == "StreamEvent":
                 _process_stream_event_message(msg, agent_invocation)
             elif msg_type == "AssistantMessage":
                 _process_assistant_message(
                     msg,
-                    model,
+                    current_model,
                     prompt,
                     agent_invocation,
                     turn_tracker,
@@ -896,17 +955,15 @@ async def _process_agent_invocation_stream(
 
     except BaseException as e:
         error_msg = str(e)
+        error = Error(message=error_msg, type=type(e))
         if not agent_closed:
+            turn_tracker.fail_llm_turn(error)
             if agent_invocation.span:
                 agent_invocation.span.set_attribute(
                     "error.type", type(e).__name__
                 )
                 agent_invocation.span.set_attribute("error.message", error_msg)
-            handler.fail_invoke_agent(
-                agent_invocation,
-                error=Error(message=error_msg, type=type(e)),
-            )
-            agent_closed = True
+            fail_agent(error)
 
         raise
     finally:
@@ -1018,13 +1075,15 @@ class AssistantTurnTracker:
         self.current_llm_invocation = llm_invocation
         return llm_invocation
 
-    def add_assistant_output(self, parts: List[Any]) -> None:
+    def add_assistant_output(
+        self, parts: List[Any], finish_reason: str = "stop"
+    ) -> None:
         """Add output message parts to current LLM invocation."""
         if not self.current_llm_invocation or not parts:
             return
 
         output_msg = OutputMessage(
-            role="assistant", parts=list(parts), finish_reason="stop"
+            role="assistant", parts=list(parts), finish_reason=finish_reason
         )
         self.current_llm_invocation.output_messages.append(output_msg)
 
@@ -1053,10 +1112,29 @@ class AssistantTurnTracker:
         if target_invocation:
             _set_llm_session_id(target_invocation, session_id)
 
+    def apply_model(self, model: str) -> None:
+        """Update an open or recently closed LLM invocation model if unknown."""
+        target_invocation = (
+            self.current_llm_invocation or self.last_closed_llm_invocation
+        )
+        if (
+            target_invocation
+            and _is_unknown_model(target_invocation.request_model)
+            and not _is_unknown_model(model)
+        ):
+            target_invocation.request_model = model
+
     def close_llm_turn(self) -> None:
         """Close the current LLM invocation span."""
         if self.current_llm_invocation:
             self.handler.stop_llm(self.current_llm_invocation)
+            self.last_closed_llm_invocation = self.current_llm_invocation
+            self.current_llm_invocation = None
+
+    def fail_llm_turn(self, error: Error) -> None:
+        """Fail the current LLM invocation span."""
+        if self.current_llm_invocation:
+            self.handler.fail_llm(self.current_llm_invocation, error)
             self.last_closed_llm_invocation = self.current_llm_invocation
             self.current_llm_invocation = None
 

--- a/instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/src/opentelemetry/instrumentation/claude_agent_sdk/patch.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/src/opentelemetry/instrumentation/claude_agent_sdk/patch.py
@@ -848,6 +848,12 @@ async def _process_agent_invocation_stream(
     session_cwd: Optional[str] = None
     agent_closed = False
 
+    def close_agent_successfully() -> None:
+        nonlocal agent_closed
+        if not agent_closed:
+            handler.stop_invoke_agent(agent_invocation)
+            agent_closed = True
+
     try:
         async for msg in wrapped_stream:
             msg_type = type(msg).__name__
@@ -882,11 +888,11 @@ async def _process_agent_invocation_stream(
                 )
             elif msg_type == "ResultMessage":
                 _process_result_message(msg, agent_invocation, turn_tracker)
+                close_agent_successfully()
 
             yield msg
 
-        handler.stop_invoke_agent(agent_invocation)
-        agent_closed = True
+        close_agent_successfully()
 
     except BaseException as e:
         error_msg = str(e)

--- a/instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/tests/test_session_capture.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/tests/test_session_capture.py
@@ -42,9 +42,18 @@ from opentelemetry.util.genai.extended_semconv.gen_ai_extended_attributes import
 
 
 class SystemMessage:
-    def __init__(self, session_id: str):
+    def __init__(
+        self,
+        session_id: str,
+        model: str | None = None,
+        cwd: str | None = None,
+    ):
         self.subtype = "init"
         self.data = {"session_id": session_id}
+        if model is not None:
+            self.data["model"] = model
+        if cwd is not None:
+            self.data["cwd"] = cwd
 
 
 class StreamEvent:
@@ -83,7 +92,11 @@ class UserMessage:
 
 
 class ResultMessage:
-    def __init__(self, session_id: str | None = None):
+    def __init__(
+        self,
+        session_id: str | None = None,
+        model_usage: dict[str, Any] | None = None,
+    ):
         self.subtype = "success"
         self.duration_ms = 10
         self.duration_api_ms = 8
@@ -94,6 +107,7 @@ class ResultMessage:
         self.usage = {"input_tokens": 11, "output_tokens": 7}
         self.result = "done"
         self.structured_output = None
+        self.model_usage = model_usage
 
 
 class TextBlock:
@@ -120,6 +134,12 @@ class ToolResultBlock:
 async def _stream(messages):
     for message in messages:
         yield message
+
+
+async def _failing_stream(messages, exc):
+    for message in messages:
+        yield message
+    raise exc
 
 
 async def _cancelled_stream(session_id):
@@ -221,6 +241,200 @@ async def test_system_session_propagates_to_agent_llm_and_tool(
     assert agent_span.attributes[GEN_AI_SESSION_ID] == "sess-system"
     assert llm_span.attributes[GEN_AI_SESSION_ID] == "sess-system"
     assert tool_span.attributes[GEN_AI_SESSION_ID] == "sess-system"
+
+
+@pytest.mark.asyncio
+async def test_assistant_message_model_fills_unknown_request_model(
+    tracer_provider, span_exporter
+):
+    handler = ExtendedTelemetryHandler(tracer_provider=tracer_provider)
+
+    async for _ in _process_agent_invocation_stream(
+        wrapped_stream=_stream(
+            [
+                SystemMessage("sess-model"),
+                AssistantMessage(
+                    [TextBlock("answer")],
+                    model="claude-actual-model",
+                ),
+                ResultMessage("sess-model"),
+            ]
+        ),
+        handler=handler,
+        model="unknown",
+        prompt="inspect the model",
+    ):
+        pass
+
+    spans = span_exporter.get_finished_spans()
+    agent_span = _spans_by_operation(spans, "invoke_agent")[0]
+    llm_span = _spans_by_operation(spans, "chat")[0]
+
+    assert (
+        agent_span.attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL]
+        == "claude-actual-model"
+    )
+    assert (
+        llm_span.attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL]
+        == "claude-actual-model"
+    )
+    assert llm_span.name == "chat claude-actual-model"
+
+
+@pytest.mark.asyncio
+async def test_system_message_model_fills_unknown_request_model(
+    tracer_provider, span_exporter
+):
+    handler = ExtendedTelemetryHandler(tracer_provider=tracer_provider)
+
+    async for _ in _process_agent_invocation_stream(
+        wrapped_stream=_stream(
+            [
+                SystemMessage(
+                    "sess-system-model", model="claude-system-model"
+                ),
+                AssistantMessage([TextBlock("answer")], model=""),
+                ResultMessage("sess-system-model"),
+            ]
+        ),
+        handler=handler,
+        model="unknown",
+        prompt="inspect the model",
+    ):
+        pass
+
+    spans = span_exporter.get_finished_spans()
+    agent_span = _spans_by_operation(spans, "invoke_agent")[0]
+    llm_span = _spans_by_operation(spans, "chat")[0]
+
+    assert (
+        agent_span.attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL]
+        == "claude-system-model"
+    )
+    assert (
+        llm_span.attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL]
+        == "claude-system-model"
+    )
+    assert llm_span.name == "chat claude-system-model"
+
+
+@pytest.mark.asyncio
+async def test_result_model_usage_fills_unknown_request_model_attribute(
+    tracer_provider, span_exporter
+):
+    handler = ExtendedTelemetryHandler(tracer_provider=tracer_provider)
+
+    async for _ in _process_agent_invocation_stream(
+        wrapped_stream=_stream(
+            [
+                AssistantMessage([TextBlock("answer")], model=""),
+                ResultMessage(
+                    "sess-result-model",
+                    model_usage={"claude-result-model": {}},
+                ),
+            ]
+        ),
+        handler=handler,
+        model="unknown",
+        prompt="inspect the model",
+    ):
+        pass
+
+    spans = span_exporter.get_finished_spans()
+    agent_span = _spans_by_operation(spans, "invoke_agent")[0]
+    llm_span = _spans_by_operation(spans, "chat")[0]
+
+    assert (
+        agent_span.attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL]
+        == "claude-result-model"
+    )
+    assert (
+        llm_span.attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL]
+        == "claude-result-model"
+    )
+
+
+@pytest.mark.asyncio
+async def test_result_model_usage_with_multiple_models_keeps_unknown_model(
+    tracer_provider, span_exporter
+):
+    handler = ExtendedTelemetryHandler(tracer_provider=tracer_provider)
+
+    async for _ in _process_agent_invocation_stream(
+        wrapped_stream=_stream(
+            [
+                AssistantMessage([TextBlock("answer")], model=""),
+                ResultMessage(
+                    "sess-multi-model",
+                    model_usage={"model-a": {}, "model-b": {}},
+                ),
+            ]
+        ),
+        handler=handler,
+        model="unknown",
+        prompt="ambiguous model usage should not be guessed",
+    ):
+        pass
+
+    spans = span_exporter.get_finished_spans()
+    agent_span = _spans_by_operation(spans, "invoke_agent")[0]
+    llm_span = _spans_by_operation(spans, "chat")[0]
+
+    assert (
+        agent_span.attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL]
+        == "unknown"
+    )
+    assert (
+        llm_span.attributes[GenAIAttributes.GEN_AI_REQUEST_MODEL] == "unknown"
+    )
+
+
+@pytest.mark.asyncio
+async def test_tool_use_without_text_does_not_create_synthetic_llm_span(
+    tracer_provider, span_exporter
+):
+    await _run_stream(
+        tracer_provider,
+        [
+            SystemMessage("sess-tool-only"),
+            AssistantMessage(
+                [ToolUseBlock("toolu_1", "Read", {"file_path": "README.md"})]
+            ),
+            AssistantMessage(
+                [ToolUseBlock("toolu_2", "Glob", {"pattern": "*.md"})]
+            ),
+            UserMessage(
+                [
+                    ToolResultBlock("toolu_1", "README content"),
+                    ToolResultBlock("toolu_2", "README.md"),
+                ]
+            ),
+            AssistantMessage([TextBlock("done")]),
+            ResultMessage("sess-tool-only"),
+        ],
+    )
+
+    spans = span_exporter.get_finished_spans()
+    agent_span = _spans_by_operation(spans, "invoke_agent")[0]
+    llm_spans = sorted(
+        _spans_by_operation(spans, "chat"), key=lambda span: span.start_time
+    )
+    tool_spans = sorted(
+        _spans_by_operation(spans, "execute_tool"),
+        key=lambda span: span.start_time,
+    )
+
+    assert len(llm_spans) == 1
+    assert len(tool_spans) == 2
+    assert all(
+        tool_span.parent.span_id == agent_span.context.span_id
+        for tool_span in tool_spans
+    )
+    assert llm_spans[0].parent.span_id == agent_span.context.span_id
+    assert tool_spans[-1].start_time < llm_spans[0].start_time
+    assert llm_spans[0].attributes[
+        GenAIAttributes.GEN_AI_RESPONSE_FINISH_REASONS
+    ] == ("stop",)
 
 
 @pytest.mark.asyncio
@@ -680,6 +894,104 @@ async def test_cancelled_stream_detaches_agent_context(
     assert cancelled_span.attributes["error.type"] == "CancelledError"
     assert after_span.parent is None
     assert after_span.context.trace_id != cancelled_span.context.trace_id
+
+
+@pytest.mark.asyncio
+async def test_stream_exception_after_llm_detaches_agent_context(
+    tracer_provider, span_exporter
+):
+    handler = ExtendedTelemetryHandler(tracer_provider=tracer_provider)
+
+    with pytest.raises(RuntimeError, match="stream exploded"):
+        async for _ in _process_agent_invocation_stream(
+            wrapped_stream=_failing_stream(
+                [
+                    SystemMessage("sess-error"),
+                    AssistantMessage([TextBlock("partial answer")]),
+                ],
+                RuntimeError("stream exploded"),
+            ),
+            handler=handler,
+            model="claude-sonnet",
+            prompt="this stream will fail after an LLM turn starts",
+        ):
+            pass
+
+    await _run_stream(
+        tracer_provider,
+        [
+            SystemMessage("sess-after-error"),
+            AssistantMessage([TextBlock("answer after error")]),
+            ResultMessage("sess-after-error"),
+        ],
+    )
+
+    agent_spans = _spans_by_operation(
+        span_exporter.get_finished_spans(), "invoke_agent"
+    )
+    failed_span = [
+        span
+        for span in agent_spans
+        if span.attributes.get(GEN_AI_SESSION_ID) == "sess-error"
+    ][0]
+    after_span = [
+        span
+        for span in agent_spans
+        if span.attributes.get(GEN_AI_SESSION_ID) == "sess-after-error"
+    ][0]
+
+    assert failed_span.attributes["error.type"] == "RuntimeError"
+    assert after_span.parent is None
+    assert after_span.context.trace_id != failed_span.context.trace_id
+
+
+@pytest.mark.asyncio
+async def test_stream_exception_restores_active_parent_context(
+    tracer_provider, span_exporter
+):
+    handler = ExtendedTelemetryHandler(tracer_provider=tracer_provider)
+    tracer = tracer_provider.get_tracer(__name__)
+
+    with tracer.start_as_current_span("caller-operation") as parent_span:
+        with pytest.raises(RuntimeError, match="stream exploded"):
+            async for _ in _process_agent_invocation_stream(
+                wrapped_stream=_failing_stream(
+                    [
+                        SystemMessage("sess-parent-error"),
+                        AssistantMessage([TextBlock("partial answer")]),
+                    ],
+                    RuntimeError("stream exploded"),
+                ),
+                handler=handler,
+                model="claude-sonnet",
+                prompt="this parented stream will fail",
+            ):
+                pass
+
+        await _run_stream(
+            tracer_provider,
+            [
+                SystemMessage("sess-parent-after-error"),
+                AssistantMessage([TextBlock("answer after parented error")]),
+                ResultMessage("sess-parent-after-error"),
+            ],
+        )
+
+    agent_spans = {
+        span.attributes[GEN_AI_SESSION_ID]: span
+        for span in _spans_by_operation(
+            span_exporter.get_finished_spans(), "invoke_agent"
+        )
+    }
+    failed_span = agent_spans["sess-parent-error"]
+    after_span = agent_spans["sess-parent-after-error"]
+
+    for span in (failed_span, after_span):
+        assert span.parent is not None
+        assert span.parent.span_id == parent_span.context.span_id
+        assert span.context.trace_id == parent_span.context.trace_id
+
+    assert after_span.parent.span_id != failed_span.context.span_id
 
 
 @pytest.mark.asyncio

--- a/instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/tests/test_session_capture.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/tests/test_session_capture.py
@@ -150,6 +150,22 @@ async def _run_stream(tracer_provider, messages, session_id=None):
         pass
 
 
+async def _read_until_result_without_exhausting(
+    handler, messages, session_id=None
+):
+    stream = _process_agent_invocation_stream(
+        wrapped_stream=_stream(messages),
+        handler=handler,
+        model="claude-sonnet",
+        prompt="inspect the project",
+        session_id=session_id,
+    )
+    while True:
+        message = await stream.__anext__()
+        if isinstance(message, ResultMessage):
+            return stream
+
+
 @pytest.mark.asyncio
 async def test_entry_baggage_session_overrides_claude_session(
     tracer_provider, span_exporter
@@ -461,6 +477,83 @@ async def test_wrap_query_preserves_active_parent_context(
     assert agent_span.parent.span_id == parent_span.context.span_id
     assert agent_span.context.trace_id == parent_span.context.trace_id
     assert agent_span.attributes[GEN_AI_SESSION_ID] == "parent-session"
+
+
+@pytest.mark.asyncio
+async def test_result_message_closes_agent_before_iterator_is_exhausted(
+    tracer_provider, span_exporter
+):
+    handler = ExtendedTelemetryHandler(tracer_provider=tracer_provider)
+    stream = await _read_until_result_without_exhausting(
+        handler,
+        [
+            SystemMessage("sess-terminal"),
+            AssistantMessage([TextBlock("terminal answer")]),
+            ResultMessage("sess-terminal"),
+        ],
+    )
+    try:
+        agent_spans = _spans_by_operation(
+            span_exporter.get_finished_spans(), "invoke_agent"
+        )
+        assert len(agent_spans) == 1
+        assert agent_spans[0].attributes[GEN_AI_SESSION_ID] == (
+            "sess-terminal"
+        )
+    finally:
+        await stream.aclose()
+
+
+@pytest.mark.asyncio
+async def test_consecutive_result_breaks_keep_outer_parent_context(
+    tracer_provider, span_exporter
+):
+    handler = ExtendedTelemetryHandler(tracer_provider=tracer_provider)
+    tracer = tracer_provider.get_tracer(__name__)
+    streams = []
+
+    try:
+        with tracer.start_as_current_span("caller-operation") as parent_span:
+            streams.append(
+                await _read_until_result_without_exhausting(
+                    handler,
+                    [
+                        SystemMessage("sess-first"),
+                        AssistantMessage([TextBlock("first answer")]),
+                        ResultMessage("sess-first"),
+                    ],
+                )
+            )
+            streams.append(
+                await _read_until_result_without_exhausting(
+                    handler,
+                    [
+                        SystemMessage("sess-second"),
+                        AssistantMessage([TextBlock("second answer")]),
+                        ResultMessage("sess-second"),
+                    ],
+                )
+            )
+    finally:
+        for stream in streams:
+            await stream.aclose()
+
+    agent_spans = {
+        span.attributes[GEN_AI_SESSION_ID]: span
+        for span in _spans_by_operation(
+            span_exporter.get_finished_spans(), "invoke_agent"
+        )
+    }
+
+    first_span = agent_spans["sess-first"]
+    second_span = agent_spans["sess-second"]
+
+    for span in (first_span, second_span):
+        assert span.parent is not None
+        assert span.parent.span_id == parent_span.context.span_id
+        assert span.context.trace_id == parent_span.context.trace_id
+
+    assert second_span.parent.span_id != first_span.context.span_id
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description

This PR fixes Claude Agent SDK stream span lifecycle and model attribution:

- close the agent span as soon as `ResultMessage` is received so a caller that stops consuming after the terminal message does not leak the previous agent context into the next query
- preserve the caller's active parent span instead of clearing OpenTelemetry context
- fill `gen_ai.request.model` from real SDK stream metadata when options/environment do not provide a model: `SystemMessage.data.model`, `AssistantMessage.model`, or a single `ResultMessage.model_usage` key
- keep `unknown` when no real model source exists or `ResultMessage.model_usage` is ambiguous
- fail open LLM spans when stream processing raises, and preserve tool-only assistant messages as TOOL spans without fabricating LLM spans

Fixes # (N/A)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] `python -m pytest instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/tests/test_session_capture.py -q`
- [x] `tox -c tox-loongsuite.ini -e py312-test-loongsuite-instrumentation-claude-agent-sdk-latest -- instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/tests/test_session_capture.py -q`
- [x] `tox -e precommit`
- [x] `weaver registry live-check -r /tmp/loongsuite-semantic-conventions/model --input-source <local spans-only sample> --input-format json --format json --no-stream true --advice-profile loongsuite-genai --skip-policies true`

## Validation Evidence

### Spec and Scope

- Linked issue/spec: N/A
- Approved spec/comment: local investigation of Claude Agent SDK stream context chaining and model attribution
- Changed surface: `loongsuite-instrumentation-claude-agent-sdk`

### Local Checks

| Check | Command | Result | Notes |
| --- | --- | --- | --- |
| Static readiness | LoongSuite PR readiness checker | pass | local pipeline checker exited 0 |
| Precommit | `tox -e precommit` | pass | fresh-cache run passed after ruff-format changes were applied |
| Focused tests | `python -m pytest instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/tests/test_session_capture.py -q` | pass | 24 passed |
| Plugin tests | `tox -c tox-loongsuite.ini -e py312-test-loongsuite-instrumentation-claude-agent-sdk-latest -- instrumentation-loongsuite/loongsuite-instrumentation-claude-agent-sdk/tests/test_session_capture.py -q` | pass | 108 passed, 9 skipped |
| Claude review | qoder deep review | pass | round 2 found 0 findings |
| Privacy scan | cassette/token/path scan for Claude Agent SDK cassettes | pass | no matches |

### Real E2E Matrix

| Scenario | Status | Command or Demo | Evidence |
| --- | --- | --- | --- |
| non-streaming | pass | focused in-memory stream tests and bounded live SDK smoke | model remains real when SDK emits it; otherwise remains `unknown` |
| streaming | pass | focused stream lifecycle tests | `ResultMessage` closes the agent before iterator exhaustion |
| concurrency | pass | focused parallel stream test | session ids and parent context remain isolated |
| agent/tool/ReAct | pass | focused tool-call stream test and bounded live SDK smoke | AGENT/LLM/TOOL spans keep valid parent-child links |
| tool-heavy | pass | focused two-tool stream test | tool-only assistant messages do not create synthetic LLM spans |
| error path | pass | focused failing-stream tests | open LLM span is failed and parent context is restored |

### Telemetry and Weaver

| Check | Status | Command or Artifact | Notes |
| --- | --- | --- | --- |
| Span tree / span kinds | pass | focused in-memory exporter sample plus cloud readback smoke | AGENT, LLM, TOOL tree validated locally; private cloud trace details kept out of PR body |
| Content capture modes | pass | focused tests with `SPAN_ONLY` | content attributes are present in test spans |
| Concurrency isolation | pass | focused parallel stream test | no cross-call parent chaining |
| Weaver live-check | pass | `weaver registry live-check -r /tmp/loongsuite-semantic-conventions/model --input-source <local spans-only sample> --input-format json --format json --no-stream true --advice-profile loongsuite-genai --skip-policies true` | exit 0; no violations |

### CI

- GitHub checks: pending until PR is opened
- Known unrelated failures: none known
- Follow-up needed: monitor CI after PR creation

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR:
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
