### PR TITLE
fix(agno): propagate run identity to child spans

### DIFF
--- a/instrumentation-loongsuite/loongsuite-instrumentation-agno/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agno/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- Propagate Agno run user and session identity to model and tool spans while
+  preferring ENTRY baggage identity over Agno framework-provided values.
+
 ### Added
 
 - Capture `gen_ai.skill.*` attributes on Agno skill tool spans such as

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agno/src/opentelemetry/instrumentation/agno/_wrapper.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agno/src/opentelemetry/instrumentation/agno/_wrapper.py
@@ -28,6 +28,8 @@ from .utils import (
     create_agent_invocation,
     create_llm_invocation,
     create_tool_invocation,
+    reset_current_agno_run_identity,
+    set_current_agno_run_identity,
     update_agent_invocation_from_events,
     update_agent_invocation_from_response,
     update_llm_invocation_from_response,
@@ -113,6 +115,7 @@ class AgnoAgentWrapper:
         self._handler.start_invoke_agent(
             invocation, context=otel_context.get_current()
         )
+        identity_token = set_current_agno_run_identity(invocation.attributes)
         try:
             response = wrapped(*args, **kwargs)
             update_agent_invocation_from_response(invocation, response)
@@ -125,6 +128,8 @@ class AgnoAgentWrapper:
                 _error(exc),
             )
             raise
+        finally:
+            reset_current_agno_run_identity(identity_token)
 
     def _run_stream(
         self,
@@ -144,6 +149,21 @@ class AgnoAgentWrapper:
             self._handler.start_invoke_agent(
                 invocation, context=parent_context
             )
+            identity_token = None
+
+            def enter_identity() -> None:
+                nonlocal identity_token
+                identity_token = set_current_agno_run_identity(
+                    invocation.attributes
+                )
+
+            def exit_identity() -> None:
+                nonlocal identity_token
+                if identity_token is not None:
+                    reset_current_agno_run_identity(identity_token)
+                    identity_token = None
+
+            enter_identity()
             try:
                 stream = wrapped(*args, **kwargs)
                 for event in stream:
@@ -152,7 +172,13 @@ class AgnoAgentWrapper:
                             timeit.default_timer()
                         )
                     events.append(event)
-                    yield event
+                    # Do not expose run-local identity to caller code while
+                    # the stream chunk is yielded outside this wrapper.
+                    exit_identity()
+                    try:
+                        yield event
+                    finally:
+                        enter_identity()
                 update_agent_invocation_from_events(invocation, events)
                 _finish_invocation(self._handler.stop_invoke_agent, invocation)
                 finalized = True
@@ -160,18 +186,23 @@ class AgnoAgentWrapper:
                 error = exc
                 raise
             finally:
-                if not finalized:
-                    if error is None or _is_stream_close(error):
-                        update_agent_invocation_from_events(invocation, events)
-                        _finish_invocation(
-                            self._handler.stop_invoke_agent, invocation
-                        )
-                    else:
-                        _finish_invocation(
-                            self._handler.fail_invoke_agent,
-                            invocation,
-                            _error(error),
-                        )
+                try:
+                    if not finalized:
+                        if error is None or _is_stream_close(error):
+                            update_agent_invocation_from_events(
+                                invocation, events
+                            )
+                            _finish_invocation(
+                                self._handler.stop_invoke_agent, invocation
+                            )
+                        else:
+                            _finish_invocation(
+                                self._handler.fail_invoke_agent,
+                                invocation,
+                                _error(error),
+                            )
+                finally:
+                    exit_identity()
 
         return generator()
 
@@ -214,6 +245,7 @@ class AgnoAgentWrapper:
     ) -> Any:
         invocation = create_agent_invocation(instance, arguments)
         self._handler.start_invoke_agent(invocation, context=parent_context)
+        identity_token = set_current_agno_run_identity(invocation.attributes)
         try:
             response = wrapped(*args, **kwargs)
             if inspect.isawaitable(response):
@@ -228,6 +260,8 @@ class AgnoAgentWrapper:
                 _error(exc),
             )
             raise
+        finally:
+            reset_current_agno_run_identity(identity_token)
 
     async def _arun_stream(
         self,
@@ -244,6 +278,21 @@ class AgnoAgentWrapper:
         finalized = False
         error = None
         self._handler.start_invoke_agent(invocation, context=parent_context)
+        identity_token = None
+
+        def enter_identity() -> None:
+            nonlocal identity_token
+            identity_token = set_current_agno_run_identity(
+                invocation.attributes
+            )
+
+        def exit_identity() -> None:
+            nonlocal identity_token
+            if identity_token is not None:
+                reset_current_agno_run_identity(identity_token)
+                identity_token = None
+
+        enter_identity()
         try:
             stream = wrapped(*args, **kwargs)
             if inspect.isawaitable(stream):
@@ -252,7 +301,13 @@ class AgnoAgentWrapper:
                 if invocation.monotonic_first_token_s is None:
                     invocation.monotonic_first_token_s = timeit.default_timer()
                 events.append(event)
-                yield event
+                # Do not expose run-local identity to caller code while
+                # the stream chunk is yielded outside this wrapper.
+                exit_identity()
+                try:
+                    yield event
+                finally:
+                    enter_identity()
             update_agent_invocation_from_events(invocation, events)
             _finish_invocation(self._handler.stop_invoke_agent, invocation)
             finalized = True
@@ -260,18 +315,21 @@ class AgnoAgentWrapper:
             error = exc
             raise
         finally:
-            if not finalized:
-                if error is None or _is_stream_close(error):
-                    update_agent_invocation_from_events(invocation, events)
-                    _finish_invocation(
-                        self._handler.stop_invoke_agent, invocation
-                    )
-                else:
-                    _finish_invocation(
-                        self._handler.fail_invoke_agent,
-                        invocation,
-                        _error(error),
-                    )
+            try:
+                if not finalized:
+                    if error is None or _is_stream_close(error):
+                        update_agent_invocation_from_events(invocation, events)
+                        _finish_invocation(
+                            self._handler.stop_invoke_agent, invocation
+                        )
+                    else:
+                        _finish_invocation(
+                            self._handler.fail_invoke_agent,
+                            invocation,
+                            _error(error),
+                        )
+            finally:
+                exit_identity()
 
 
 class AgnoFunctionCallWrapper:

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agno/src/opentelemetry/instrumentation/agno/utils.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agno/src/opentelemetry/instrumentation/agno/utils.py
@@ -15,9 +15,11 @@
 from __future__ import annotations
 
 import json
+from contextvars import ContextVar, Token
 from dataclasses import asdict, is_dataclass
 from typing import Any, Dict, Mapping, Optional, Sequence
 
+from opentelemetry import baggage
 from opentelemetry.util.genai.extended_semconv.gen_ai_extended_attributes import (
     GEN_AI_SESSION_ID,
     GEN_AI_USER_ID,
@@ -44,6 +46,106 @@ _SKILL_TOOL_NAMES = {
     "get_skill_reference",
     "get_skill_script",
 }
+_CURRENT_AGNO_RUN_IDENTITY: ContextVar[dict[str, str] | None] = ContextVar(
+    "agno_current_run_identity",
+    default=None,
+)
+
+
+def _identity_value(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _first_identity_value(*values: Any) -> str | None:
+    for value in values:
+        identity = _identity_value(value)
+        if identity is not None:
+            return identity
+    return None
+
+
+def _current_baggage_value(key: str) -> str | None:
+    try:
+        value = baggage.get_baggage(key)
+    except Exception:
+        return None
+    return _identity_value(value)
+
+
+def entry_baggage_identity_attributes() -> dict[str, str]:
+    attributes: dict[str, str] = {}
+    session_id = _current_baggage_value(GEN_AI_SESSION_ID)
+    user_id = _current_baggage_value(GEN_AI_USER_ID)
+    if session_id:
+        attributes[GEN_AI_SESSION_ID] = session_id
+    if user_id:
+        attributes[GEN_AI_USER_ID] = user_id
+    return attributes
+
+
+def _framework_identity_attributes(
+    agent: Any, arguments: Mapping[str, Any]
+) -> dict[str, str]:
+    attributes: dict[str, str] = {}
+    user_id = _first_identity_value(
+        arguments.get("user_id"),
+        getattr(agent, "user_id", None),
+    )
+    session_id = _first_identity_value(
+        arguments.get("session_id"),
+        getattr(agent, "session_id", None),
+    )
+    if user_id:
+        attributes[GEN_AI_USER_ID] = user_id
+    if session_id:
+        attributes[GEN_AI_SESSION_ID] = session_id
+    return attributes
+
+
+def agno_run_identity_attributes(
+    agent: Any, arguments: Mapping[str, Any]
+) -> dict[str, str]:
+    attributes = _framework_identity_attributes(agent, arguments)
+    attributes.update(entry_baggage_identity_attributes())
+    return attributes
+
+
+def set_current_agno_run_identity(
+    attributes: Mapping[str, Any],
+) -> Token[dict[str, str] | None]:
+    identity = {
+        key: value
+        for key in (GEN_AI_SESSION_ID, GEN_AI_USER_ID)
+        if (value := _identity_value(attributes.get(key))) is not None
+    }
+    return _CURRENT_AGNO_RUN_IDENTITY.set(identity or None)
+
+
+def reset_current_agno_run_identity(
+    token: Token[dict[str, str] | None],
+) -> None:
+    _CURRENT_AGNO_RUN_IDENTITY.reset(token)
+
+
+def _current_identity_attributes() -> dict[str, str]:
+    attributes: dict[str, str] = {}
+    run_identity = _CURRENT_AGNO_RUN_IDENTITY.get()
+    if run_identity:
+        attributes.update(run_identity)
+    # Re-read baggage so ENTRY identity stays highest priority for child spans
+    # even if the active OTel context changes while an Agno run is in progress.
+    attributes.update(entry_baggage_identity_attributes())
+    return attributes
+
+
+def _apply_current_identity(invocation: Any) -> str | None:
+    attributes = _current_identity_attributes()
+    for key, value in attributes.items():
+        invocation.attributes[key] = value
+    return attributes.get(GEN_AI_SESSION_ID)
 
 
 def _json_default(value: Any) -> Any:
@@ -421,15 +523,8 @@ def create_agent_invocation(
 ) -> InvokeAgentInvocation:
     model = getattr(agent, "model", None)
     input_value = arguments.get("input")
-    user_id = arguments.get("user_id") or getattr(agent, "user_id", None)
-    session_id = arguments.get("session_id") or getattr(
-        agent, "session_id", None
-    )
-    attributes: dict[str, Any] = {}
-    if user_id:
-        attributes[GEN_AI_USER_ID] = str(user_id)
-    if session_id:
-        attributes[GEN_AI_SESSION_ID] = str(session_id)
+    attributes: dict[str, Any] = agno_run_identity_attributes(agent, arguments)
+    session_id = attributes.get(GEN_AI_SESSION_ID)
 
     invocation = InvokeAgentInvocation(
         provider=_PROVIDER,
@@ -568,6 +663,9 @@ def create_llm_invocation(
         input_messages=convert_model_messages(arguments.get("messages")),
         tool_definitions=convert_tool_definitions(arguments.get("tools")),
     )
+    session_id = _apply_current_identity(invocation)
+    if session_id and not getattr(invocation, "conversation_id", None):
+        invocation.conversation_id = session_id
 
     for name in (
         "temperature",
@@ -657,6 +755,7 @@ def create_tool_invocation(function_call: Any) -> ExecuteToolInvocation:
         tool_type="function",
         tool_call_arguments=getattr(function_call, "arguments", None),
     )
+    _apply_current_identity(invocation)
     _apply_agno_skill_tool_metadata(invocation, invocation.tool_call_arguments)
     return invocation
 

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agno/tests/test_agno.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agno/tests/test_agno.py
@@ -27,9 +27,12 @@ from agno.models.base import Model
 from agno.models.response import ModelResponse
 from agno.tools.function import Function, FunctionCall
 
+from opentelemetry import baggage
+from opentelemetry import context as otel_context
 from opentelemetry import trace as trace_api
 from opentelemetry.instrumentation.agno import AgnoInstrumentor
 from opentelemetry.instrumentation.agno._wrapper import (
+    AgnoAgentWrapper,
     AgnoFunctionCallWrapper,
     AgnoModelWrapper,
 )
@@ -49,6 +52,10 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
 )
 from opentelemetry.util.genai.extended_handler import (
     get_extended_telemetry_handler,
+)
+from opentelemetry.util.genai.extended_semconv.gen_ai_extended_attributes import (
+    GEN_AI_SESSION_ID,
+    GEN_AI_USER_ID,
 )
 
 
@@ -176,6 +183,8 @@ def test_agent_model_and_tool_spans_use_genai_util(
     response = agent.run("Say hello", user_id="u1", session_id="s1")
     assert response.content == "hello"
 
+    # This standalone tool call happens after the agent run completes; run-local
+    # identity must not leak to tool spans outside the active Agno run.
     fn = Function.from_callable(lambda city: f"sunny in {city}")
     fn.name = "get_weather"
     function_call = FunctionCall(
@@ -206,6 +215,10 @@ def test_agent_model_and_tool_spans_use_genai_util(
     assert model_attrs["gen_ai.span.kind"] == "LLM"
     assert model_attrs["gen_ai.operation.name"] == "chat"
     assert model_attrs["gen_ai.request.model"] == "echo-model"
+    assert model_attrs["gen_ai.session.id"] == "s1"
+    assert model_attrs["gen_ai.user.id"] == "u1"
+    assert model_attrs["gen_ai.conversation.id"] == "s1"
+    assert model_attrs["gen_ai.agent.name"] == "EchoAgent"
     assert model_attrs["gen_ai.usage.input_tokens"] == 2
     assert model_attrs["gen_ai.usage.output_tokens"] == 3
 
@@ -213,8 +226,236 @@ def test_agent_model_and_tool_spans_use_genai_util(
     assert tool_attrs["gen_ai.operation.name"] == "execute_tool"
     assert tool_attrs["gen_ai.tool.name"] == "get_weather"
     assert tool_attrs["gen_ai.tool.call.id"] == "call_1"
+    assert "gen_ai.session.id" not in tool_attrs
+    assert "gen_ai.user.id" not in tool_attrs
     assert "Hangzhou" in tool_attrs["gen_ai.tool.call.arguments"]
     assert "sunny in Hangzhou" in tool_attrs["gen_ai.tool.call.result"]
+
+
+def test_agent_invocation_prefers_entry_baggage_identity():
+    agent = SimpleNamespace(
+        name="EntryAgent",
+        id="agent-id",
+        model=EchoModel(),
+        user_id="agno-user",
+        session_id="agno-session",
+        tools=[],
+        instructions=[],
+    )
+    ctx = baggage.set_baggage(GEN_AI_SESSION_ID, "entry-session")
+    ctx = baggage.set_baggage(GEN_AI_USER_ID, "entry-user", ctx)
+    token = otel_context.attach(ctx)
+    try:
+        invocation = create_agent_invocation(
+            agent,
+            {
+                "input": "hello",
+                "user_id": "run-user",
+                "session_id": "run-session",
+            },
+        )
+    finally:
+        otel_context.detach(token)
+
+    assert invocation.conversation_id == "entry-session"
+    assert invocation.attributes[GEN_AI_SESSION_ID] == "entry-session"
+    assert invocation.attributes[GEN_AI_USER_ID] == "entry-user"
+
+
+def test_agent_invocation_applies_entry_identity_per_key():
+    agent = SimpleNamespace(
+        name="PartialEntryAgent",
+        id="agent-id",
+        model=EchoModel(),
+        user_id="agent-user",
+        session_id="agent-session",
+        tools=[],
+        instructions=[],
+    )
+
+    ctx = baggage.set_baggage(GEN_AI_SESSION_ID, "entry-session")
+    token = otel_context.attach(ctx)
+    try:
+        session_invocation = create_agent_invocation(
+            agent,
+            {
+                "input": "hello",
+                "user_id": "run-user",
+                "session_id": "run-session",
+            },
+        )
+    finally:
+        otel_context.detach(token)
+
+    ctx = baggage.set_baggage(GEN_AI_USER_ID, "entry-user")
+    token = otel_context.attach(ctx)
+    try:
+        user_invocation = create_agent_invocation(
+            agent,
+            {
+                "input": "hello",
+                "user_id": "run-user",
+                "session_id": "run-session",
+            },
+        )
+    finally:
+        otel_context.detach(token)
+
+    assert session_invocation.conversation_id == "entry-session"
+    assert session_invocation.attributes[GEN_AI_SESSION_ID] == "entry-session"
+    assert session_invocation.attributes[GEN_AI_USER_ID] == "run-user"
+    assert user_invocation.conversation_id == "run-session"
+    assert user_invocation.attributes[GEN_AI_SESSION_ID] == "run-session"
+    assert user_invocation.attributes[GEN_AI_USER_ID] == "entry-user"
+
+
+def test_agent_invocation_falls_back_to_agent_identity():
+    agent = SimpleNamespace(
+        name="FallbackAgent",
+        id="agent-id",
+        model=EchoModel(),
+        user_id="agent-user",
+        session_id="agent-session",
+        tools=[],
+        instructions=[],
+    )
+
+    invocation = create_agent_invocation(agent, {"input": "hello"})
+
+    assert invocation.conversation_id == "agent-session"
+    assert invocation.attributes[GEN_AI_SESSION_ID] == "agent-session"
+    assert invocation.attributes[GEN_AI_USER_ID] == "agent-user"
+
+
+def test_agent_run_identity_propagates_to_tool_span(
+    span_exporter: InMemorySpanExporter,
+):
+    fn = Function.from_callable(lambda city: f"sunny in {city}")
+    fn.name = "get_weather"
+    function_call = FunctionCall(
+        function=fn,
+        arguments={"city": "Hangzhou"},
+        call_id="call_in_agent",
+    )
+    agent = SimpleNamespace(
+        name="ToolAgent",
+        id="agent-id",
+        model=EchoModel(),
+        tools=[],
+        instructions=[],
+    )
+    wrapper = AgnoAgentWrapper(get_extended_telemetry_handler())
+
+    def wrapped(
+        prompt: str, user_id: str | None = None, session_id: str | None = None
+    ):
+        assert prompt == "call the tool"
+        assert user_id == "tool-user"
+        assert session_id == "tool-session"
+        function_call.execute()
+        return SimpleNamespace(role="assistant", content="done")
+
+    response = wrapper._run(
+        wrapped,
+        agent,
+        ("call the tool",),
+        {"user_id": "tool-user", "session_id": "tool-session"},
+        {
+            "input": "call the tool",
+            "user_id": "tool-user",
+            "session_id": "tool-session",
+        },
+    )
+
+    assert response.content == "done"
+    spans = _spans_by_name(span_exporter)
+    tool_attrs = spans["execute_tool get_weather"].attributes
+    assert tool_attrs["gen_ai.session.id"] == "tool-session"
+    assert tool_attrs["gen_ai.user.id"] == "tool-user"
+    assert tool_attrs["gen_ai.agent.name"] == "ToolAgent"
+
+
+def test_nested_agent_run_restores_outer_identity(
+    span_exporter: InMemorySpanExporter,
+):
+    handler = get_extended_telemetry_handler()
+    agent_wrapper = AgnoAgentWrapper(handler)
+    model_wrapper = AgnoModelWrapper(handler)
+    outer_agent = SimpleNamespace(
+        name="OuterAgent",
+        id="outer-agent-id",
+        model=EchoModel(),
+        tools=[],
+        instructions=[],
+    )
+    inner_agent = SimpleNamespace(
+        name="InnerAgent",
+        id="inner-agent-id",
+        model=EchoModel(),
+        tools=[],
+        instructions=[],
+    )
+
+    def model_call(name: str):
+        model = SimpleNamespace(id=f"{name}-model", provider="test")
+
+        def wrapped(messages=None):
+            return SimpleNamespace(role="assistant", content=name)
+
+        return model_wrapper.response(wrapped, model, (), {"messages": []})
+
+    def inner_wrapped(prompt, user_id=None, session_id=None):
+        assert prompt == "inner"
+        assert user_id == "inner-user"
+        assert session_id == "inner-session"
+        model_call("inner")
+        return SimpleNamespace(role="assistant", content="inner done")
+
+    def outer_wrapped(prompt, user_id=None, session_id=None):
+        assert prompt == "outer"
+        assert user_id == "outer-user"
+        assert session_id == "outer-session"
+        model_call("outer-before")
+        agent_wrapper._run(
+            inner_wrapped,
+            inner_agent,
+            ("inner",),
+            {"user_id": "inner-user", "session_id": "inner-session"},
+            {
+                "input": "inner",
+                "user_id": "inner-user",
+                "session_id": "inner-session",
+            },
+        )
+        model_call("outer-after")
+        return SimpleNamespace(role="assistant", content="outer done")
+
+    agent_wrapper._run(
+        outer_wrapped,
+        outer_agent,
+        ("outer",),
+        {"user_id": "outer-user", "session_id": "outer-session"},
+        {
+            "input": "outer",
+            "user_id": "outer-user",
+            "session_id": "outer-session",
+        },
+    )
+
+    spans = _spans_by_name(span_exporter)
+    outer_before_attrs = spans["chat outer-before-model"].attributes
+    inner_attrs = spans["chat inner-model"].attributes
+    outer_after_attrs = spans["chat outer-after-model"].attributes
+
+    assert outer_before_attrs["gen_ai.user.id"] == "outer-user"
+    assert outer_before_attrs["gen_ai.session.id"] == "outer-session"
+    assert outer_before_attrs["gen_ai.agent.name"] == "OuterAgent"
+    assert inner_attrs["gen_ai.user.id"] == "inner-user"
+    assert inner_attrs["gen_ai.session.id"] == "inner-session"
+    assert inner_attrs["gen_ai.agent.name"] == "InnerAgent"
+    assert outer_after_attrs["gen_ai.user.id"] == "outer-user"
+    assert outer_after_attrs["gen_ai.session.id"] == "outer-session"
+    assert outer_after_attrs["gen_ai.agent.name"] == "OuterAgent"
 
 
 def test_agno_skill_tool_invocation_captures_skill_attributes():
@@ -289,7 +530,14 @@ def test_streaming_agent_finishes_agent_and_model_spans(
 ):
     agent = Agent(name="StreamAgent", model=EchoModel(), tools=[])
 
-    chunks = list(agent.run("stream please", stream=True))
+    chunks = list(
+        agent.run(
+            "stream please",
+            stream=True,
+            user_id="stream-user",
+            session_id="stream-session",
+        )
+    )
     assert [chunk.content for chunk in chunks] == ["he", "llo"]
 
     spans = _spans_by_name(span_exporter)
@@ -297,13 +545,56 @@ def test_streaming_agent_finishes_agent_and_model_spans(
     model_attrs = spans["chat echo-model"].attributes
 
     assert agent_attrs["gen_ai.span.kind"] == "AGENT"
+    assert agent_attrs["gen_ai.user.id"] == "stream-user"
+    assert agent_attrs["gen_ai.session.id"] == "stream-session"
     assert "hello" in agent_attrs["gen_ai.output.messages"]
     assert "gen_ai.response.time_to_first_token" in agent_attrs
     assert model_attrs["gen_ai.span.kind"] == "LLM"
+    assert model_attrs["gen_ai.user.id"] == "stream-user"
+    assert model_attrs["gen_ai.session.id"] == "stream-session"
+    assert model_attrs["gen_ai.conversation.id"] == "stream-session"
     assert "hello" in model_attrs["gen_ai.output.messages"]
     assert "gen_ai.response.time_to_first_token" in model_attrs
     assert model_attrs["gen_ai.usage.input_tokens"] == 2
     assert model_attrs["gen_ai.usage.output_tokens"] == 3
+
+
+def test_streaming_agent_identity_is_scoped_between_yields(
+    span_exporter: InMemorySpanExporter,
+):
+    agent = Agent(name="ScopedStreamAgent", model=EchoModel(), tools=[])
+    fn = Function.from_callable(lambda city: f"sunny in {city}")
+    fn.name = "get_weather"
+    function_call = FunctionCall(
+        function=fn,
+        arguments={"city": "Hangzhou"},
+        call_id="call_between_stream_chunks",
+    )
+
+    stream = agent.run(
+        "stream please",
+        stream=True,
+        user_id="scoped-stream-user",
+        session_id="scoped-stream-session",
+    )
+    first_chunk = next(stream)
+    function_call.execute()
+    remaining_chunks = list(stream)
+    chunk_contents = [
+        first_chunk.content,
+        *[chunk.content for chunk in remaining_chunks],
+    ]
+
+    assert chunk_contents == ["he", "llo"]
+
+    spans = _spans_by_name(span_exporter)
+    model_attrs = spans["chat echo-model"].attributes
+    tool_attrs = spans["execute_tool get_weather"].attributes
+
+    assert model_attrs["gen_ai.user.id"] == "scoped-stream-user"
+    assert model_attrs["gen_ai.session.id"] == "scoped-stream-session"
+    assert "gen_ai.user.id" not in tool_attrs
+    assert "gen_ai.session.id" not in tool_attrs
 
 
 def test_streaming_agent_span_finishes_when_consumer_breaks(
@@ -342,6 +633,9 @@ def test_async_agent_run_finishes_agent_and_model_spans(
     assert agent_attrs["gen_ai.span.kind"] == "AGENT"
     assert agent_attrs["gen_ai.user.id"] == "u2"
     assert agent_attrs["gen_ai.session.id"] == "s2"
+    assert model_attrs["gen_ai.user.id"] == "u2"
+    assert model_attrs["gen_ai.session.id"] == "s2"
+    assert model_attrs["gen_ai.conversation.id"] == "s2"
     assert model_attrs["gen_ai.usage.input_tokens"] == 2
     assert model_attrs["gen_ai.usage.output_tokens"] == 4
 
@@ -352,7 +646,12 @@ def test_async_streaming_agent_finishes_spans(
     async def run_agent():
         agent = Agent(name="AsyncStreamAgent", model=EchoModel(), tools=[])
         chunks = []
-        async for chunk in agent.arun("stream please", stream=True):
+        async for chunk in agent.arun(
+            "stream please",
+            stream=True,
+            user_id="async-stream-user",
+            session_id="async-stream-session",
+        ):
             chunks.append(chunk.content)
         return chunks
 
@@ -365,6 +664,49 @@ def test_async_streaming_agent_finishes_spans(
         == "AGENT"
     )
     assert "chat echo-model" in spans
+    model_attrs = spans["chat echo-model"].attributes
+    assert model_attrs["gen_ai.user.id"] == "async-stream-user"
+    assert model_attrs["gen_ai.session.id"] == "async-stream-session"
+    assert model_attrs["gen_ai.conversation.id"] == "async-stream-session"
+
+
+def test_async_streaming_agent_identity_is_scoped_between_yields(
+    span_exporter: InMemorySpanExporter,
+):
+    fn = Function.from_callable(lambda city: f"sunny in {city}")
+    fn.name = "get_weather"
+    function_call = FunctionCall(
+        function=fn,
+        arguments={"city": "Hangzhou"},
+        call_id="call_between_async_stream_chunks",
+    )
+
+    async def run_agent():
+        agent = Agent(
+            name="AsyncScopedStreamAgent", model=EchoModel(), tools=[]
+        )
+        chunks = []
+        async for chunk in agent.arun(
+            "stream please",
+            stream=True,
+            user_id="async-scoped-stream-user",
+            session_id="async-scoped-stream-session",
+        ):
+            chunks.append(chunk.content)
+            if len(chunks) == 1:
+                function_call.execute()
+        return chunks
+
+    assert asyncio.run(run_agent()) == ["he", "llo"]
+
+    spans = _spans_by_name(span_exporter)
+    model_attrs = spans["chat echo-model"].attributes
+    tool_attrs = spans["execute_tool get_weather"].attributes
+
+    assert model_attrs["gen_ai.user.id"] == "async-scoped-stream-user"
+    assert model_attrs["gen_ai.session.id"] == "async-scoped-stream-session"
+    assert "gen_ai.user.id" not in tool_attrs
+    assert "gen_ai.session.id" not in tool_attrs
 
 
 def test_concurrent_runs_do_not_drop_spans(
@@ -372,7 +714,11 @@ def test_concurrent_runs_do_not_drop_spans(
 ):
     def run_once(index: int):
         agent = Agent(name=f"Agent{index}", model=EchoModel(), tools=[])
-        return agent.run(f"hello {index}").content
+        return agent.run(
+            f"hello {index}",
+            user_id=f"user-{index}",
+            session_id=f"session-{index}",
+        ).content
 
     with ThreadPoolExecutor(max_workers=3) as executor:
         results = list(executor.map(run_once, range(3)))
@@ -391,6 +737,28 @@ def test_concurrent_runs_do_not_drop_spans(
     ]
     assert len(agent_spans) == 3
     assert len(model_spans) == 3
+    assert {
+        (
+            span.attributes.get("gen_ai.user.id"),
+            span.attributes.get("gen_ai.session.id"),
+        )
+        for span in agent_spans
+    } == {
+        ("user-0", "session-0"),
+        ("user-1", "session-1"),
+        ("user-2", "session-2"),
+    }
+    assert {
+        (
+            span.attributes.get("gen_ai.user.id"),
+            span.attributes.get("gen_ai.session.id"),
+        )
+        for span in model_spans
+    } == {
+        ("user-0", "session-0"),
+        ("user-1", "session-1"),
+        ("user-2", "session-2"),
+    }
 
 
 @pytest.mark.parametrize("content_capture_mode", [None, "NO_CONTENT"])


### PR DESCRIPTION
# Description

This PR aligns Agno identity handling with ENTRY priority and propagates the effective Agno run identity to child GenAI spans.

Changes:
- Prefer ENTRY baggage `gen_ai.user.id` / `gen_ai.session.id` over Agno `run()` arguments or agent attributes, per key.
- Store the effective Agno run identity in an Agno-local `ContextVar` while an agent run is active.
- Apply the current identity to child LLM and TOOL invocations, setting LLM `gen_ai.conversation.id` from the effective session id when unset.
- Scope streaming run identity so unrelated caller code between yielded stream chunks does not inherit the internal Agno run identity.
- Add regression coverage for sync, async, streaming, nested runs, concurrent runs, ENTRY priority, per-key fallback, tool propagation, and stream-yield scoping.

Fixes # (not filed)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] `uvx tox -c tox-loongsuite.ini -e py311-test-loongsuite-instrumentation-agno -- -q`
- [x] `uvx tox -c tox-loongsuite.ini -e py39-test-loongsuite-instrumentation-agno -- -q`
- [x] `uvx tox -c tox-loongsuite.ini -e lint-loongsuite-instrumentation-agno`
- [x] Fresh-cache precommit gate: `PRE_COMMIT_HOME="$(mktemp -d)" tox -e precommit`
- [x] Static LoongSuite readiness checker passed.
- [x] LoongSuite detector simulation passed with `full=false`, `packages=|loongsuite-instrumentation-agno|`.
- [x] Weaver live-check passed against the regenerated Agno GenAI JSON sample.
- [x] Real DashScope smoke passed for non-streaming, streaming, and concurrent Agno calls.
- [x] Real DashScope identity smoke passed for 4 AGENT and 4 LLM spans with distinct user/session/conversation values.
- [x] Real DashScope tool-heavy smoke passed with two TOOL spans carrying the run user/session identity.

## Validation Evidence

### Spec and Scope
- Linked issue/spec: N/A, direct user-requested Agno identity propagation fix.
- Approved spec/comment: Direct implementation request in local maintainer thread.
- Changed surface: `loongsuite-instrumentation-agno` wrapper, Agno utility helpers, Agno tests, and package changelog.

### Local Checks
| Check | Command | Result | Notes |
| --- | --- | --- | --- |
| Static readiness | `python "$PIPELINE_SKILL_DIR/scripts/check_loongsuite_pr_readiness.py" --repo .` | pass | No readiness blockers. |
| Precommit | `PRE_COMMIT_HOME="$(mktemp -d)" tox -e precommit` | pass | Run with fresh hook cache; `git diff --check` passed after the run. |
| Focused tests | `uvx tox -c tox-loongsuite.ini -e py311-test-loongsuite-instrumentation-agno -- -q` | pass | 29 passed. |
| Focused tests | `uvx tox -c tox-loongsuite.ini -e py39-test-loongsuite-instrumentation-agno -- -q` | pass | 29 passed. |
| Focused lint | `uvx tox -c tox-loongsuite.ini -e lint-loongsuite-instrumentation-agno` | pass | Ruff check passed. |
| Claude/Qoder review | qoder deep review | pass | Final round: 0 blocking findings; remaining comments were P3 advisories. |
| Privacy scan | Diff scan for local paths, bearer tokens, API keys, and secret-looking keys | pass | No matches. |
| Package detector | `GITHUB_EVENT_NAME=pull_request LOONGSUITE_CHANGED_FILES="$(git diff --name-only)" python .github/scripts/detect_loongsuite_changes.py` | pass | `full=false`, `packages=|loongsuite-instrumentation-agno|`. |

### Real E2E Matrix
| Scenario | Status | Command or Demo | Evidence |
| --- | --- | --- | --- |
| non-streaming | pass | DashScope Agno smoke with `AGNO_SMOKE_MODE=all` | Non-streaming call returned successfully. |
| streaming | pass | DashScope Agno smoke with `AGNO_SMOKE_MODE=all` | Streaming call completed successfully. |
| concurrency | pass | DashScope Agno smoke with `AGNO_SMOKE_MODE=all`; separate identity smoke with 2 concurrent calls | Concurrent calls completed; identity smoke verified distinct user/session values. |
| agent/tool/ReAct | pass | DashScope Agno smoke with local `get_weather` tool | Tool-using agent path completed successfully. |
| tool-heavy | pass | DashScope identity smoke with `get_weather` and `get_air_quality` tools | Two TOOL spans emitted and both carried the run user/session identity. |
| error path | pass | Focused Agno failure tests | Model and tool wrapper failure tests passed without losing failure handling. |

### Telemetry and Weaver
| Check | Status | Command or Artifact | Notes |
| --- | --- | --- | --- |
| Span tree / span kinds | pass | Focused Agno tests and regenerated JSON sample | AGENT, LLM, and TOOL span kinds verified. |
| Content capture modes | pass | `test_content_capture_mode_does_not_gate_span_creation` plus NO_CONTENT Weaver sample | NO_CONTENT sample omitted message content while keeping required identity fields. |
| Concurrency isolation | pass | `test_concurrent_runs_do_not_drop_spans`; real DashScope identity smoke | Per-run user/session values stayed isolated. |
| Weaver live-check | pass | `weaver registry live-check -r <loongsuite-semantic-conventions-registry> --advice-profile loongsuite-genai ...` | Exit 0; only known stability / enum advisories. |

### CI
- GitHub checks: Not run yet; PR branch has not been pushed.
- Known unrelated failures: None known locally.
- Follow-up needed: Inspect GitHub Actions after the PR is opened.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR:
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
