### PR TITLE
fix(agno): split tool-call loops into react steps

### DIFF
--- a/instrumentation-loongsuite/loongsuite-instrumentation-agno/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agno/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Split Agno 2.x tool-call loops into ReAct step spans with one LLM span per
+  provider request, and populate streaming agent token usage from child LLM
+  spans when Agno run events do not include metrics.
 - Propagate Agno run user and session identity to model and tool spans while
   preferring ENTRY baggage identity over Agno framework-provided values.
 

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agno/src/opentelemetry/instrumentation/agno/__init__.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agno/src/opentelemetry/instrumentation/agno/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
+import logging
 from typing import Any, Collection
 
 from wrapt import wrap_function_wrapper
@@ -30,7 +32,64 @@ from opentelemetry.instrumentation.utils import unwrap
 _AGENT = "agno.agent"
 _MODULE = "agno.models.base"
 _TOOLKIT = "agno.tools.function"
+_logger = logging.getLogger(__name__)
 __all__ = ["AgnoInstrumentor"]
+
+_INNER_MODEL_WRAPPERS = (
+    ("Model._process_model_response", "process_model_response"),
+    ("Model._aprocess_model_response", "aprocess_model_response"),
+    ("Model.process_response_stream", "process_response_stream"),
+    ("Model.aprocess_response_stream", "aprocess_response_stream"),
+    ("Model.run_function_calls", "run_function_calls"),
+    ("Model.arun_function_calls", "arun_function_calls"),
+)
+
+_FALLBACK_MODEL_WRAPPERS = (
+    ("Model.response", "response"),
+    ("Model.aresponse", "aresponse"),
+    ("Model.response_stream", "response_stream"),
+    ("Model.aresponse_stream", "aresponse_stream"),
+)
+
+
+def _has_wrap_target(module_name: str, name: str) -> bool:
+    try:
+        target = importlib.import_module(module_name)
+        for part in name.split("."):
+            target = getattr(target, part)
+    except Exception:
+        return False
+    return True
+
+
+def _wrap_model_methods(model_wrapper: AgnoModelWrapper) -> None:
+    if all(
+        _has_wrap_target(_MODULE, name)
+        for name, _wrapper_name in _INNER_MODEL_WRAPPERS
+    ):
+        for name, wrapper_name in _INNER_MODEL_WRAPPERS:
+            wrap_function_wrapper(
+                module=_MODULE,
+                name=name,
+                wrapper=getattr(model_wrapper, wrapper_name),
+            )
+        return
+
+    _logger.warning(
+        "Agno inner model hooks are unavailable; falling back to outer "
+        "Model.response wrappers."
+    )
+    for name, wrapper_name in _FALLBACK_MODEL_WRAPPERS:
+        wrap_function_wrapper(
+            module=_MODULE,
+            name=name,
+            wrapper=getattr(model_wrapper, wrapper_name),
+        )
+
+
+def _unwrap_if_present(target: Any, name: str) -> None:
+    if hasattr(target, name):
+        unwrap(target, name)
 
 
 class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
@@ -91,27 +150,9 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
             wrapper=function_call_wrapper.aexecute,
         )
 
-        # Wrap the model
-        wrap_function_wrapper(
-            module=_MODULE,
-            name="Model.response",
-            wrapper=model_wrapper.response,
-        )
-        wrap_function_wrapper(
-            module=_MODULE,
-            name="Model.aresponse",
-            wrapper=model_wrapper.aresponse,
-        )
-        wrap_function_wrapper(
-            module=_MODULE,
-            name="Model.response_stream",
-            wrapper=model_wrapper.response_stream,
-        )
-        wrap_function_wrapper(
-            module=_MODULE,
-            name="Model.aresponse_stream",
-            wrapper=model_wrapper.aresponse_stream,
-        )
+        # Wrap the model. Prefer Agno's per-request internals so a tool-call
+        # loop emits one LLM span per provider call.
+        _wrap_model_methods(model_wrapper)
 
     def _uninstrument(self, **kwargs: Any) -> None:
         # Unwrap the agent call function
@@ -129,8 +170,9 @@ class AgnoInstrumentor(BaseInstrumentor):  # type: ignore
         # Unwrap the model
         import agno.models.base  # noqa: PLC0415
 
-        unwrap(agno.models.base.Model, "response")
-        unwrap(agno.models.base.Model, "aresponse")
-        unwrap(agno.models.base.Model, "response_stream")
-        unwrap(agno.models.base.Model, "aresponse_stream")
+        for name, _wrapper_name in (
+            *_INNER_MODEL_WRAPPERS,
+            *_FALLBACK_MODEL_WRAPPERS,
+        ):
+            _unwrap_if_present(agno.models.base.Model, name.split(".", 1)[1])
         self._handler = None

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agno/src/opentelemetry/instrumentation/agno/_wrapper.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agno/src/opentelemetry/instrumentation/agno/_wrapper.py
@@ -14,14 +14,17 @@
 
 from __future__ import annotations
 
+import contextvars
 import inspect
 import timeit
 from collections import OrderedDict
 from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
+from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Mapping
 
 from opentelemetry import context as otel_context
+from opentelemetry.util.genai.extended_types import ReactStepInvocation
 from opentelemetry.util.genai.types import Error
 
 from .utils import (
@@ -78,6 +81,124 @@ def _is_stream_close(exc: BaseException) -> bool:
     return isinstance(exc, (GeneratorExit, StopIteration, StopAsyncIteration))
 
 
+@dataclass
+class _AgnoRunState:
+    handler: ExtendedTelemetryHandler
+    agent_context: Any
+    react_round: int = 0
+    active_step: ReactStepInvocation | None = None
+    llm_input_tokens: int = 0
+    llm_output_tokens: int = 0
+    llm_cache_read_tokens: int = 0
+    llm_cache_write_tokens: int = 0
+
+
+_AGNO_RUN_STATE: contextvars.ContextVar[_AgnoRunState | None] = (
+    contextvars.ContextVar("agno_run_state", default=None)
+)
+
+
+def _current_run_state(
+    handler: ExtendedTelemetryHandler,
+) -> _AgnoRunState | None:
+    state = _AGNO_RUN_STATE.get()
+    if state is None or state.handler is not handler:
+        return None
+    return state
+
+
+def _close_active_react_step(
+    handler: ExtendedTelemetryHandler,
+    state: _AgnoRunState,
+    finish_reason: str,
+) -> None:
+    step = state.active_step
+    if step is None:
+        return
+    state.active_step = None
+    step.finish_reason = step.finish_reason or finish_reason
+    _finish_invocation(handler.stop_react_step, step)
+
+
+def _fail_active_react_step(
+    handler: ExtendedTelemetryHandler,
+    state: _AgnoRunState | None,
+    error: Error,
+) -> None:
+    if state is None or state.active_step is None:
+        return
+    step = state.active_step
+    state.active_step = None
+    _finish_invocation(handler.fail_react_step, step, error)
+
+
+def _start_next_react_step(
+    handler: ExtendedTelemetryHandler,
+    state: _AgnoRunState | None,
+) -> None:
+    if state is None:
+        return
+    if state.active_step is not None:
+        _close_active_react_step(handler, state, "tool_calls")
+    state.react_round += 1
+    invocation = ReactStepInvocation(round=state.react_round)
+    handler.start_react_step(invocation, context=state.agent_context)
+    state.active_step = invocation
+
+
+def _finish_react_step_after_llm(
+    handler: ExtendedTelemetryHandler,
+    state: _AgnoRunState | None,
+    assistant_message: Any,
+) -> None:
+    if state is None or state.active_step is None:
+        return
+    if getattr(assistant_message, "tool_calls", None):
+        state.active_step.finish_reason = "tool_calls"
+        return
+    _close_active_react_step(handler, state, "stop")
+
+
+def _record_llm_usage(
+    state: _AgnoRunState | None,
+    invocation: Any,
+) -> None:
+    if state is None:
+        return
+    state.llm_input_tokens += invocation.input_tokens or 0
+    state.llm_output_tokens += invocation.output_tokens or 0
+    state.llm_cache_read_tokens += (
+        invocation.usage_cache_read_input_tokens or 0
+    )
+    state.llm_cache_write_tokens += (
+        invocation.usage_cache_creation_input_tokens or 0
+    )
+
+
+def _apply_agent_token_fallback(
+    invocation: Any,
+    state: _AgnoRunState | None,
+) -> None:
+    if state is None:
+        return
+    if invocation.input_tokens is None and state.llm_input_tokens:
+        invocation.input_tokens = state.llm_input_tokens
+    if invocation.output_tokens is None and state.llm_output_tokens:
+        invocation.output_tokens = state.llm_output_tokens
+    if (
+        invocation.usage_cache_read_input_tokens is None
+        and state.llm_cache_read_tokens
+    ):
+        invocation.usage_cache_read_input_tokens = state.llm_cache_read_tokens
+    if (
+        invocation.usage_cache_creation_input_tokens is None
+        and state.llm_cache_write_tokens
+    ):
+        invocation.usage_cache_creation_input_tokens = (
+            state.llm_cache_write_tokens
+        )
+
+
 class AgnoAgentWrapper:
     def __init__(self, handler: ExtendedTelemetryHandler) -> None:
         self._handler = handler
@@ -115,21 +236,31 @@ class AgnoAgentWrapper:
         self._handler.start_invoke_agent(
             invocation, context=otel_context.get_current()
         )
+        state = _AgnoRunState(
+            handler=self._handler,
+            agent_context=otel_context.get_current(),
+        )
+        state_token = _AGNO_RUN_STATE.set(state)
         identity_token = set_current_agno_run_identity(invocation.attributes)
         try:
             response = wrapped(*args, **kwargs)
             update_agent_invocation_from_response(invocation, response)
+            _apply_agent_token_fallback(invocation, state)
+            _close_active_react_step(self._handler, state, "stop")
             _finish_invocation(self._handler.stop_invoke_agent, invocation)
             return response
         except Exception as exc:
+            error = _error(exc)
+            _fail_active_react_step(self._handler, state, error)
             _finish_invocation(
                 self._handler.fail_invoke_agent,
                 invocation,
-                _error(exc),
+                error,
             )
             raise
         finally:
             reset_current_agno_run_identity(identity_token)
+            _AGNO_RUN_STATE.reset(state_token)
 
     def _run_stream(
         self,
@@ -146,10 +277,16 @@ class AgnoAgentWrapper:
             events = []
             finalized = False
             error = None
+            state = None
+            state_token = None
             self._handler.start_invoke_agent(
                 invocation, context=parent_context
             )
             identity_token = None
+            state = _AgnoRunState(
+                handler=self._handler,
+                agent_context=otel_context.get_current(),
+            )
 
             def enter_identity() -> None:
                 nonlocal identity_token
@@ -163,7 +300,18 @@ class AgnoAgentWrapper:
                     reset_current_agno_run_identity(identity_token)
                     identity_token = None
 
+            def enter_run_state() -> None:
+                nonlocal state_token
+                state_token = _AGNO_RUN_STATE.set(state)
+
+            def exit_run_state() -> None:
+                nonlocal state_token
+                if state_token is not None:
+                    _AGNO_RUN_STATE.reset(state_token)
+                    state_token = None
+
             enter_identity()
+            enter_run_state()
             try:
                 stream = wrapped(*args, **kwargs)
                 for event in stream:
@@ -172,14 +320,18 @@ class AgnoAgentWrapper:
                             timeit.default_timer()
                         )
                     events.append(event)
-                    # Do not expose run-local identity to caller code while
-                    # the stream chunk is yielded outside this wrapper.
+                    # Do not expose run-local state to caller code while the
+                    # stream chunk is yielded outside this wrapper.
+                    exit_run_state()
                     exit_identity()
                     try:
                         yield event
                     finally:
                         enter_identity()
+                        enter_run_state()
                 update_agent_invocation_from_events(invocation, events)
+                _apply_agent_token_fallback(invocation, state)
+                _close_active_react_step(self._handler, state, "stop")
                 _finish_invocation(self._handler.stop_invoke_agent, invocation)
                 finalized = True
             except BaseException as exc:
@@ -192,16 +344,25 @@ class AgnoAgentWrapper:
                             update_agent_invocation_from_events(
                                 invocation, events
                             )
+                            _apply_agent_token_fallback(invocation, state)
+                            _close_active_react_step(
+                                self._handler, state, "stop"
+                            )
                             _finish_invocation(
                                 self._handler.stop_invoke_agent, invocation
                             )
                         else:
+                            invoke_error = _error(error)
+                            _fail_active_react_step(
+                                self._handler, state, invoke_error
+                            )
                             _finish_invocation(
                                 self._handler.fail_invoke_agent,
                                 invocation,
-                                _error(error),
+                                invoke_error,
                             )
                 finally:
+                    exit_run_state()
                     exit_identity()
 
         return generator()
@@ -245,23 +406,33 @@ class AgnoAgentWrapper:
     ) -> Any:
         invocation = create_agent_invocation(instance, arguments)
         self._handler.start_invoke_agent(invocation, context=parent_context)
+        state = _AgnoRunState(
+            handler=self._handler,
+            agent_context=otel_context.get_current(),
+        )
+        state_token = _AGNO_RUN_STATE.set(state)
         identity_token = set_current_agno_run_identity(invocation.attributes)
         try:
             response = wrapped(*args, **kwargs)
             if inspect.isawaitable(response):
                 response = await response
             update_agent_invocation_from_response(invocation, response)
+            _apply_agent_token_fallback(invocation, state)
+            _close_active_react_step(self._handler, state, "stop")
             _finish_invocation(self._handler.stop_invoke_agent, invocation)
             return response
         except Exception as exc:
+            error = _error(exc)
+            _fail_active_react_step(self._handler, state, error)
             _finish_invocation(
                 self._handler.fail_invoke_agent,
                 invocation,
-                _error(exc),
+                error,
             )
             raise
         finally:
             reset_current_agno_run_identity(identity_token)
+            _AGNO_RUN_STATE.reset(state_token)
 
     async def _arun_stream(
         self,
@@ -277,8 +448,14 @@ class AgnoAgentWrapper:
         events = []
         finalized = False
         error = None
+        state = None
+        state_token = None
         self._handler.start_invoke_agent(invocation, context=parent_context)
         identity_token = None
+        state = _AgnoRunState(
+            handler=self._handler,
+            agent_context=otel_context.get_current(),
+        )
 
         def enter_identity() -> None:
             nonlocal identity_token
@@ -292,7 +469,18 @@ class AgnoAgentWrapper:
                 reset_current_agno_run_identity(identity_token)
                 identity_token = None
 
+        def enter_run_state() -> None:
+            nonlocal state_token
+            state_token = _AGNO_RUN_STATE.set(state)
+
+        def exit_run_state() -> None:
+            nonlocal state_token
+            if state_token is not None:
+                _AGNO_RUN_STATE.reset(state_token)
+                state_token = None
+
         enter_identity()
+        enter_run_state()
         try:
             stream = wrapped(*args, **kwargs)
             if inspect.isawaitable(stream):
@@ -301,14 +489,18 @@ class AgnoAgentWrapper:
                 if invocation.monotonic_first_token_s is None:
                     invocation.monotonic_first_token_s = timeit.default_timer()
                 events.append(event)
-                # Do not expose run-local identity to caller code while
-                # the stream chunk is yielded outside this wrapper.
+                # Do not expose run-local state to caller code while the
+                # stream chunk is yielded outside this wrapper.
+                exit_run_state()
                 exit_identity()
                 try:
                     yield event
                 finally:
                     enter_identity()
+                    enter_run_state()
             update_agent_invocation_from_events(invocation, events)
+            _apply_agent_token_fallback(invocation, state)
+            _close_active_react_step(self._handler, state, "stop")
             _finish_invocation(self._handler.stop_invoke_agent, invocation)
             finalized = True
         except BaseException as exc:
@@ -319,16 +511,23 @@ class AgnoAgentWrapper:
                 if not finalized:
                     if error is None or _is_stream_close(error):
                         update_agent_invocation_from_events(invocation, events)
+                        _apply_agent_token_fallback(invocation, state)
+                        _close_active_react_step(self._handler, state, "stop")
                         _finish_invocation(
                             self._handler.stop_invoke_agent, invocation
                         )
                     else:
+                        invoke_error = _error(error)
+                        _fail_active_react_step(
+                            self._handler, state, invoke_error
+                        )
                         _finish_invocation(
                             self._handler.fail_invoke_agent,
                             invocation,
-                            _error(error),
+                            invoke_error,
                         )
             finally:
+                exit_run_state()
                 exit_identity()
 
 
@@ -392,6 +591,264 @@ class AgnoFunctionCallWrapper:
 class AgnoModelWrapper:
     def __init__(self, handler: ExtendedTelemetryHandler) -> None:
         self._handler = handler
+
+    def _start_llm_call(
+        self,
+        instance: Any,
+        arguments: Mapping[str, Any],
+    ) -> tuple[_AgnoRunState | None, Any]:
+        state = _current_run_state(self._handler)
+        _start_next_react_step(self._handler, state)
+        invocation = create_llm_invocation(instance, arguments)
+        self._handler.start_llm(invocation, context=otel_context.get_current())
+        return state, invocation
+
+    def _finish_llm_call(
+        self,
+        state: _AgnoRunState | None,
+        invocation: Any,
+        response: Any,
+    ) -> None:
+        update_llm_invocation_from_response(invocation, response)
+        _record_llm_usage(state, invocation)
+        _finish_invocation(self._handler.stop_llm, invocation)
+        _finish_react_step_after_llm(self._handler, state, response)
+
+    def _fail_llm_call(
+        self,
+        state: _AgnoRunState | None,
+        invocation: Any,
+        exc: BaseException,
+    ) -> None:
+        error = _error(exc)
+        _finish_invocation(self._handler.fail_llm, invocation, error)
+        _fail_active_react_step(self._handler, state, error)
+
+    @staticmethod
+    def _response_for_llm_finish(
+        arguments: Mapping[str, Any],
+        responses: list[Any] | None = None,
+    ) -> Any:
+        if responses:
+            return _merge_model_responses(responses)
+        assistant_message = arguments.get("assistant_message")
+        if assistant_message is not None and (
+            getattr(assistant_message, "metrics", None) is not None
+            or getattr(assistant_message, "content", None) is not None
+            or getattr(assistant_message, "reasoning_content", None)
+            is not None
+            or getattr(assistant_message, "tool_calls", None)
+        ):
+            return assistant_message
+        return assistant_message
+
+    def process_model_response(
+        self,
+        wrapped: Callable[..., Any],
+        instance: Any,
+        args: tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> Any:
+        arguments = bind_arguments(wrapped, *args, **kwargs)
+        if instance is None:
+            return wrapped(*args, **kwargs)
+        state, invocation = self._start_llm_call(instance, arguments)
+        try:
+            response = wrapped(*args, **kwargs)
+            self._finish_llm_call(
+                state,
+                invocation,
+                self._response_for_llm_finish(arguments),
+            )
+            return response
+        except BaseException as exc:
+            self._fail_llm_call(state, invocation, exc)
+            raise
+
+    async def aprocess_model_response(
+        self,
+        wrapped: Callable[..., Awaitable[Any]],
+        instance: Any,
+        args: tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> Any:
+        arguments = bind_arguments(wrapped, *args, **kwargs)
+        if instance is None:
+            return await wrapped(*args, **kwargs)
+        state, invocation = self._start_llm_call(instance, arguments)
+        try:
+            response = await wrapped(*args, **kwargs)
+            self._finish_llm_call(
+                state,
+                invocation,
+                self._response_for_llm_finish(arguments),
+            )
+            return response
+        except BaseException as exc:
+            self._fail_llm_call(state, invocation, exc)
+            raise
+
+    def process_response_stream(
+        self,
+        wrapped: Callable[..., Any],
+        instance: Any,
+        args: tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> Iterator[Any]:
+        arguments = bind_arguments(wrapped, *args, **kwargs)
+        if instance is None:
+            yield from wrapped(*args, **kwargs)
+            return
+
+        state, invocation = self._start_llm_call(instance, arguments)
+        responses = []
+        finalized = False
+        error = None
+        try:
+            stream = wrapped(*args, **kwargs)
+            for response in stream:
+                if invocation.monotonic_first_token_s is None:
+                    invocation.monotonic_first_token_s = timeit.default_timer()
+                responses.append(response)
+                yield response
+            self._finish_llm_call(
+                state,
+                invocation,
+                self._response_for_llm_finish(arguments, responses),
+            )
+            finalized = True
+        except BaseException as exc:
+            error = exc
+            raise
+        finally:
+            if not finalized:
+                if error is None or _is_stream_close(error):
+                    self._finish_llm_call(
+                        state,
+                        invocation,
+                        self._response_for_llm_finish(arguments, responses),
+                    )
+                else:
+                    self._fail_llm_call(state, invocation, error)
+
+    async def aprocess_response_stream(
+        self,
+        wrapped: Callable[..., Any],
+        instance: Any,
+        args: tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> AsyncIterator[Any]:
+        arguments = bind_arguments(wrapped, *args, **kwargs)
+        if instance is None:
+            async for response in wrapped(*args, **kwargs):
+                yield response
+            return
+
+        state, invocation = self._start_llm_call(instance, arguments)
+        responses = []
+        finalized = False
+        error = None
+        try:
+            stream = wrapped(*args, **kwargs)
+            if inspect.isawaitable(stream):
+                stream = await stream
+            async for response in stream:
+                if invocation.monotonic_first_token_s is None:
+                    invocation.monotonic_first_token_s = timeit.default_timer()
+                responses.append(response)
+                yield response
+            self._finish_llm_call(
+                state,
+                invocation,
+                self._response_for_llm_finish(arguments, responses),
+            )
+            finalized = True
+        except BaseException as exc:
+            error = exc
+            raise
+        finally:
+            if not finalized:
+                if error is None or _is_stream_close(error):
+                    self._finish_llm_call(
+                        state,
+                        invocation,
+                        self._response_for_llm_finish(arguments, responses),
+                    )
+                else:
+                    self._fail_llm_call(state, invocation, error)
+
+    def run_function_calls(
+        self,
+        wrapped: Callable[..., Any],
+        instance: Any,
+        args: tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> Iterator[Any]:
+        if instance is None:
+            yield from wrapped(*args, **kwargs)
+            return
+
+        state = _current_run_state(self._handler)
+        finalized = False
+        error = None
+        try:
+            for response in wrapped(*args, **kwargs):
+                yield response
+            if state is not None:
+                _close_active_react_step(self._handler, state, "tool_calls")
+            finalized = True
+        except BaseException as exc:
+            error = exc
+            raise
+        finally:
+            if not finalized and state is not None and state.active_step:
+                if error is None or _is_stream_close(error):
+                    _close_active_react_step(
+                        self._handler, state, "tool_calls"
+                    )
+                else:
+                    _fail_active_react_step(
+                        self._handler,
+                        state,
+                        _error(error),
+                    )
+
+    async def arun_function_calls(
+        self,
+        wrapped: Callable[..., Any],
+        instance: Any,
+        args: tuple[Any, ...],
+        kwargs: Mapping[str, Any],
+    ) -> AsyncIterator[Any]:
+        if instance is None:
+            async for response in wrapped(*args, **kwargs):
+                yield response
+            return
+
+        state = _current_run_state(self._handler)
+        finalized = False
+        error = None
+        try:
+            async for response in wrapped(*args, **kwargs):
+                yield response
+            if state is not None:
+                _close_active_react_step(self._handler, state, "tool_calls")
+            finalized = True
+        except BaseException as exc:
+            error = exc
+            raise
+        finally:
+            if not finalized and state is not None and state.active_step:
+                if error is None or _is_stream_close(error):
+                    _close_active_react_step(
+                        self._handler, state, "tool_calls"
+                    )
+                else:
+                    _fail_active_react_step(
+                        self._handler,
+                        state,
+                        _error(error),
+                    )
 
     def response(
         self,

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agno/src/opentelemetry/instrumentation/agno/_wrapper.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agno/src/opentelemetry/instrumentation/agno/_wrapper.py
@@ -631,16 +631,7 @@ class AgnoModelWrapper:
     ) -> Any:
         if responses:
             return _merge_model_responses(responses)
-        assistant_message = arguments.get("assistant_message")
-        if assistant_message is not None and (
-            getattr(assistant_message, "metrics", None) is not None
-            or getattr(assistant_message, "content", None) is not None
-            or getattr(assistant_message, "reasoning_content", None)
-            is not None
-            or getattr(assistant_message, "tool_calls", None)
-        ):
-            return assistant_message
-        return assistant_message
+        return arguments.get("assistant_message")
 
     def process_model_response(
         self,

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agno/src/opentelemetry/instrumentation/agno/utils.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agno/src/opentelemetry/instrumentation/agno/utils.py
@@ -712,6 +712,8 @@ def update_llm_invocation_from_response(
     )
     invocation.output_messages = [_message_to_output(response)]
     finish_reason = _finish_reason(response)
+    if finish_reason is None and getattr(response, "tool_calls", None):
+        finish_reason = "tool_calls"
     if finish_reason:
         invocation.finish_reasons = [finish_reason]
     invocation.input_tokens = _usage_value(
@@ -742,6 +744,23 @@ def update_llm_invocation_from_response(
         invocation.usage_cache_creation_input_tokens = (
             invocation.usage_cache_creation_input_tokens
             or _usage_value(usage, "cache_write_tokens")
+        )
+
+    metrics = getattr(response, "metrics", None)
+    if metrics is not None:
+        invocation.input_tokens = invocation.input_tokens or _usage_value(
+            metrics, "input_tokens", "prompt_tokens"
+        )
+        invocation.output_tokens = invocation.output_tokens or _usage_value(
+            metrics, "output_tokens", "completion_tokens"
+        )
+        invocation.usage_cache_read_input_tokens = (
+            invocation.usage_cache_read_input_tokens
+            or _usage_value(metrics, "cache_read_tokens")
+        )
+        invocation.usage_cache_creation_input_tokens = (
+            invocation.usage_cache_creation_input_tokens
+            or _usage_value(metrics, "cache_write_tokens")
         )
 
 

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agno/tests/test_agno.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agno/tests/test_agno.py
@@ -24,6 +24,7 @@ import pytest
 from agno.agent import Agent
 from agno.metrics import MessageMetrics
 from agno.models.base import Model
+from agno.models.message import Message
 from agno.models.response import ModelResponse
 from agno.tools.function import Function, FunctionCall
 
@@ -110,6 +111,81 @@ class EchoModel(Model):
         return response
 
 
+class ToolLoopModel(Model):
+    def __init__(self):
+        super().__init__(
+            id="tool-loop-model",
+            name="tool-loop",
+            provider="test",
+        )
+        self.calls = 0
+
+    def _next_response(self) -> ModelResponse:
+        self.calls += 1
+        if self.calls % 2 == 1:
+            return ModelResponse(
+                role="assistant",
+                tool_calls=[
+                    {
+                        "id": "call_weather",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"city":"Hangzhou"}',
+                        },
+                    }
+                ],
+                response_usage=MessageMetrics(
+                    input_tokens=10,
+                    output_tokens=2,
+                    cache_read_tokens=4,
+                ),
+            )
+        return ModelResponse(
+            role="assistant",
+            content="sunny in Hangzhou",
+            response_usage=MessageMetrics(input_tokens=20, output_tokens=3),
+        )
+
+    def invoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return self._next_response()
+
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        return self._next_response()
+
+    def invoke_stream(self, *args: Any, **kwargs: Any) -> Iterator[Any]:
+        response = self._next_response()
+        if response.tool_calls:
+            yield ModelResponse(
+                role="assistant",
+                tool_calls=response.tool_calls,
+                response_usage=response.response_usage,
+            )
+            return
+        yield ModelResponse(
+            role="assistant",
+            content="sunny ",
+            response_usage=MessageMetrics(input_tokens=20, output_tokens=1),
+        )
+        yield ModelResponse(
+            role="assistant",
+            content="in Hangzhou",
+            response_usage=MessageMetrics(output_tokens=2),
+        )
+
+    async def ainvoke_stream(self, *args: Any, **kwargs: Any) -> AsyncIterator:
+        for response in self.invoke_stream(*args, **kwargs):
+            yield response
+
+    def _parse_provider_response(
+        self, response: Any, **kwargs: Any
+    ) -> ModelResponse:
+        return response
+
+    def _parse_provider_response_delta(self, response: Any) -> ModelResponse:
+        return response
+
+
 @pytest.fixture
 def span_exporter() -> InMemorySpanExporter:
     return InMemorySpanExporter()
@@ -137,6 +213,73 @@ def instrument(tracer_provider: trace_api.TracerProvider):
 
 def _spans_by_name(span_exporter: InMemorySpanExporter):
     return {span.name: span for span in span_exporter.get_finished_spans()}
+
+
+def _spans_by_kind(
+    span_exporter: InMemorySpanExporter, span_kind: str
+) -> list[Any]:
+    return sorted(
+        [
+            span
+            for span in span_exporter.get_finished_spans()
+            if span.attributes.get("gen_ai.span.kind") == span_kind
+        ],
+        key=lambda span: span.start_time,
+    )
+
+
+def _weather_tool() -> Function:
+    fn = Function.from_callable(lambda city: f"weather for {city}: sunny")
+    fn.name = "get_weather"
+    return fn
+
+
+def _assert_tool_loop_tree(
+    span_exporter: InMemorySpanExporter,
+    agent_name: str,
+) -> None:
+    agent_spans = _spans_by_kind(span_exporter, "AGENT")
+    step_spans = _spans_by_kind(span_exporter, "STEP")
+    llm_spans = _spans_by_kind(span_exporter, "LLM")
+    tool_spans = _spans_by_kind(span_exporter, "TOOL")
+
+    agent_span = next(
+        span
+        for span in agent_spans
+        if span.name == f"invoke_agent {agent_name}"
+    )
+    assert len(step_spans) == 2
+    assert len(llm_spans) == 2
+    assert len(tool_spans) == 1
+
+    for step_span in step_spans:
+        assert step_span.parent is not None
+        assert step_span.parent.span_id == agent_span.context.span_id
+
+    assert llm_spans[0].parent is not None
+    assert llm_spans[0].parent.span_id == step_spans[0].context.span_id
+    assert tool_spans[0].parent is not None
+    assert tool_spans[0].parent.span_id == step_spans[0].context.span_id
+    assert llm_spans[1].parent is not None
+    assert llm_spans[1].parent.span_id == step_spans[1].context.span_id
+
+    assert step_spans[0].attributes["gen_ai.react.round"] == 1
+    assert step_spans[0].attributes["gen_ai.react.finish_reason"] == (
+        "tool_calls"
+    )
+    assert step_spans[1].attributes["gen_ai.react.round"] == 2
+    assert step_spans[1].attributes["gen_ai.react.finish_reason"] == "stop"
+
+    assert [
+        span.attributes["gen_ai.usage.total_tokens"] for span in llm_spans
+    ] == [
+        12,
+        23,
+    ]
+    assert agent_span.attributes["gen_ai.usage.input_tokens"] == 30
+    assert agent_span.attributes["gen_ai.usage.output_tokens"] == 5
+    assert agent_span.attributes["gen_ai.usage.total_tokens"] == 35
+    assert agent_span.attributes["gen_ai.usage.cache_read.input_tokens"] == 4
 
 
 class RecordingHandler:
@@ -707,6 +850,83 @@ def test_async_streaming_agent_identity_is_scoped_between_yields(
     assert model_attrs["gen_ai.session.id"] == "async-scoped-stream-session"
     assert "gen_ai.user.id" not in tool_attrs
     assert "gen_ai.session.id" not in tool_attrs
+
+
+def test_tool_call_loop_emits_react_steps_and_split_llm_spans(
+    span_exporter: InMemorySpanExporter,
+):
+    agent = Agent(
+        name="ToolLoopAgent",
+        model=ToolLoopModel(),
+        tools=[_weather_tool()],
+    )
+
+    response = agent.run("what is the weather")
+
+    assert response.content == "sunny in Hangzhou"
+    _assert_tool_loop_tree(span_exporter, "ToolLoopAgent")
+
+
+def test_async_tool_call_loop_emits_react_steps_and_split_llm_spans(
+    span_exporter: InMemorySpanExporter,
+):
+    async def run_agent():
+        agent = Agent(
+            name="AsyncToolLoopAgent",
+            model=ToolLoopModel(),
+            tools=[_weather_tool()],
+        )
+        return await agent.arun("what is the weather")
+
+    response = asyncio.run(run_agent())
+
+    assert response.content == "sunny in Hangzhou"
+    _assert_tool_loop_tree(span_exporter, "AsyncToolLoopAgent")
+
+
+def test_stream_tool_call_loop_emits_agent_tokens_and_split_llm_spans(
+    span_exporter: InMemorySpanExporter,
+):
+    agent = Agent(
+        name="StreamToolLoopAgent",
+        model=ToolLoopModel(),
+        tools=[_weather_tool()],
+    )
+
+    list(agent.run("what is the weather", stream=True))
+
+    _assert_tool_loop_tree(span_exporter, "StreamToolLoopAgent")
+
+
+def test_async_stream_tool_call_loop_emits_agent_tokens_and_split_llm_spans(
+    span_exporter: InMemorySpanExporter,
+):
+    async def run_agent():
+        agent = Agent(
+            name="AsyncStreamToolLoopAgent",
+            model=ToolLoopModel(),
+            tools=[_weather_tool()],
+        )
+        async for _event in agent.arun("what is the weather", stream=True):
+            pass
+
+    asyncio.run(run_agent())
+
+    _assert_tool_loop_tree(span_exporter, "AsyncStreamToolLoopAgent")
+
+
+def test_direct_model_call_without_agent_does_not_emit_react_step(
+    span_exporter: InMemorySpanExporter,
+):
+    model = EchoModel()
+
+    response = model.response(
+        messages=[Message(role="user", content="say hello")]
+    )
+
+    assert response.content == "hello"
+    assert len(_spans_by_kind(span_exporter, "LLM")) == 1
+    assert len(_spans_by_kind(span_exporter, "STEP")) == 0
 
 
 def test_concurrent_runs_do_not_drop_spans(

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agno/tests/test_agno.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agno/tests/test_agno.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 from typing import Any, AsyncIterator, Iterator
@@ -186,6 +187,64 @@ class ToolLoopModel(Model):
         return response
 
 
+class LatencyToolLoopModel(ToolLoopModel):
+    def __init__(self, delay_s: float = 0.03):
+        super().__init__()
+        self.delay_s = delay_s
+
+    def invoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        time.sleep(self.delay_s)
+        return self._next_response()
+
+    async def ainvoke(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        await asyncio.sleep(self.delay_s)
+        return self._next_response()
+
+    def invoke_stream(self, *args: Any, **kwargs: Any) -> Iterator[Any]:
+        response = self._next_response()
+        time.sleep(self.delay_s)
+        if response.tool_calls:
+            yield ModelResponse(
+                role="assistant",
+                tool_calls=response.tool_calls,
+                response_usage=response.response_usage,
+            )
+            return
+        yield ModelResponse(
+            role="assistant",
+            content="sunny ",
+            response_usage=MessageMetrics(input_tokens=20, output_tokens=1),
+        )
+        time.sleep(self.delay_s)
+        yield ModelResponse(
+            role="assistant",
+            content="in Hangzhou",
+            response_usage=MessageMetrics(output_tokens=2),
+        )
+
+    async def ainvoke_stream(self, *args: Any, **kwargs: Any) -> AsyncIterator:
+        response = self._next_response()
+        await asyncio.sleep(self.delay_s)
+        if response.tool_calls:
+            yield ModelResponse(
+                role="assistant",
+                tool_calls=response.tool_calls,
+                response_usage=response.response_usage,
+            )
+            return
+        yield ModelResponse(
+            role="assistant",
+            content="sunny ",
+            response_usage=MessageMetrics(input_tokens=20, output_tokens=1),
+        )
+        await asyncio.sleep(self.delay_s)
+        yield ModelResponse(
+            role="assistant",
+            content="in Hangzhou",
+            response_usage=MessageMetrics(output_tokens=2),
+        )
+
+
 @pytest.fixture
 def span_exporter() -> InMemorySpanExporter:
     return InMemorySpanExporter()
@@ -226,6 +285,10 @@ def _spans_by_kind(
         ],
         key=lambda span: span.start_time,
     )
+
+
+def _duration_ms(span: Any) -> float:
+    return (span.end_time - span.start_time) / 1_000_000
 
 
 def _weather_tool() -> Function:
@@ -896,6 +959,40 @@ def test_stream_tool_call_loop_emits_agent_tokens_and_split_llm_spans(
     list(agent.run("what is the weather", stream=True))
 
     _assert_tool_loop_tree(span_exporter, "StreamToolLoopAgent")
+
+
+def test_tool_call_loop_llm_spans_cover_provider_latency(
+    span_exporter: InMemorySpanExporter,
+):
+    agent = Agent(
+        name="LatencyToolLoopAgent",
+        model=LatencyToolLoopModel(),
+        tools=[_weather_tool()],
+        telemetry=False,
+    )
+
+    agent.run("what is the weather")
+
+    llm_spans = _spans_by_kind(span_exporter, "LLM")
+    assert len(llm_spans) == 2
+    assert all(_duration_ms(span) >= 25 for span in llm_spans)
+
+
+def test_stream_tool_call_loop_llm_spans_cover_provider_latency(
+    span_exporter: InMemorySpanExporter,
+):
+    agent = Agent(
+        name="LatencyStreamToolLoopAgent",
+        model=LatencyToolLoopModel(),
+        tools=[_weather_tool()],
+        telemetry=False,
+    )
+
+    list(agent.run("what is the weather", stream=True))
+
+    llm_spans = _spans_by_kind(span_exporter, "LLM")
+    assert len(llm_spans) == 2
+    assert all(_duration_ms(span) >= 25 for span in llm_spans)
 
 
 def test_async_stream_tool_call_loop_emits_agent_tokens_and_split_llm_spans(


### PR DESCRIPTION
# Description

This fixes Agno 2.x tool-call loop instrumentation so every real model provider request is emitted as its own `chat` span under a ReAct step, instead of wrapping the whole Agno model response loop as one LLM span.

The change keeps direct `Model.response` usage covered through a fallback wrapper, but uses Agno's per-request processing hooks when they are available. Streaming agent token totals now fall back to the sum of child LLM spans when Agno does not expose final run metrics.

Fixes no existing issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] `tox -c tox-loongsuite.ini -e py311-test-loongsuite-instrumentation-agno -- -q`
- [x] `tox -c tox-loongsuite.ini -e py39-test-loongsuite-instrumentation-agno,py313-test-loongsuite-instrumentation-agno -- -q`
- [x] `tox -c tox-loongsuite.ini -e lint-loongsuite-instrumentation-agno`
- [x] `tox -e precommit`
- [x] `python "$PIPELINE_SKILL_DIR/scripts/check_loongsuite_pr_readiness.py" --repo .`

## Validation Evidence

### Spec and Scope
- Linked issue/spec: none
- Approved spec/comment: requested Agno tool-call loop / ReAct span repair
- Changed surface: `loongsuite-instrumentation-agno` instrumentation hooks, span/token aggregation logic, and focused Agno tests

### Local Checks
| Check | Command | Result | Notes |
| --- | --- | --- | --- |
| Static readiness | `python "$PIPELINE_SKILL_DIR/scripts/check_loongsuite_pr_readiness.py" --repo .` | pass | |
| Precommit | `tox -e precommit` | pass | |
| Focused tests | `tox -c tox-loongsuite.ini -e py311-test-loongsuite-instrumentation-agno -- -q` | pass | 36 tests |
| Version edge tests | `tox -c tox-loongsuite.ini -e py39-test-loongsuite-instrumentation-agno,py313-test-loongsuite-instrumentation-agno -- -q` | pass | 36 tests on each env |
| Focused lint | `tox -c tox-loongsuite.ini -e lint-loongsuite-instrumentation-agno` | pass | |
| Privacy scan | changed-file scan for secrets and private trace material | pass | no hits |

### Real E2E Matrix
| Scenario | Status | Command or Demo | Evidence |
| --- | --- | --- | --- |
| non-streaming | pass | deterministic Agno 2.x latency tool-call smoke with OTLP export | ARMS/CMS cloud readback verified; LLM/tool durations match injected provider/tool latency |
| streaming | pass | deterministic Agno 2.x streaming latency tool-call smoke with OTLP export | agent and child LLM token totals verified in ARMS/CMS; streaming LLM span covers chunk interval |
| concurrency | pass | concurrent `Agent.arun(stream=True)` smoke | no round/token/context leakage observed |
| agent/tool/ReAct | pass | deterministic two-round tool-call loop | tree verified as Agent -> Step -> LLM/Tool -> Step -> LLM |
| tool-heavy | N/A | not part of this bug surface | focused fix covers one tool-call batch per round |
| error path | pass | focused unit coverage for stream close/cancel cleanup | ContextVar cleanup verified |

### Telemetry and Weaver
| Check | Status | Command or Artifact | Notes |
| --- | --- | --- | --- |
| Span tree / span kinds | pass | local in-memory spans plus ARMS/CMS cloud readback | tool spans are siblings of LLM spans under ReAct step |
| Span timing | pass | local in-memory spans plus ARMS/CMS cloud readback | LLM spans cover provider latency; tool spans cover tool execution latency |
| Token totals | pass | local in-memory spans plus ARMS/CMS cloud readback | agent total equals sum of child LLM totals |
| Concurrency isolation | pass | concurrent async streaming smoke | per-run ReAct rounds and token aggregation remain isolated |
| Weaver live-check | pass | `weaver registry live-check --advice-profile loongsuite-genai ...` | no violations |

### CI
- GitHub checks: not run yet
- Known unrelated failures: none known
- Follow-up needed: inspect GitHub Actions after PR creation

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
