### PR TITLE
docs: update LoongSuite Java references

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -14,7 +14,7 @@ LoongSuite 包含以下核心组件：
 * [LoongCollector](https://github.com/alibaba/loongcollector)：通用节点 Agent，基于 eBPF 提供日志采集、Prometheus 指标采集以及网络与安全采集能力。
 * [LoongSuite Python Agent](https://github.com/alibaba/loongsuite-python)：为 Python 应用提供埋点能力的进程 Agent。
 * [LoongSuite Go Agent](https://github.com/alibaba/loongsuite-go)：支持编译期埋点的 Golang 进程 Agent。
-* [LoongSuite Java Agent](https://github.com/alibaba/loongsuite-java-agent)：面向 Java 应用的进程 Agent。
+* [LoongSuite Java](https://github.com/alibaba/loongsuite-java)：面向 Java GenAI 埋点的共享遥测工具库。
 * 其他语言 Agent 正在建设中。
 
 LoongSuite Python Agent 同时也是上游 [OTel Python Agent](https://github.com/open-telemetry/opentelemetry-python-contrib) 的定制化发行版，增强了对主流 AI Agent 框架的支持。

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ LoongSuite includes the following key components:
 * [LoongCollector](https://github.com/alibaba/loongcollector): universal node agent, which prodivdes log collection, prometheus metric collection, and network and security collection capabilities based on eBPF.
 * [LoongSuite Python Agent](https://github.com/alibaba/loongsuite-python): a process agent providing instrumentation for python applications.
 * [LoongSuite Go Agent](https://github.com/alibaba/loongsuite-go): a process agent for golang with compile time instrumentation.
-* [LoongSuite Java Agent](https://github.com/alibaba/loongsuite-java-agent): a process agent for Java applications.
+* [LoongSuite Java](https://github.com/alibaba/loongsuite-java): a shared telemetry utility library for Java GenAI instrumentation.
 * Other upcoming language agent.
 
 Loongsuite Python Agent is also a customized distribution of upstream [OTel Python Agent](https://github.com/open-telemetry/opentelemetry-python-contrib), with enhanced support for popular AI agent framework. 


### PR DESCRIPTION
# Description

This PR updates the English and Chinese root READMEs to:

- use the canonical `alibaba/loongsuite-java` repository URL;
- describe LoongSuite Java according to its current public scope as a shared telemetry utility library for Java GenAI instrumentation, instead of a Java process agent.

Fixes: N/A (documentation-only correction requested directly).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] `tox -e precommit`
- [x] Confirmed the obsolete repository/name/description no longer appears in either root README
- [x] Confirmed the canonical repository URL resolves successfully
- [x] `git diff --check`

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR:
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [x] Documentation has been updated

The changelog and unit-test items are not applicable because this PR only corrects component links and descriptions in the root documentation. The PR uses the `Skip Changelog` label.

## Validation Evidence

### Spec and Scope

- Linked issue/spec: N/A; documentation-only correction requested directly.
- Approved scope: update the outdated Java repository naming and description in both root READMEs.
- Changed surface: `README.md` and `README-zh.md`.
- Non-goals: runtime behavior, instrumentation packages, semantic conventions, installation flow, and other LoongSuite component descriptions.

### Local Checks

| Check | Result | Notes |
| --- | --- | --- |
| Static PR readiness | Pass | The only warning is expected: no instrumentation plugin directory changed. |
| Full pre-commit suite | Pass | Ruff, Ruff format, uv-lock, and rstcheck passed from a fresh pre-commit cache. |
| Focused documentation checks | Pass | No obsolete Java repository/name/description remains; the canonical link returned HTTP 200; `git diff --check` passed. |
| Change detector | Pass | Classified as no LoongSuite package changes, as expected for root documentation only. |
| External read-only review | Pass | Zero findings and zero blocking findings. |
| Privacy scan | Pass | No local paths, credentials, or secret-like values appear in the branch diff. |

### Runtime and Telemetry

- Business isolation: N/A; no application or instrumentation code changed.
- Real E2E validation: N/A; no runtime behavior changed.
- Telemetry/semantic-convention validation: N/A; no telemetry schema or emitted data changed.
- Weaver validation: N/A; no semantic-convention registry or advice profile changed.

### CI

- GitHub checks: pending until the PR is published.
- Known unrelated failures: none.
