### PR TITLE
feat: capture skill metadata for Agno and Google ADK

### DIFF
--- a/.github/workflows/generate_workflows.py
+++ b/.github/workflows/generate_workflows.py
@@ -25,5 +25,9 @@ generate_lint_workflow(
     batch_size=4,
     parallelism=4,
 )
-generate_misc_workflow(tox_ini_path, workflows_directory_path)
+generate_misc_workflow(
+    tox_ini_path,
+    workflows_directory_path,
+    runner=arc_runner_label,
+)
 generate_contrib_workflow(workflows_directory_path)

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/__init__.py
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/__init__.py
@@ -356,11 +356,13 @@ def generate_contrib_workflow(
 def generate_misc_workflow(
     tox_ini_path: Path,
     workflow_directory_path: Path,
+    runner="ubuntu-latest",
 ) -> None:
     _generate_workflow(
         get_misc_job_datas(get_tox_envs(tox_ini_path)),
         "misc",
         workflow_directory_path,
+        runner=runner,
     )
 
 
@@ -445,6 +447,7 @@ def generate_extension_misc_workflow(
     tox_ini_path: Path,
     workflow_directory_path: Path,
     additional_config_path: Path,
+    runner="ubuntu-latest",
 ) -> None:
     loongsuite_envs = get_loongsuite_tox_envs(additional_config_path)
     if not loongsuite_envs:
@@ -455,6 +458,7 @@ def generate_extension_misc_workflow(
         "loongsuite_misc",
         "loongsuite_misc",
         workflow_directory_path,
+        runner=runner,
     )
 
 

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/loongsuite_misc.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/loongsuite_misc.yml.j2
@@ -36,7 +36,7 @@ jobs:
 
   {{ job_data }}:
     name: LoongSuite {{ job_data }}
-    runs-on: ubuntu-latest
+    runs-on: {{ runner }}
     timeout-minutes: 30
     {%- if job_data == "generate-workflows" %}
     if: |

--- a/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/misc.yml.j2
+++ b/.github/workflows/generate_workflows_lib/src/generate_workflows_lib/misc.yml.j2
@@ -5,9 +5,8 @@ name: Misc {{ file_number }}
 
 on:
   push:
-    branches-ignore:
-    - 'release/*'
-    - 'otelbot/*'
+    branches:
+    - main
   pull_request:
 
 permissions:
@@ -36,7 +35,7 @@ jobs:
 
   {{ job_data }}:
     name: {{ job_data }}
-    runs-on: ubuntu-latest
+    runs-on: {{ "ubuntu-latest" if job_data == "docker-tests" else runner }}
     timeout-minutes: 30
     {%- if job_data == "generate-workflows" %}
     if: |

--- a/.github/workflows/generate_workflows_loongsuite.py
+++ b/.github/workflows/generate_workflows_loongsuite.py
@@ -29,5 +29,8 @@ generate_extension_lint_workflow(
     control_runner=arc_runner_label,
 )
 generate_extension_misc_workflow(
-    tox_ini_path, workflows_directory_path, tox_loongsuite_ini_path
+    tox_ini_path,
+    workflows_directory_path,
+    tox_loongsuite_ini_path,
+    runner=arc_runner_label,
 )

--- a/.github/workflows/loongsuite_misc_0.yml
+++ b/.github/workflows/loongsuite_misc_0.yml
@@ -35,7 +35,7 @@ jobs:
 
   check-license-header:
     name: LoongSuite check-license-header
-    runs-on: ubuntu-latest
+    runs-on: loongsuite-python-arc
     timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
@@ -54,7 +54,7 @@ jobs:
 
   generate-loongsuite:
     name: LoongSuite generate-loongsuite
-    runs-on: ubuntu-latest
+    runs-on: loongsuite-python-arc
     timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}

--- a/.github/workflows/misc_0.yml
+++ b/.github/workflows/misc_0.yml
@@ -5,9 +5,8 @@ name: Misc 0
 
 on:
   push:
-    branches-ignore:
-    - 'release/*'
-    - 'otelbot/*'
+    branches:
+    - main
   pull_request:
 
 permissions:
@@ -35,7 +34,7 @@ jobs:
 
   spellcheck:
     name: spellcheck
-    runs-on: ubuntu-latest
+    runs-on: loongsuite-python-arc
     timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
@@ -73,7 +72,7 @@ jobs:
 
   docs:
     name: docs
-    runs-on: ubuntu-latest
+    runs-on: loongsuite-python-arc
     timeout-minutes: 30
     if: |
       github.event.pull_request.user.login != 'otelbot[bot]' && github.event_name == 'pull_request'
@@ -94,7 +93,7 @@ jobs:
 
   generate:
     name: generate
-    runs-on: ubuntu-latest
+    runs-on: loongsuite-python-arc
     timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
@@ -116,7 +115,7 @@ jobs:
 
   generate-workflows:
     name: generate-workflows
-    runs-on: ubuntu-latest
+    runs-on: loongsuite-python-arc
     timeout-minutes: 30
     if: |
       !contains(github.event.pull_request.labels.*.name, 'Skip generate-workflows')
@@ -141,7 +140,7 @@ jobs:
 
   shellcheck:
     name: shellcheck
-    runs-on: ubuntu-latest
+    runs-on: loongsuite-python-arc
     timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
@@ -160,7 +159,7 @@ jobs:
 
   precommit:
     name: precommit
-    runs-on: ubuntu-latest
+    runs-on: loongsuite-python-arc
     timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}
@@ -179,7 +178,7 @@ jobs:
 
   typecheck:
     name: typecheck
-    runs-on: ubuntu-latest
+    runs-on: loongsuite-python-arc
     timeout-minutes: 30
     steps:
       - name: Checkout repo @ SHA - ${{ github.sha }}

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agno/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agno/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Capture `gen_ai.skill.*` attributes on Agno skill tool spans such as
+  `get_skill_instructions`, `get_skill_reference`, and `get_skill_script`.
+
 ## Version 0.7.0 (2026-07-03)
 
 ### Removed

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agno/src/opentelemetry/instrumentation/agno/utils.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agno/src/opentelemetry/instrumentation/agno/utils.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import asdict, is_dataclass
-from typing import Any, Mapping, Sequence
+from typing import Any, Dict, Mapping, Optional, Sequence
 
 from opentelemetry.util.genai.extended_semconv.gen_ai_extended_attributes import (
     GEN_AI_SESSION_ID,
@@ -87,7 +87,7 @@ def _to_dict(value: Any) -> dict[str, Any] | None:
     return None
 
 
-def _mapping_from_any(value: Any) -> dict[str, Any]:
+def _mapping_from_any(value: Any) -> Dict[str, Any]:
     data = _to_dict(value)
     if data is not None:
         return data
@@ -100,7 +100,7 @@ def _mapping_from_any(value: Any) -> dict[str, Any]:
     return {}
 
 
-def _first_text(*values: Any) -> str | None:
+def _first_text(*values: Any) -> Optional[str]:
     for value in values:
         if value is None:
             continue
@@ -110,7 +110,7 @@ def _first_text(*values: Any) -> str | None:
     return None
 
 
-def _extract_skill_metadata(value: Any) -> dict[str, Any]:
+def _extract_skill_metadata(value: Any) -> Dict[str, Any]:
     data = _mapping_from_any(value)
     if not data:
         return {}

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agno/src/opentelemetry/instrumentation/agno/utils.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agno/src/opentelemetry/instrumentation/agno/utils.py
@@ -39,6 +39,11 @@ from opentelemetry.util.genai.types import (
 )
 
 _PROVIDER = "agno"
+_SKILL_TOOL_NAMES = {
+    "get_skill_instructions",
+    "get_skill_reference",
+    "get_skill_script",
+}
 
 
 def _json_default(value: Any) -> Any:
@@ -80,6 +85,95 @@ def _to_dict(value: Any) -> dict[str, Any] | None:
         except Exception:
             return None
     return None
+
+
+def _mapping_from_any(value: Any) -> dict[str, Any]:
+    data = _to_dict(value)
+    if data is not None:
+        return data
+    if isinstance(value, str):
+        try:
+            loaded = json.loads(value)
+        except Exception:
+            return {}
+        return loaded if isinstance(loaded, dict) else {}
+    return {}
+
+
+def _first_text(*values: Any) -> str | None:
+    for value in values:
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return None
+
+
+def _extract_skill_metadata(value: Any) -> dict[str, Any]:
+    data = _mapping_from_any(value)
+    if not data:
+        return {}
+    frontmatter = _mapping_from_any(data.get("frontmatter"))
+    metadata = _mapping_from_any(data.get("metadata")) or _mapping_from_any(
+        frontmatter.get("metadata")
+    )
+    return {
+        "name": _first_text(
+            data.get("skill_name"),
+            data.get("skill"),
+            data.get("name"),
+            frontmatter.get("name"),
+        ),
+        "id": _first_text(
+            data.get("skill_id"),
+            data.get("id"),
+            metadata.get("id"),
+        ),
+        "description": _first_text(
+            data.get("skill_description"),
+            data.get("description"),
+            frontmatter.get("description"),
+        ),
+        "version": _first_text(
+            data.get("skill_version"),
+            data.get("version"),
+            metadata.get("version"),
+        ),
+    }
+
+
+def _apply_skill_metadata(
+    invocation: ExecuteToolInvocation, metadata: Mapping[str, Any]
+) -> None:
+    name = _first_text(metadata.get("name"))
+    if name:
+        invocation.skill_name = invocation.skill_name or name
+        invocation.skill_id = (
+            invocation.skill_id or _first_text(metadata.get("id")) or name
+        )
+    elif metadata.get("id"):
+        invocation.skill_id = invocation.skill_id or _first_text(
+            metadata.get("id")
+        )
+
+    description = _first_text(metadata.get("description"))
+    if description:
+        invocation.skill_description = (
+            invocation.skill_description or description
+        )
+
+    version = _first_text(metadata.get("version"))
+    if version:
+        invocation.skill_version = invocation.skill_version or version
+
+
+def _apply_agno_skill_tool_metadata(
+    invocation: ExecuteToolInvocation, data: Any
+) -> None:
+    if invocation.tool_name not in _SKILL_TOOL_NAMES:
+        return
+    _apply_skill_metadata(invocation, _extract_skill_metadata(data))
 
 
 def _get_value(value: Any, name: str, default: Any = None) -> Any:
@@ -555,7 +649,7 @@ def update_llm_invocation_from_response(
 
 def create_tool_invocation(function_call: Any) -> ExecuteToolInvocation:
     function = getattr(function_call, "function", None)
-    return ExecuteToolInvocation(
+    invocation = ExecuteToolInvocation(
         tool_name=getattr(function, "name", None) or "unknown_tool",
         provider=_PROVIDER,
         tool_call_id=getattr(function_call, "call_id", None),
@@ -563,6 +657,8 @@ def create_tool_invocation(function_call: Any) -> ExecuteToolInvocation:
         tool_type="function",
         tool_call_arguments=getattr(function_call, "arguments", None),
     )
+    _apply_agno_skill_tool_metadata(invocation, invocation.tool_call_arguments)
+    return invocation
 
 
 def update_tool_invocation_from_response(
@@ -572,3 +668,4 @@ def update_tool_invocation_from_response(
     invocation.tool_call_result = (
         result if isinstance(result, str) else _stringify(result)
     )
+    _apply_agno_skill_tool_metadata(invocation, result)

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agno/tests/test_agno.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agno/tests/test_agno.py
@@ -254,6 +254,36 @@ def test_agno_skill_tool_invocation_captures_skill_attributes():
     assert invocation.skill_version == "1.2.3"
 
 
+def test_agno_non_skill_tool_invocation_ignores_skill_like_payload():
+    fn = Function.from_callable(lambda skill_name: f"loaded {skill_name}")
+    fn.name = "get_weather"
+    function_call = FunctionCall(
+        function=fn,
+        arguments={"skill_name": "code-review"},
+        call_id="call_regular_1",
+    )
+
+    invocation = create_tool_invocation(function_call)
+    update_tool_invocation_from_response(
+        invocation,
+        SimpleNamespace(
+            result={
+                "skill_name": "code-review",
+                "frontmatter": {
+                    "description": "Review code for quality and security.",
+                    "metadata": {"version": "1.2.3"},
+                },
+            }
+        ),
+    )
+
+    assert invocation.tool_name == "get_weather"
+    assert invocation.skill_name is None
+    assert invocation.skill_id is None
+    assert invocation.skill_description is None
+    assert invocation.skill_version is None
+
+
 def test_streaming_agent_finishes_agent_and_model_spans(
     span_exporter: InMemorySpanExporter,
 ):

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agno/tests/test_agno.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agno/tests/test_agno.py
@@ -37,8 +37,10 @@ from opentelemetry.instrumentation.agno.utils import (
     convert_agent_input,
     create_agent_invocation,
     create_llm_invocation,
+    create_tool_invocation,
     update_agent_invocation_from_response,
     update_llm_invocation_from_response,
+    update_tool_invocation_from_response,
 )
 from opentelemetry.sdk.trace import Resource, TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -213,6 +215,43 @@ def test_agent_model_and_tool_spans_use_genai_util(
     assert tool_attrs["gen_ai.tool.call.id"] == "call_1"
     assert "Hangzhou" in tool_attrs["gen_ai.tool.call.arguments"]
     assert "sunny in Hangzhou" in tool_attrs["gen_ai.tool.call.result"]
+
+
+def test_agno_skill_tool_invocation_captures_skill_attributes():
+    fn = Function.from_callable(lambda skill_name: f"loaded {skill_name}")
+    fn.name = "get_skill_instructions"
+    fn.description = "Load full instructions for a skill."
+    function_call = FunctionCall(
+        function=fn,
+        arguments={"skill_name": "code-review"},
+        call_id="call_skill_1",
+    )
+
+    invocation = create_tool_invocation(function_call)
+
+    assert invocation.tool_name == "get_skill_instructions"
+    assert invocation.skill_name == "code-review"
+    assert invocation.skill_id == "code-review"
+
+    update_tool_invocation_from_response(
+        invocation,
+        SimpleNamespace(
+            result={
+                "skill_name": "code-review",
+                "frontmatter": {
+                    "description": "Review code for quality and security.",
+                    "metadata": {"version": "1.2.3"},
+                },
+            }
+        ),
+    )
+
+    assert invocation.skill_name == "code-review"
+    assert invocation.skill_id == "code-review"
+    assert (
+        invocation.skill_description == "Review code for quality and security."
+    )
+    assert invocation.skill_version == "1.2.3"
 
 
 def test_streaming_agent_finishes_agent_and_model_spans(

--- a/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Capture `gen_ai.skill.*` attributes on Google ADK SkillToolset
+  `load_skill` and `load_skill_resource` execute-tool spans.
+
 ## Version 0.7.0 (2026-07-03)
 
 There are no changelog entries for this release.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/src/opentelemetry/instrumentation/google_adk/internal/_plugin.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/src/opentelemetry/instrumentation/google_adk/internal/_plugin.py
@@ -26,7 +26,7 @@ import logging
 import timeit
 from contextvars import ContextVar, Token
 from dataclasses import asdict, is_dataclass
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 from google.adk.agents.base_agent import BaseAgent
 from google.adk.agents.callback_context import CallbackContext
@@ -62,7 +62,7 @@ _ACTIVE_LLM_REQUEST_KEY: ContextVar[Optional[str]] = ContextVar(
 _SKILL_LOAD_TOOL_NAMES = {"load_skill", "load_skill_resource"}
 
 
-def _mapping_from_any(value: Any) -> dict[str, Any]:
+def _mapping_from_any(value: Any) -> Dict[str, Any]:
     if value is None:
         return {}
     if isinstance(value, Mapping):
@@ -88,7 +88,7 @@ def _mapping_from_any(value: Any) -> dict[str, Any]:
     return {}
 
 
-def _first_text(*values: Any) -> str | None:
+def _first_text(*values: Any) -> Optional[str]:
     for value in values:
         if value is None:
             continue
@@ -98,7 +98,7 @@ def _first_text(*values: Any) -> str | None:
     return None
 
 
-def _extract_skill_metadata(value: Any) -> dict[str, Any]:
+def _extract_skill_metadata(value: Any) -> Dict[str, Any]:
     data = _mapping_from_any(value)
     if not data:
         return {}
@@ -602,7 +602,7 @@ class GoogleAdkObservabilityPlugin(BasePlugin):
         self,
         *,
         tool: BaseTool,
-        tool_args: dict[str, Any],
+        tool_args: Dict[str, Any],
         tool_context: ToolContext,
     ) -> None:
         """
@@ -646,9 +646,9 @@ class GoogleAdkObservabilityPlugin(BasePlugin):
         self,
         *,
         tool: BaseTool,
-        tool_args: dict[str, Any],
+        tool_args: Dict[str, Any],
         tool_context: ToolContext,
-        result: dict,
+        result: Dict[str, Any],
     ) -> None:
         """
         End Tool execution - finish execute_tool span.
@@ -674,7 +674,7 @@ class GoogleAdkObservabilityPlugin(BasePlugin):
         self,
         *,
         tool: BaseTool,
-        tool_args: dict[str, Any],
+        tool_args: Dict[str, Any],
         tool_context: ToolContext,
         error: Exception,
     ) -> Optional[dict]:
@@ -832,7 +832,7 @@ class GoogleAdkObservabilityPlugin(BasePlugin):
     def _tool_key(
         self,
         tool: BaseTool,
-        tool_args: dict[str, Any],
+        tool_args: Dict[str, Any],
         tool_context: ToolContext,
     ) -> str:
         invocation_context = getattr(tool_context, "_invocation_context", None)
@@ -848,7 +848,7 @@ class GoogleAdkObservabilityPlugin(BasePlugin):
         self,
         callback_context: CallbackContext,
         llm_request: Optional[LlmRequest] = None,
-    ) -> tuple[Optional[str], Optional[LLMInvocation]]:
+    ) -> Tuple[Optional[str], Optional[LLMInvocation]]:
         context_request_key = _ACTIVE_LLM_REQUEST_KEY.get()
         if context_request_key:
             invocation = self._active_llm_invocations.get(context_request_key)
@@ -915,7 +915,7 @@ class GoogleAdkObservabilityPlugin(BasePlugin):
 
     @staticmethod
     def _mock_has_explicit_attrs(
-        value: Any, attr_names: tuple[str, ...]
+        value: Any, attr_names: Tuple[str, ...]
     ) -> bool:
         value_dict = getattr(value, "__dict__", {})
         return any(attr_name in value_dict for attr_name in attr_names)

--- a/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/src/opentelemetry/instrumentation/google_adk/internal/_plugin.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/src/opentelemetry/instrumentation/google_adk/internal/_plugin.py
@@ -25,7 +25,8 @@ for standard span and metrics management.
 import logging
 import timeit
 from contextvars import ContextVar, Token
-from typing import Any, Dict, List, Optional
+from dataclasses import asdict, is_dataclass
+from typing import Any, Dict, List, Mapping, Optional
 
 from google.adk.agents.base_agent import BaseAgent
 from google.adk.agents.callback_context import CallbackContext
@@ -58,6 +59,109 @@ _logger = logging.getLogger(__name__)
 _ACTIVE_LLM_REQUEST_KEY: ContextVar[Optional[str]] = ContextVar(
     "google_adk_active_llm_request_key", default=None
 )
+_SKILL_LOAD_TOOL_NAMES = {"load_skill", "load_skill_resource"}
+
+
+def _mapping_from_any(value: Any) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if isinstance(value, Mapping):
+        return dict(value)
+    model_dump = getattr(value, "model_dump", None)
+    if callable(model_dump):
+        try:
+            data = model_dump(mode="json")
+        except TypeError:
+            try:
+                data = model_dump()
+            except Exception:
+                return {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+    if is_dataclass(value):
+        try:
+            data = asdict(value)
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+    return {}
+
+
+def _first_text(*values: Any) -> str | None:
+    for value in values:
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return None
+
+
+def _extract_skill_metadata(value: Any) -> dict[str, Any]:
+    data = _mapping_from_any(value)
+    if not data:
+        return {}
+    frontmatter = _mapping_from_any(data.get("frontmatter"))
+    metadata = _mapping_from_any(data.get("metadata")) or _mapping_from_any(
+        frontmatter.get("metadata")
+    )
+    return {
+        "name": _first_text(
+            data.get("skill_name"),
+            data.get("skill"),
+            data.get("name"),
+            frontmatter.get("name"),
+        ),
+        "id": _first_text(
+            data.get("skill_id"),
+            data.get("id"),
+            metadata.get("id"),
+        ),
+        "description": _first_text(
+            data.get("skill_description"),
+            data.get("description"),
+            frontmatter.get("description"),
+        ),
+        "version": _first_text(
+            data.get("skill_version"),
+            data.get("version"),
+            metadata.get("version"),
+        ),
+    }
+
+
+def _apply_skill_metadata(
+    invocation: ExecuteToolInvocation, metadata: Mapping[str, Any]
+) -> None:
+    name = _first_text(metadata.get("name"))
+    if name:
+        invocation.skill_name = invocation.skill_name or name
+        invocation.skill_id = (
+            invocation.skill_id or _first_text(metadata.get("id")) or name
+        )
+    elif metadata.get("id"):
+        invocation.skill_id = invocation.skill_id or _first_text(
+            metadata.get("id")
+        )
+
+    description = _first_text(metadata.get("description"))
+    if description:
+        invocation.skill_description = (
+            invocation.skill_description or description
+        )
+
+    version = _first_text(metadata.get("version"))
+    if version:
+        invocation.skill_version = invocation.skill_version or version
+
+
+def _apply_adk_skill_tool_metadata(
+    invocation: ExecuteToolInvocation, data: Any
+) -> None:
+    if invocation.tool_name not in _SKILL_LOAD_TOOL_NAMES:
+        return
+    _apply_skill_metadata(invocation, _extract_skill_metadata(data))
 
 
 class GoogleAdkObservabilityPlugin(BasePlugin):
@@ -524,6 +628,8 @@ class GoogleAdkObservabilityPlugin(BasePlugin):
             if tool_args:
                 invocation.tool_call_arguments = tool_args
 
+            _apply_adk_skill_tool_metadata(invocation, tool_args)
+
             # Start invocation (creates span)
             self._handler.start_execute_tool(invocation)
 
@@ -555,6 +661,7 @@ class GoogleAdkObservabilityPlugin(BasePlugin):
                 # Set tool result (content capture is controlled by the util layer)
                 if result:
                     invocation.tool_call_result = result
+                    _apply_adk_skill_tool_metadata(invocation, result)
 
                 # Stop invocation (ends span and records metrics automatically)
                 self._handler.stop_execute_tool(invocation)

--- a/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/tests/test_plugin_integration.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/tests/test_plugin_integration.py
@@ -440,7 +440,11 @@ class TestGoogleAdkPluginIntegration:
         mock_tool_args = {"operation": "add", "a": 5, "b": 3}
         mock_tool_context = Mock()
         mock_tool_context.session_id = "session_456"
-        mock_result = {"result": 8}
+        mock_result = {
+            "result": 8,
+            "skill_name": "should-not-be-captured",
+            "frontmatter": {"description": "Not a skill load tool."},
+        }
 
         # Execute Tool span lifecycle
         await plugin.before_tool_callback(
@@ -489,6 +493,9 @@ class TestGoogleAdkPluginIntegration:
             attributes.get("gen_ai.tool.description")
             == "Mathematical calculator"
         )
+        assert "gen_ai.skill.name" not in attributes
+        assert "gen_ai.skill.id" not in attributes
+        assert "gen_ai.skill.description" not in attributes
 
     @pytest.mark.asyncio
     async def test_skill_load_tool_span_captures_skill_attributes(self):

--- a/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/tests/test_plugin_integration.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-google-adk/tests/test_plugin_integration.py
@@ -491,6 +491,59 @@ class TestGoogleAdkPluginIntegration:
         )
 
     @pytest.mark.asyncio
+    async def test_skill_load_tool_span_captures_skill_attributes(self):
+        """ADK SkillToolset load_skill spans should include skill metadata."""
+        self.instrumentor.instrument(
+            tracer_provider=self.tracer_provider,
+            meter_provider=self.meter_provider,
+        )
+
+        plugin = self.instrumentor._plugin
+
+        mock_tool = Mock()
+        mock_tool.name = "load_skill"
+        mock_tool.description = "Load full instructions for a skill."
+        tool_args = {"name": "weather-skill"}
+        mock_tool_context = Mock()
+        mock_tool_context.call_id = "skill_call_1"
+        mock_tool_context.invocation_id = "skill_invocation"
+        mock_result = {
+            "skill_name": "weather-skill",
+            "frontmatter": {
+                "description": "Weather workflow instructions.",
+                "metadata": {"version": "1.2.3"},
+            },
+            "instructions": "Use the weather references.",
+        }
+
+        await plugin.before_tool_callback(
+            tool=mock_tool,
+            tool_args=tool_args,
+            tool_context=mock_tool_context,
+        )
+        await plugin.after_tool_callback(
+            tool=mock_tool,
+            tool_args=tool_args,
+            tool_context=mock_tool_context,
+            result=mock_result,
+        )
+
+        spans = self.span_exporter.get_finished_spans()
+        assert len(spans) == 1
+        span = spans[0]
+        attrs = span.attributes
+
+        assert span.name == "execute_tool load_skill"
+        assert attrs.get("gen_ai.tool.name") == "load_skill"
+        assert attrs.get("gen_ai.skill.name") == "weather-skill"
+        assert attrs.get("gen_ai.skill.id") == "weather-skill"
+        assert (
+            attrs.get("gen_ai.skill.description")
+            == "Weather workflow instructions."
+        )
+        assert attrs.get("gen_ai.skill.version") == "1.2.3"
+
+    @pytest.mark.asyncio
     async def test_runner_span_attributes(self):
         """Test Runner span creation and attributes."""
         # Instrument

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/tests/requirements.latest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/tests/requirements.latest.txt
@@ -15,7 +15,7 @@
 # This variant of the requirements aims to test the system using
 # the latest supported QwenPaw runtime.
 
-qwenpaw==1.1.4.post2
+qwenpaw==1.1.12.post3
 pytest
 pytest-asyncio
 wrapt<2.0.0


### PR DESCRIPTION
# Description

This PR captures `gen_ai.skill.*` attributes for skill-loading tool spans in the
Agno and Google ADK LoongSuite integrations.

Agno skill tools such as `get_skill_instructions`, `get_skill_reference`, and
`get_skill_script` now populate skill metadata from tool arguments and returned
skill metadata. Google ADK SkillToolset tools such as `load_skill` and
`load_skill_resource` now apply the same enrichment from tool arguments and
results.

Fixes # (N/A)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] `$PIPELINE_SKILL_DIR/scripts/check_loongsuite_pr_readiness.py --repo .`
- [x] `PRE_COMMIT_HOME="$(mktemp -d /tmp/loongsuite-precommit.XXXXXX)" tox -e precommit`
- [x] `tox -c tox-loongsuite.ini -e py312-test-loongsuite-instrumentation-agno,py312-test-loongsuite-instrumentation-google-adk-latest,py312-test-loongsuite-instrumentation-google-adk-oldest`
- [x] `tox -c tox-loongsuite.ini -e lint-loongsuite-instrumentation-agno,lint-loongsuite-instrumentation-google-adk`
- [x] `AGNO_SMOKE_MODE=non_stream python instrumentation-loongsuite/loongsuite-instrumentation-agno/examples/agno_dashscope_smoke.py`
- [x] `AGNO_SMOKE_MODE=stream python instrumentation-loongsuite/loongsuite-instrumentation-agno/examples/agno_dashscope_smoke.py`
- [x] `AGNO_SMOKE_MODE=concurrent python instrumentation-loongsuite/loongsuite-instrumentation-agno/examples/agno_dashscope_smoke.py`
- [x] `python instrumentation-loongsuite/loongsuite-instrumentation-google-adk/examples/otelgui_smoke.py --scenario non-stream`
- [x] `python instrumentation-loongsuite/loongsuite-instrumentation-google-adk/examples/otelgui_smoke.py --scenario stream`
- [x] `python instrumentation-loongsuite/loongsuite-instrumentation-google-adk/examples/otelgui_smoke.py --scenario concurrent --concurrent-count 2`
- [x] `weaver registry live-check -r <loongsuite-semantic-conventions>/model --input-source stdin --input-format json --format json --no-stream true --advice-profile loongsuite-genai --skip-policies true`

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR:
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated

## Validation Evidence

### Spec and Scope
- Linked issue/spec: N/A; direct feature request to support skill-load telemetry in additional skill-capable frameworks.
- Approved spec/comment: User requested PR submission for the implemented skill-load support.
- Changed surface: `loongsuite-instrumentation-agno` and `loongsuite-instrumentation-google-adk`.

### Local Checks
| Check | Command | Result | Notes |
| --- | --- | --- | --- |
| Static readiness | `$PIPELINE_SKILL_DIR/scripts/check_loongsuite_pr_readiness.py --repo .` | pass | LoongSuite static PR readiness checks passed. |
| Change detector | `LOONGSUITE_CHANGED_FILES="$(git diff --name-only origin/main...HEAD)" GITHUB_EVENT_NAME=pull_request python .github/scripts/detect_loongsuite_changes.py` | pass | `full=false`; packages are `loongsuite-instrumentation-agno` and `loongsuite-instrumentation-google-adk`. |
| Precommit | `PRE_COMMIT_HOME="$(mktemp -d /tmp/loongsuite-precommit.XXXXXX)" tox -e precommit` | pass | `ruff`, `ruff format`, `uv-lock`, and `rstcheck` passed. |
| Focused tests | `tox -c tox-loongsuite.ini -e py312-test-loongsuite-instrumentation-agno,py312-test-loongsuite-instrumentation-google-adk-latest,py312-test-loongsuite-instrumentation-google-adk-oldest` | pass | Agno: 21 passed. Google ADK latest/oldest: 23 passed each. |
| Focused lint | `tox -c tox-loongsuite.ini -e lint-loongsuite-instrumentation-agno,lint-loongsuite-instrumentation-google-adk` | pass | Ruff passed for both changed plugins. |
| External AI review | N/A | blocked | Not run in this submission environment. |
| Privacy scan | `git diff --name-only origin/main...HEAD \| xargs rg --pcre2 <secret-and-local-path-pattern> -S` | pass | No matches in changed files; no cassettes changed. |

### Real E2E Matrix
| Scenario | Status | Command or Demo | Evidence |
| --- | --- | --- | --- |
| non-streaming | pass | Agno and Google ADK DashScope smoke commands listed above | Both returned concise weather responses without errors. |
| streaming | pass | Agno `AGNO_SMOKE_MODE=stream`; Google ADK `--scenario stream` | Both streaming paths completed without errors. |
| concurrency | pass | Agno `AGNO_SMOKE_MODE=concurrent`; Google ADK `--scenario concurrent --concurrent-count 2` | Agno returned three concurrent responses; Google ADK returned two concurrent responses. |
| agent/tool/ReAct | pass | Focused pytest plus DashScope smoke with deterministic weather tools | Tool execution path is covered; this PR only changes skill-load tool metadata enrichment. |
| tool-heavy | N/A | N/A | This PR does not change multi-tool selection or tool ordering behavior. |
| error path | N/A | N/A | This PR does not change exception handling; existing tool failure tests are unchanged and passed in the Agno focused suite. |

### Telemetry and Weaver
| Check | Status | Command or Artifact | Notes |
| --- | --- | --- | --- |
| Span tree / span kinds | pass | Focused Agno and Google ADK tests | Skill load tool spans remain `execute_tool ...` TOOL spans. |
| Skill attributes | pass | Focused Agno and Google ADK tests | Validated `gen_ai.skill.name`, `gen_ai.skill.id`, `gen_ai.skill.description`, and `gen_ai.skill.version`. |
| Content capture modes | pass | Existing focused Agno content-capture tests | Existing NO_CONTENT/content-capture behavior remains covered by the focused suite. |
| Concurrency isolation | pass | Agno focused test plus live concurrency smokes | Agno concurrent span test passed; live concurrency smokes completed for both frameworks. |
| Weaver live-check | pass | `weaver registry live-check -r <loongsuite-semantic-conventions>/model --input-source stdin --input-format json --format json --no-stream true --advice-profile loongsuite-genai --skip-policies true` | Representative TOOL span with `gen_ai.skill.*` passed with no violations; only development-stability improvement advice was emitted. |

### CI
- GitHub checks: Pending; PR has not been opened yet.
- Known unrelated failures: None known.
- Follow-up needed: Inspect GitHub checks after PR creation.
