### PR TITLE
fix(agentscope): start streaming LLM spans before model calls

### DIFF
--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Start AgentScope v2 streaming LLM spans before invoking the underlying model
+  call so TTFT and stream lifecycle are recorded on the framework LLM span.
+- Capture AgentScope v2 string message content as text parts so LLM input and
+  output message attributes are populated when content capture is enabled.
+
 ## Version 0.7.0 (2026-07-03)
 
 ### Added

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/_v2_middleware.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/_v2_middleware.py
@@ -31,7 +31,7 @@ from agentscope.middleware import MiddlewareBase
 from agentscope.model import ChatModelBase, ChatResponse
 from agentscope.tool import ToolResponse
 
-from opentelemetry.context import Context, get_current
+from opentelemetry.context import get_current
 from opentelemetry.util.genai.extended_handler import ExtendedTelemetryHandler
 from opentelemetry.util.genai.extended_types import (
     ExecuteToolInvocation,
@@ -175,30 +175,20 @@ class AgentScopeV2Middleware(MiddlewareBase):
 
         invocation = _create_llm_invocation(model, input_kwargs)
         span_context = get_current()
-        started = False
-        if not _is_streaming_model(model, input_kwargs):
-            handler.start_llm(invocation, context=span_context)
-            started = True
+        handler.start_llm(invocation, context=span_context)
         try:
             result = await next_handler(**input_kwargs)
             if inspect.isasyncgen(result):
                 return self._wrap_model_stream(
                     result,
                     invocation,
-                    span_context,
                     handler,
-                    span_started=started,
                 )
 
-            if not started:
-                handler.start_llm(invocation, context=span_context)
-                started = True
             _finish_llm_invocation(invocation, result)
             handler.stop_llm(invocation)
             return result
         except BaseException as exc:
-            if not started:
-                handler.start_llm(invocation, context=span_context)
             handler.fail_llm(
                 invocation,
                 Error(message=str(exc) or type(exc).__name__, type=type(exc)),
@@ -209,17 +199,11 @@ class AgentScopeV2Middleware(MiddlewareBase):
         self,
         result: AsyncGenerator[ChatResponse, None],
         invocation: LLMInvocation,
-        span_context: Context,
         handler: ExtendedTelemetryHandler,
-        *,
-        span_started: bool,
     ) -> AsyncGenerator[ChatResponse, None]:
         first_token_seen = False
         last_chunk = None
         closed = False
-        if not span_started:
-            handler.start_llm(invocation, context=span_context)
-            span_started = True
         try:
             async for chunk in result:
                 if not first_token_seen:
@@ -239,7 +223,7 @@ class AgentScopeV2Middleware(MiddlewareBase):
             handler.stop_llm(invocation)
             closed = True
         finally:
-            if span_started and not closed:
+            if not closed:
                 handler.stop_llm(invocation)
 
     async def on_acting(
@@ -402,6 +386,10 @@ def _chat_response_to_output(response: ChatResponse) -> OutputMessage:
 
 
 def _blocks_to_parts(blocks: Sequence[Any]) -> list[Any]:
+    if blocks is None:
+        return []
+    if isinstance(blocks, str):
+        return [Text(content=blocks)]
     parts = []
     for block in blocks:
         block_type = getattr(block, "type", None)

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/test_v2_instrumentation.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/test_v2_instrumentation.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib.metadata
+import json
 import os
 from dataclasses import asdict
 from types import SimpleNamespace
@@ -41,12 +42,16 @@ from agentscope.message import (  # noqa: E402
 from agentscope.model import ChatResponse, DashScopeChatModel  # noqa: E402
 from agentscope.tool import ToolResponse  # noqa: E402
 
+from opentelemetry import trace as trace_api  # noqa: E402
 from opentelemetry.instrumentation.agentscope._v2_middleware import (  # noqa: E402
     AgentScopeV2Middleware,
     _message_to_input,
 )
 from opentelemetry.instrumentation.agentscope.package import (  # noqa: E402
     get_installed_instrumentation_dependencies,
+)
+from opentelemetry.semconv._incubating.attributes import (  # noqa: E402
+    gen_ai_attributes as GenAI,
 )
 from opentelemetry.trace.status import StatusCode  # noqa: E402
 from opentelemetry.util.genai.utils import gen_ai_json_dumps  # noqa: E402
@@ -207,6 +212,114 @@ async def test_v2_streaming_model_call_error_path(instrument, span_exporter):
     span = _spans_by_operation(span_exporter.get_finished_spans(), "chat")[0]
     assert span.status.status_code == StatusCode.ERROR
     assert span.attributes["error.type"] == "RuntimeError"
+
+
+async def test_v2_streaming_model_call_starts_llm_span_before_model_handler(
+    instrument,
+    span_exporter,
+):
+    agent = Agent(
+        name="stream_suppression_agent",
+        system_prompt="Reply briefly.",
+        model=_make_model(stream=True),
+    )
+    middleware = _middleware(agent._model_call_middlewares)
+    observed_current_span_ids = []
+    consumer_current_span_ids = []
+
+    async def stream_handler(**kwargs):
+        del kwargs
+        observed_current_span_ids.append(
+            trace_api.get_current_span().get_span_context().span_id
+        )
+
+        async def stream():
+            observed_current_span_ids.append(
+                trace_api.get_current_span().get_span_context().span_id
+            )
+            yield ChatResponse(
+                content=[TextBlock(text="partial")],
+                is_last=False,
+            )
+            observed_current_span_ids.append(
+                trace_api.get_current_span().get_span_context().span_id
+            )
+            yield ChatResponse(
+                content=[TextBlock(text="done")],
+                is_last=True,
+            )
+
+        return stream()
+
+    stream = await middleware.on_model_call(
+        agent,
+        {
+            "current_model": agent.model,
+            "messages": [UserMsg(name="user", content="hello")],
+        },
+        stream_handler,
+    )
+
+    async for _ in stream:
+        consumer_current_span_ids.append(
+            trace_api.get_current_span().get_span_context().span_id
+        )
+
+    spans = _spans_by_operation(span_exporter.get_finished_spans(), "chat")
+    assert len(spans) == 1
+    llm_span_id = spans[0].context.span_id
+    assert observed_current_span_ids == [llm_span_id, llm_span_id, llm_span_id]
+    assert consumer_current_span_ids == [llm_span_id, llm_span_id]
+    assert (
+        trace_api.get_current_span().get_span_context().span_id != llm_span_id
+    )
+
+
+async def test_v2_streaming_model_call_captures_input_and_output_content(
+    instrument_with_content,
+    span_exporter,
+):
+    agent = Agent(
+        name="stream_content_agent",
+        system_prompt="Reply briefly.",
+        model=_make_model(stream=True),
+    )
+    middleware = _middleware(agent._model_call_middlewares)
+
+    async def stream_handler(**kwargs):
+        del kwargs
+
+        async def stream():
+            yield ChatResponse(
+                content=[TextBlock(text="partial")],
+                is_last=False,
+            )
+            yield ChatResponse(
+                content=[TextBlock(text="done")],
+                is_last=True,
+            )
+
+        return stream()
+
+    stream = await middleware.on_model_call(
+        agent,
+        {
+            "current_model": agent.model,
+            "messages": [UserMsg(name="user", content="hello")],
+        },
+        stream_handler,
+    )
+
+    async for _ in stream:
+        pass
+
+    span = _spans_by_operation(span_exporter.get_finished_spans(), "chat")[0]
+    input_messages = json.loads(span.attributes[GenAI.GEN_AI_INPUT_MESSAGES])
+    output_messages = json.loads(span.attributes[GenAI.GEN_AI_OUTPUT_MESSAGES])
+    assert input_messages[0]["role"] == "user"
+    assert input_messages[0]["parts"][0]["content"] == "hello"
+    assert output_messages[0]["role"] == "assistant"
+    assert output_messages[0]["parts"][0]["content"] == "done"
 
 
 async def test_v2_tool_acting_hook(instrument, span_exporter):


### PR DESCRIPTION
# Description

This PR fixes AgentScope v2 streaming model-call telemetry so the framework LLM span starts before the underlying model handler is invoked. This keeps the util-genai context active during the provider call, which prevents duplicate provider LLM spans in full-agent installations while preserving TTFT, token usage, stream finalization, and captured input/output messages on the framework span.

Fixes # (N/A)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] `tox -c tox-loongsuite.ini -e py312-test-loongsuite-instrumentation-agentscope-latest`
- [x] `tox -c tox-loongsuite.ini -e py312-test-loongsuite-instrumentation-agentscope-oldest`
- [x] `tox -c tox-loongsuite.ini -e lint-loongsuite-instrumentation-agentscope`
- [x] `PRE_COMMIT_HOME="$(mktemp -d)" tox -e precommit`
- [x] `git diff --check`
- [x] Weaver live-check on a generated AgentScope v2 streaming JSON span sample, using the `loongsuite-genai` advice profile
- [x] Downstream full-agent live smoke for AgentScope v2 streaming confirmed one framework LLM span and one provider HTTP span, with no duplicate provider LLM span

## Validation Evidence

### Spec and Scope
- Linked issue/spec: N/A. Fixes the observed duplicate AgentScope v2 streaming LLM telemetry when framework and provider instrumentation are both active.
- Approved spec/comment: direct maintainer request in this thread.
- Changed surface: `loongsuite-instrumentation-agentscope` v2 middleware, tests, and package changelog.

### Local Checks
| Check | Command | Result | Notes |
| --- | --- | --- | --- |
| Static readiness | LoongSuite pipeline static PR readiness checker | pass | No readiness blockers reported. |
| Change detector | Pull-request event simulation for changed files | pass | `packages=|loongsuite-instrumentation-agentscope|`, `full=false`. |
| Precommit | `PRE_COMMIT_HOME="$(mktemp -d)" tox -e precommit` | pass | Fresh pre-commit hook cache. |
| Focused tests | `tox -c tox-loongsuite.ini -e py312-test-loongsuite-instrumentation-agentscope-latest` | pass | 15 passed. Covers AgentScope v2 streaming span ordering and content capture. |
| Focused tests | `tox -c tox-loongsuite.ini -e py312-test-loongsuite-instrumentation-agentscope-oldest` | pass | 94 passed. Maintains older AgentScope compatibility. |
| Focused lint | `tox -c tox-loongsuite.ini -e lint-loongsuite-instrumentation-agentscope` | pass | Ruff check passed. |
| External review | Codex/Qoder review loop | pass | Deep review found no blocking findings; advisory generator-lifecycle risks are deferred as non-blocking. |
| Privacy scan | Branch diff scan for credentials, private trace IDs, local paths, and internal artifacts | pass | No sensitive content found in the PR diff. |

### Real E2E Matrix
| Scenario | Status | Command or Demo | Evidence |
| --- | --- | --- | --- |
| non-streaming | pass | `py312-test-loongsuite-instrumentation-agentscope-latest` | AgentScope v2 non-streaming E2E test passed. |
| streaming | pass | `py312-test-loongsuite-instrumentation-agentscope-latest`; downstream full-agent live smoke | Streaming E2E passed; live smoke confirmed one framework LLM span plus provider HTTP span, without duplicate provider LLM span. |
| concurrency | pass | `py312-test-loongsuite-instrumentation-agentscope-latest` | Concurrent AgentScope v2 E2E test produced isolated agent and LLM spans. |
| agent/tool/ReAct | pass | `py312-test-loongsuite-instrumentation-agentscope-latest` | Tool and ReAct telemetry tests passed. |
| tool-heavy | pass | `py312-test-loongsuite-instrumentation-agentscope-latest` | Multi-tool ReAct telemetry test passed. |
| error path | pass | `py312-test-loongsuite-instrumentation-agentscope-latest` | Non-streaming and streaming model error-path tests passed. |

### Telemetry and Weaver
| Check | Status | Command or Artifact | Notes |
| --- | --- | --- | --- |
| Span tree / span kinds | pass | Focused AgentScope v2 tests and downstream full-agent live smoke | Streaming path now emits a single framework LLM span under the agent span and a provider HTTP child span. |
| Content capture modes | pass | `py312-test-loongsuite-instrumentation-agentscope-latest` | New streaming test verifies `gen_ai.input.messages` and `gen_ai.output.messages` in SPAN_ONLY mode; NO_CONTENT behavior is unchanged by this diff. |
| Concurrency isolation | pass | `py312-test-loongsuite-instrumentation-agentscope-latest` | Concurrent AgentScope v2 E2E test passed. |
| Weaver live-check | pass | `weaver registry live-check -r <loongsuite-semantic-conventions>/model --input-source <generated AgentScope v2 streaming JSON sample> --input-format json --advice-profile loongsuite-genai --skip-policies true` | Exit 0, no violations. Only expected development-stability advice was reported. |

### CI
- GitHub checks: not started yet; this PR has not been opened at the time of local validation.
- Known unrelated failures: none known.
- Follow-up needed: inspect GitHub checks after the PR is opened.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR:
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated
