### PR TITLE
fix(agentscope): preserve v2 ReAct hierarchy across tasks

### DIFF
--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/CHANGELOG.md
@@ -18,8 +18,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Start AgentScope v2 streaming LLM spans before invoking the underlying model,
   restore their context for each stream operation, and treat cross-task
   `GeneratorExit` as a successful close while preserving TTFT.
+- Model AgentScope v2 ReAct iterations from `on_reasoning` so each `react step`
+  span parents both its LLM call and tool executions, including concurrent
+  tools and QwenPaw cross-task stream handoffs.
 - Capture AgentScope v2 string message content as text parts so LLM input and
   output message attributes are populated when content capture is enabled.
+
+### Added
+
+- Capture `gen_ai.skill.name`, `gen_ai.skill.id`, and available skill metadata
+  on AgentScope v2 built-in `Skill` viewer tool spans.
 
 ## Version 0.7.0 (2026-07-03)
 

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/CHANGELOG.md
@@ -15,8 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Restore Agent, ReAct, and tool span contexts for each stream advance so
   cross-task QwenPaw handoffs preserve parentage, and treat `GeneratorExit` as
   a successful stream close instead of a tool failure.
-- Start AgentScope v2 streaming LLM spans before invoking the underlying model
-  call so TTFT and stream lifecycle are recorded on the framework LLM span.
+- Start AgentScope v2 streaming LLM spans before invoking the underlying model,
+  restore their context for each stream operation, and treat cross-task
+  `GeneratorExit` as a successful close while preserving TTFT.
 - Capture AgentScope v2 string message content as text parts so LLM input and
   output message attributes are populated when content capture is enabled.
 

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/README.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/README.md
@@ -103,6 +103,12 @@ with:
 - `gen_ai.skill.description`
 - `gen_ai.skill.version`
 
+AgentScope v2 exposes skill loading through its built-in `Skill` viewer tool.
+The v2 middleware records the requested `skill` argument as
+`gen_ai.skill.name` and `gen_ai.skill.id`; when QwenPaw or AgentScope exposes
+the registered skill directory, it also resolves the available description,
+workspace-scoped id, and version metadata.
+
 The matching is intentionally conservative:
 
 - only registered skills can match

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/_skill.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/_skill.py
@@ -1,0 +1,95 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AgentScope-version-independent skill metadata helpers."""
+
+from __future__ import annotations
+
+import json
+from importlib import import_module
+from pathlib import Path
+from typing import Any
+
+_SKILL_MANIFEST = "SKILL.md"
+
+
+def _enrich_skill_metadata(skill: dict[str, Any]) -> dict[str, Any]:
+    """Enrich a skill mapping with a version and runtime-scoped identifier."""
+
+    skill_dir = skill.get("dir", "")
+    skill_name = skill.get("name", "")
+    if not skill_dir:
+        return dict(skill)
+
+    enriched = dict(skill)
+    version_text = None
+
+    try:
+        skills_manager = import_module("copaw.agents.skills_manager")
+        post = skills_manager._read_frontmatter_safe(
+            Path(skill_dir), skill_name
+        )
+        version_text = skills_manager._extract_version(post)
+    except Exception:
+        version_text = None
+
+    if not version_text:
+        try:
+            frontmatter = import_module("frontmatter")
+            post = frontmatter.load(Path(skill_dir) / _SKILL_MANIFEST)
+            metadata = post.get("metadata") or {}
+            for value in (
+                post.get("version"),
+                metadata.get("version"),
+                metadata.get("builtin_skill_version"),
+            ):
+                if value not in (None, ""):
+                    version_text = str(value)
+                    break
+        except Exception:
+            version_text = None
+
+    if not version_text:
+        try:
+            skill_path = Path(skill_dir)
+            skill_json_path = skill_path.parent.parent / "skill.json"
+            if skill_json_path.exists():
+                payload = json.loads(
+                    skill_json_path.read_text(encoding="utf-8")
+                )
+                entry = payload.get("skills", {}).get(skill_name, {})
+                metadata = entry.get("metadata", {}) or {}
+                value = metadata.get("version_text")
+                if value not in (None, ""):
+                    version_text = str(value)
+        except Exception:
+            version_text = None
+
+    if version_text:
+        enriched["version"] = str(version_text)
+
+    try:
+        parts = str(skill_dir).replace("\\", "/").split("/")
+        workspace_name = "default"
+        try:
+            skills_idx = len(parts) - 1 - parts[::-1].index("skills")
+            if skills_idx >= 1:
+                workspace_name = parts[skills_idx - 1]
+        except ValueError:
+            pass
+        enriched["id"] = f"workspace:{workspace_name}:{skill_name}"
+    except Exception:
+        pass
+
+    return enriched

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/_v2_middleware.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/_v2_middleware.py
@@ -79,6 +79,16 @@ class _AgentState:
 
 
 @dataclass
+class _LLMState:
+    handler: ExtendedTelemetryHandler
+    invocation: LLMInvocation
+    context: Context
+    first_token_seen: bool = False
+    last_chunk: ChatResponse | None = None
+    finalized: bool = False
+
+
+@dataclass
 class _ActingState:
     handler: ExtendedTelemetryHandler
     react_invocation: ReactStepInvocation
@@ -97,6 +107,83 @@ def _abandon_invocation(invocation: Any) -> None:
     span = invocation.span
     if span is not None and span.is_recording():
         span.end()
+
+
+@hook_advice("agentscope", "start_llm")
+def _start_llm(
+    handler: ExtendedTelemetryHandler,
+    invocation: LLMInvocation,
+    context: Context,
+) -> _LLMState:
+    """Start LLM and capture its Context before stream ownership transfer."""
+
+    try:
+        handler.start_llm(invocation, context=context)
+        llm_context = get_current()
+    except Exception:
+        _abandon_invocation(invocation)
+        raise
+
+    return _LLMState(
+        handler=handler,
+        invocation=invocation,
+        context=llm_context,
+    )
+
+
+@hook_advice("agentscope", "release_llm_context")
+def _release_llm_context(state: _LLMState) -> bool:
+    """Detach the start token in its creation Task before returning a stream."""
+
+    token = state.invocation.context_token
+    state.invocation.context_token = None
+    _safe_detach(token)
+    return True
+
+
+@hook_advice("agentscope", "record_llm_chunk")
+def _record_llm_chunk(state: _LLMState, chunk: ChatResponse) -> None:
+    if not state.first_token_seen:
+        state.invocation.monotonic_first_token_s = timeit.default_timer()
+        state.first_token_seen = True
+    state.last_chunk = chunk
+
+
+@hook_advice("agentscope", "finish_llm")
+def _finish_llm(
+    state: _LLMState,
+    error: BaseException | None = None,
+) -> None:
+    if state.finalized:
+        return
+    state.finalized = True
+
+    invocation = state.invocation
+    token = None
+    callback_completed = False
+    span = invocation.span
+    try:
+        token = otel_context.attach(state.context)
+        invocation.context_token = token
+        if error is None or isinstance(error, GeneratorExit):
+            if error is None or getattr(state.last_chunk, "is_last", False):
+                _finish_llm_invocation(invocation, state.last_chunk)
+            state.handler.stop_llm(invocation)
+        else:
+            state.handler.fail_llm(
+                invocation,
+                Error(
+                    message=str(error) or type(error).__name__,
+                    type=type(error),
+                ),
+            )
+        callback_completed = True
+    finally:
+        invocation.context_token = None
+        if get_current() is state.context:
+            _safe_detach(token)
+        if not callback_completed and span is not None and span.is_recording():
+            span.end()
 
 
 @hook_advice("agentscope", "start_invoke_agent")
@@ -438,57 +525,63 @@ class AgentScopeV2Middleware(MiddlewareBase):
             return await next_handler(**input_kwargs)
 
         invocation = _create_llm_invocation(model, input_kwargs)
-        span_context = get_current()
-        handler.start_llm(invocation, context=span_context)
+        state = _start_llm(handler, invocation, get_current())
         try:
             result = await next_handler(**input_kwargs)
-            if inspect.isasyncgen(result):
-                return self._wrap_model_stream(
-                    result,
-                    invocation,
-                    handler,
-                )
-
-            _finish_llm_invocation(invocation, result)
-            handler.stop_llm(invocation)
-            return result
         except BaseException as exc:
-            handler.fail_llm(
-                invocation,
-                Error(message=str(exc) or type(exc).__name__, type=type(exc)),
-            )
+            if state is not None:
+                if _release_llm_context(state):
+                    _finish_llm(state, exc)
+                else:
+                    _abandon_invocation(invocation)
             raise
+        if state is None:
+            return result
+        if not _release_llm_context(state):
+            _abandon_invocation(invocation)
+            return result
+        if inspect.isasyncgen(result):
+            return self._wrap_model_stream(result, state)
+
+        state.last_chunk = result
+        _finish_llm(state)
+        return result
 
     async def _wrap_model_stream(
         self,
         result: AsyncGenerator[ChatResponse, None],
-        invocation: LLMInvocation,
-        handler: ExtendedTelemetryHandler,
+        state: _LLMState,
     ) -> AsyncGenerator[ChatResponse, None]:
-        first_token_seen = False
-        last_chunk = None
-        closed = False
+        iterator = result.__aiter__()
         try:
-            async for chunk in result:
-                if not first_token_seen:
-                    invocation.monotonic_first_token_s = timeit.default_timer()
-                    first_token_seen = True
-                last_chunk = chunk
+            while True:
+                token = _attach_stream_context(state.context)
+                try:
+                    chunk = await iterator.__anext__()
+                except StopAsyncIteration:
+                    break
+                finally:
+                    _detach_stream_context(token)
+
+                _record_llm_chunk(state, chunk)
                 yield chunk
-        except BaseException as exc:
-            handler.fail_llm(
-                invocation,
-                Error(message=str(exc) or type(exc).__name__, type=type(exc)),
-            )
-            closed = True
+        except GeneratorExit as exc:
+            token = _attach_stream_context(state.context)
+            try:
+                await _close_iterator(iterator)
+            except BaseException as close_error:
+                _finish_llm(state, close_error)
+                raise
+            finally:
+                _detach_stream_context(token)
+            _finish_llm(state, exc)
             raise
-        else:
-            _finish_llm_invocation(invocation, last_chunk)
-            handler.stop_llm(invocation)
-            closed = True
+        except BaseException as exc:
+            _finish_llm(state, exc)
+            raise
         finally:
-            if not closed:
-                handler.stop_llm(invocation)
+            if not state.finalized:
+                _finish_llm(state)
 
     async def on_acting(
         self,

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/_v2_middleware.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/_v2_middleware.py
@@ -58,6 +58,8 @@ from opentelemetry.util.genai.types import (
     ToolCallResponse,
 )
 
+from ._skill import _enrich_skill_metadata
+
 logger = logging.getLogger(__name__)
 
 _MIDDLEWARE_PARAMETER = "middlewares"
@@ -69,12 +71,23 @@ _FIRST_TOKEN_EVENT_TYPES = {
 
 
 @dataclass
+class _ReactState:
+    handler: ExtendedTelemetryHandler
+    invocation: ReactStepInvocation
+    context: Context
+    finish_reason: str | None = None
+    error: BaseException | None = None
+    finalized: bool = False
+
+
+@dataclass
 class _AgentState:
     handler: ExtendedTelemetryHandler
     invocation: InvokeAgentInvocation
     context: Context
     first_token_seen: bool = False
     last_msg: Msg | None = None
+    active_react: _ReactState | None = None
     finalized: bool = False
 
 
@@ -91,13 +104,12 @@ class _LLMState:
 @dataclass
 class _ActingState:
     handler: ExtendedTelemetryHandler
-    react_invocation: ReactStepInvocation
     tool_invocation: ExecuteToolInvocation
-    react_context: Context
     tool_context: Context
+    react_state: _ReactState | None = None
+    owns_react: bool = False
     last_item: Any = None
     tool_finalized: bool = False
-    react_finalized: bool = False
 
 
 def _abandon_invocation(invocation: Any) -> None:
@@ -267,12 +279,12 @@ def _finish_agent(
             span.end()
 
 
-@hook_advice("agentscope", "start_acting")
-def _start_acting(
+@hook_advice("agentscope", "start_react_step")
+def _start_react(
     handler: ExtendedTelemetryHandler,
     agent: Agent,
-    tool_call: Any,
-) -> _ActingState:
+    context: Context,
+) -> _ReactState:
     react_invocation = ReactStepInvocation(
         round=getattr(
             getattr(agent, "state", None),
@@ -281,36 +293,150 @@ def _start_acting(
         )
         + 1
     )
+
+    try:
+        handler.start_react_step(react_invocation, context=context)
+        react_context = get_current()
+    except Exception:
+        _abandon_invocation(react_invocation)
+        raise
+
+    react_token = react_invocation.context_token
+    react_invocation.context_token = None
+    _safe_detach(react_token)
+    return _ReactState(
+        handler=handler,
+        invocation=react_invocation,
+        context=react_context,
+    )
+
+
+@hook_advice("agentscope", "record_react_event")
+def _record_react_event(state: _ReactState, item: Any) -> None:
+    event_type = str(getattr(item, "type", "")).lower()
+    if event_type in {
+        "tool_call",
+        "tool_call_start",
+        "tool_call_delta",
+        "tool_call_end",
+    }:
+        state.finish_reason = "tool_calls"
+    elif isinstance(item, Msg) and state.finish_reason != "tool_calls":
+        state.finish_reason = "stop"
+
+
+@hook_advice("agentscope", "record_react_error")
+def _record_react_error(
+    state: _ReactState,
+    error: BaseException,
+) -> None:
+    if not isinstance(error, GeneratorExit):
+        state.error = error
+
+
+def _create_tool_invocation(
+    agent: Agent,
+    tool_call: Any,
+) -> ExecuteToolInvocation:
+    tool_name = str(getattr(tool_call, "name", "unknown_tool"))
+    tool_call_arguments = _loads_json(getattr(tool_call, "input", None))
     tool_invocation = ExecuteToolInvocation(
-        tool_name=getattr(tool_call, "name", "unknown_tool"),
+        tool_name=tool_name,
         tool_type="function",
         tool_call_id=getattr(tool_call, "id", None),
-        tool_call_arguments=_loads_json(getattr(tool_call, "input", None)),
+        tool_call_arguments=tool_call_arguments,
         provider="agentscope",
+    )
+    _apply_skill_metadata(
+        tool_invocation,
+        agent,
+        tool_name,
+        tool_call_arguments,
+    )
+    return tool_invocation
+
+
+def _apply_skill_metadata(
+    invocation: ExecuteToolInvocation,
+    agent: Agent,
+    tool_name: str,
+    tool_call_arguments: Any,
+) -> None:
+    """Enrich AgentScope v2's built-in Skill viewer tool span."""
+
+    if tool_name.lower() != "skill" or not isinstance(
+        tool_call_arguments, dict
+    ):
+        return
+
+    requested_name = tool_call_arguments.get("skill")
+    if not isinstance(requested_name, str) or not requested_name:
+        return
+
+    metadata: dict[str, Any] = {"name": requested_name}
+    toolkit = getattr(agent, "toolkit", None)
+
+    qwenpaw_skills = getattr(toolkit, "_qp_skills", None)
+    if isinstance(qwenpaw_skills, dict):
+        qwenpaw_metadata = qwenpaw_skills.get(requested_name)
+        if isinstance(qwenpaw_metadata, dict):
+            metadata.update(qwenpaw_metadata)
+
+    for group in getattr(toolkit, "tool_groups", ()) or ():
+        for entry in getattr(group, "skills_or_loaders", ()) or ():
+            candidates = [entry]
+            cache = getattr(entry, "_cache", None)
+            if isinstance(cache, dict):
+                candidates.extend(cache.values())
+            for candidate in candidates:
+                if getattr(candidate, "name", None) != requested_name:
+                    continue
+                for field_name in ("name", "description", "dir"):
+                    value = getattr(candidate, field_name, None)
+                    if value not in (None, ""):
+                        metadata[field_name] = value
+
+    enriched = _enrich_skill_metadata(metadata)
+    invocation.skill_name = enriched.get("name") or requested_name
+    invocation.skill_id = enriched.get("id") or requested_name
+    invocation.skill_description = enriched.get("description")
+    invocation.skill_version = enriched.get("version")
+
+
+@hook_advice("agentscope", "start_acting")
+def _start_acting(
+    handler: ExtendedTelemetryHandler,
+    agent: Agent,
+    tool_call: Any,
+    react_state: _ReactState | None,
+) -> _ActingState:
+    tool_invocation = _create_tool_invocation(agent, tool_call)
+    owns_react = react_state is None
+    if react_state is None:
+        react_state = _start_react(handler, agent, get_current())
+
+    parent_context = (
+        react_state.context if react_state is not None else get_current()
     )
 
     try:
-        handler.start_react_step(react_invocation, context=get_current())
-        react_context = get_current()
-        handler.start_execute_tool(tool_invocation)
+        handler.start_execute_tool(tool_invocation, context=parent_context)
         tool_context = get_current()
     except Exception:
         _abandon_invocation(tool_invocation)
-        _abandon_invocation(react_invocation)
+        if owns_react and react_state is not None:
+            _finish_react(react_state)
         raise
 
     tool_token = tool_invocation.context_token
     tool_invocation.context_token = None
     _safe_detach(tool_token)
-    react_token = react_invocation.context_token
-    react_invocation.context_token = None
-    _safe_detach(react_token)
     return _ActingState(
         handler=handler,
-        react_invocation=react_invocation,
         tool_invocation=tool_invocation,
-        react_context=react_context,
         tool_context=tool_context,
+        react_state=react_state,
+        owns_react=owns_react,
     )
 
 
@@ -356,28 +482,37 @@ def _finish_tool(
 
 @hook_advice("agentscope", "finish_react_step")
 def _finish_react(
-    state: _ActingState,
+    state: _ReactState,
     error: BaseException | None = None,
+    finish_reason: str | None = None,
 ) -> None:
-    if state.react_finalized:
+    if state.finalized:
         return
-    state.react_finalized = True
+    state.finalized = True
 
-    invocation = state.react_invocation
+    invocation = state.invocation
+    if finish_reason is not None:
+        state.finish_reason = finish_reason
+    invocation.finish_reason = state.finish_reason
+    failure = error
+    if failure is None:
+        failure = state.error
+    if isinstance(failure, GeneratorExit):
+        failure = None
+
     token = None
     span = invocation.span
     try:
-        token = otel_context.attach(state.react_context)
+        token = otel_context.attach(state.context)
         invocation.context_token = token
-        if error is None or isinstance(error, GeneratorExit):
-            invocation.finish_reason = "tool_calls"
+        if failure is None:
             state.handler.stop_react_step(invocation)
         else:
             state.handler.fail_react_step(
                 invocation,
                 Error(
-                    message=str(error) or type(error).__name__,
-                    type=type(error),
+                    message=str(failure) or type(failure).__name__,
+                    type=type(failure),
                 ),
             )
     finally:
@@ -392,7 +527,19 @@ def _finish_acting(
     error: BaseException | None = None,
 ) -> None:
     _finish_tool(state, error)
-    _finish_react(state, error)
+    if state.react_state is not None:
+        if error is not None:
+            _record_react_error(state.react_state, error)
+        if state.owns_react:
+            _finish_react(
+                state.react_state,
+                error,
+                finish_reason=(
+                    "tool_calls"
+                    if error is None or isinstance(error, GeneratorExit)
+                    else None
+                ),
+            )
 
 
 async def _close_iterator(iterator: AsyncIterator[Any]) -> None:
@@ -446,6 +593,32 @@ class AgentScopeV2Middleware(MiddlewareBase):
         self, handler: Callable[[], ExtendedTelemetryHandler | None]
     ) -> None:
         self._handler = handler
+        # AgentScope itself stores reply_id, cur_iter, and memory on the Agent,
+        # so one Agent instance supports one in-flight reply at a time.
+        self._reply_states: dict[int, _AgentState] = {}
+
+    def _reply_state(self, agent: Agent) -> _AgentState | None:
+        return self._reply_states.get(id(agent))
+
+    def _clear_reply_state(
+        self,
+        agent: Agent,
+        state: _AgentState,
+    ) -> None:
+        if self._reply_states.get(id(agent)) is state:
+            self._reply_states.pop(id(agent), None)
+
+    def _finish_active_react(
+        self,
+        agent: Agent,
+        state: _AgentState,
+        error: BaseException | None = None,
+        finish_reason: str | None = None,
+    ) -> None:
+        react_state = state.active_react
+        state.active_react = None
+        if react_state is not None:
+            _finish_react(react_state, error, finish_reason)
 
     async def on_reply(
         self,
@@ -477,6 +650,7 @@ class AgentScopeV2Middleware(MiddlewareBase):
                 raise
             return
 
+        self._reply_states[id(agent)] = state
         try:
             while True:
                 token = _attach_stream_context(state.context)
@@ -494,18 +668,97 @@ class AgentScopeV2Middleware(MiddlewareBase):
             try:
                 await _close_iterator(iterator)
             except BaseException as close_error:
+                self._finish_active_react(agent, state, close_error)
                 _finish_agent(state, close_error)
                 raise
             finally:
                 _detach_stream_context(token)
+            self._finish_active_react(agent, state, exc)
             _finish_agent(state, exc)
             raise
         except BaseException as exc:
+            self._finish_active_react(agent, state, exc)
             _finish_agent(state, exc)
             raise
         finally:
+            if state.active_react is not None:
+                self._finish_active_react(agent, state)
             if not state.finalized:
                 _finish_agent(state)
+            self._clear_reply_state(agent, state)
+
+    async def on_reasoning(
+        self,
+        agent: Agent,
+        input_kwargs: dict,
+        next_handler: Callable[..., AsyncGenerator],
+    ) -> AsyncGenerator:
+        handler = self._handler()
+        reply_state = self._reply_state(agent)
+        if handler is None or reply_state is None:
+            async for item in next_handler(**input_kwargs):
+                yield item
+            return
+
+        self._finish_active_react(
+            agent,
+            reply_state,
+            finish_reason="tool_calls",
+        )
+        state = _start_react(handler, agent, reply_state.context)
+        if state is None:
+            async for item in next_handler(**input_kwargs):
+                yield item
+            return
+        reply_state.active_react = state
+
+        try:
+            business_stream = next_handler(**input_kwargs)
+            iterator = business_stream.__aiter__()
+        except BaseException as exc:
+            self._finish_active_react(agent, reply_state, exc)
+            raise
+
+        try:
+            while True:
+                token = _attach_stream_context(state.context)
+                try:
+                    item = await iterator.__anext__()
+                except StopAsyncIteration:
+                    break
+                finally:
+                    _detach_stream_context(token)
+
+                _record_react_event(state, item)
+                yield item
+        except GeneratorExit as exc:
+            token = _attach_stream_context(state.context)
+            try:
+                await _close_iterator(iterator)
+            except BaseException as close_error:
+                self._finish_active_react(
+                    agent,
+                    reply_state,
+                    close_error,
+                )
+                raise
+            finally:
+                _detach_stream_context(token)
+            self._finish_active_react(agent, reply_state, exc)
+            raise
+        except BaseException as exc:
+            self._finish_active_react(agent, reply_state, exc)
+            raise
+        finally:
+            if (
+                reply_state.active_react is state
+                and state.finish_reason != "tool_calls"
+            ):
+                self._finish_active_react(
+                    agent,
+                    reply_state,
+                    finish_reason=state.finish_reason or "stop",
+                )
 
     async def on_model_call(
         self,
@@ -596,7 +849,15 @@ class AgentScopeV2Middleware(MiddlewareBase):
             return
 
         tool_call = input_kwargs.get("tool_call")
-        state = _start_acting(handler, agent, tool_call)
+        reply_state = self._reply_state(agent)
+        react_state = (
+            reply_state.active_react if reply_state is not None else None
+        )
+        if reply_state is not None and react_state is None:
+            react_state = _start_react(handler, agent, reply_state.context)
+            reply_state.active_react = react_state
+
+        state = _start_acting(handler, agent, tool_call, react_state)
         try:
             business_stream = next_handler(**input_kwargs)
             iterator = business_stream.__aiter__()
@@ -640,7 +901,11 @@ class AgentScopeV2Middleware(MiddlewareBase):
             _finish_acting(state, exc)
             raise
         finally:
-            if not state.tool_finalized or not state.react_finalized:
+            if not state.tool_finalized or (
+                state.owns_react
+                and state.react_state is not None
+                and not state.react_state.finalized
+            ):
                 _finish_acting(state)
 
 

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/patch.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/patch.py
@@ -16,12 +16,9 @@
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 import timeit
-from importlib import import_module
-from pathlib import Path
 
 from opentelemetry.semconv._incubating.attributes import (
     gen_ai_attributes as GenAIAttributes,
@@ -34,6 +31,7 @@ from opentelemetry.util.genai.extended_types import ExecuteToolInvocation
 from opentelemetry.util.genai.span_utils import _apply_error_attributes
 from opentelemetry.util.genai.types import Error
 
+from ._skill import _enrich_skill_metadata
 from .utils import (
     apply_entry_baggage_identity,
     entry_baggage_identity_attributes,
@@ -113,109 +111,6 @@ def _resolves_to_skill_md(
         return False
 
     return False
-
-
-def _enrich_skill_metadata(skill):
-    """Enrich a matched skill dict with version and id from SKILL.md.
-
-    AgentScope's ``AgentSkill`` only stores ``name``, ``description``,
-    and ``dir``. This function best-effort extracts ``version`` from
-    SKILL.md/frontmatter-related sources and builds a
-    **runtime / deployment-scoped** ``id`` when ``dir`` is available.
-
-    The enrichment is best-effort: if frontmatter/version data cannot be
-    read (e.g. file missing, parse error, or running without CoPaw), the
-    returned dict may still include a path-derived ``id`` when possible,
-    but ``version`` is only added when successfully determined.
-
-    When CoPaw is available, its ``_read_frontmatter_safe`` and
-    ``_extract_version`` helpers are preferred because they are the
-    canonical source of truth.  Otherwise we fall back to a lightweight
-    ``frontmatter`` parse.
-
-    Returns a new dict (never mutates the original).
-    """
-    skill_dir = skill.get("dir", "")
-    skill_name = skill.get("name", "")
-    if not skill_dir:
-        return dict(skill)
-
-    enriched = dict(skill)
-
-    # --- Extract version ---
-    version_text = None
-
-    # Prefer CoPaw's own helpers (canonical source of truth). If that
-    # path fails at runtime for any reason, continue to lightweight
-    # frontmatter/manifest fallbacks instead of dropping version entirely.
-    try:
-        skills_manager = import_module("copaw.agents.skills_manager")
-
-        post = skills_manager._read_frontmatter_safe(
-            Path(skill_dir), skill_name
-        )
-        version_text = skills_manager._extract_version(post)
-    except Exception:
-        version_text = None
-
-    if not version_text:
-        try:
-            frontmatter = import_module("frontmatter")
-
-            skill_md_path = os.path.join(skill_dir, _SKILL_MANIFEST)
-            with open(skill_md_path, "r", encoding="utf-8") as fh:
-                post = frontmatter.load(fh)
-            metadata = post.get("metadata") or {}
-            for value in (
-                post.get("version"),
-                metadata.get("version"),
-                metadata.get("builtin_skill_version"),
-            ):
-                if value not in (None, ""):
-                    version_text = str(value)
-                    break
-        except Exception:
-            version_text = None
-
-    if not version_text:
-        try:
-            skill_path = Path(skill_dir)
-            skill_json_path = skill_path.parent.parent / "skill.json"
-            if skill_json_path.exists():
-                # CoPaw-specific runtime fallback: workspace skill.json may
-                # already contain normalized version_text even when direct
-                # helper/frontmatter extraction is unavailable in-process.
-                payload = json.loads(
-                    skill_json_path.read_text(encoding="utf-8")
-                )
-                entry = payload.get("skills", {}).get(skill_name, {})
-                metadata = entry.get("metadata", {}) or {}
-                value = metadata.get("version_text")
-                if value not in (None, ""):
-                    version_text = str(value)
-        except Exception:
-            version_text = None
-
-    if version_text:
-        enriched["version"] = str(version_text)
-
-    # --- Build runtime/deployment-scoped skill ID ---
-    # Format: workspace:{workspace_name}:{skill_name}
-    # NOT a globally canonical ID — stable within one workspace.
-    try:
-        parts = skill_dir.replace("\\", "/").split("/")
-        workspace_name = "default"
-        try:
-            skills_idx = len(parts) - 1 - parts[::-1].index("skills")
-            if skills_idx >= 1:
-                workspace_name = parts[skills_idx - 1]
-        except ValueError:
-            pass
-        enriched["id"] = f"workspace:{workspace_name}:{skill_name}"
-    except Exception:
-        pass
-
-    return enriched
 
 
 def _match_skill_for_tool(instance, tool_args):

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/test_v2_instrumentation.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/test_v2_instrumentation.py
@@ -36,6 +36,7 @@ from agentscope.credential import DashScopeCredential  # noqa: E402
 from agentscope.message import (  # noqa: E402
     Msg,
     TextBlock,
+    ToolCallBlock,
     ToolResultBlock,
     UserMsg,
 )
@@ -99,6 +100,10 @@ def test_instrumentor_injects_v2_middleware(instrument):
     assert any(
         isinstance(middleware, AgentScopeV2Middleware)
         for middleware in agent._model_call_middlewares
+    )
+    assert any(
+        isinstance(middleware, AgentScopeV2Middleware)
+        for middleware in agent._reasoning_middlewares
     )
     assert any(
         isinstance(middleware, AgentScopeV2Middleware)
@@ -621,6 +626,108 @@ async def test_v2_reply_start_failure_preserves_business_stream(
     assert not trace_api.get_current_span().get_span_context().is_valid
 
 
+async def test_v2_react_start_failure_preserves_reasoning_stream(
+    instrument,
+    span_exporter,
+    monkeypatch,
+):
+    agent = Agent(
+        name="react_start_failure_agent",
+        system_prompt="Reply briefly.",
+        model=_make_model(stream=False),
+    )
+    middleware = _middleware(agent._reply_middlewares)
+    handler = middleware._handler()
+    expected = Msg(
+        name="assistant",
+        role="assistant",
+        content=[TextBlock(text="business result")],
+    )
+
+    def start_react_step(*args, **kwargs):
+        del args, kwargs
+        raise ValueError("probe step start failure")
+
+    monkeypatch.setattr(handler, "start_react_step", start_react_step)
+
+    async def reasoning_handler(**kwargs):
+        del kwargs
+        yield expected
+
+    async def reply_handler(**kwargs):
+        del kwargs
+        async for item in middleware.on_reasoning(
+            agent,
+            {},
+            reasoning_handler,
+        ):
+            yield item
+
+    results = [
+        item
+        async for item in middleware.on_reply(
+            agent,
+            {"inputs": []},
+            reply_handler,
+        )
+    ]
+
+    assert results == [expected]
+    assert not _spans_by_operation(
+        span_exporter.get_finished_spans(),
+        "react",
+    )
+    assert _spans_by_operation(
+        span_exporter.get_finished_spans(),
+        "invoke_agent",
+    )
+    assert not middleware._reply_states
+
+
+async def test_v2_reasoning_error_preserves_identity_and_fails_step(
+    instrument,
+    span_exporter,
+):
+    agent = Agent(
+        name="react_error_agent",
+        system_prompt="Reply briefly.",
+        model=_make_model(stream=False),
+    )
+    middleware = _middleware(agent._reply_middlewares)
+    business_error = RuntimeError("reasoning failed")
+
+    async def reasoning_handler(**kwargs):
+        del kwargs
+        yield SimpleNamespace(type="thinking_block_delta")
+        raise business_error
+
+    async def reply_handler(**kwargs):
+        del kwargs
+        async for item in middleware.on_reasoning(
+            agent,
+            {},
+            reasoning_handler,
+        ):
+            yield item
+
+    stream = middleware.on_reply(agent, {"inputs": []}, reply_handler)
+    await _heartbeat_next(stream)
+    try:
+        await _heartbeat_next(stream)
+    except RuntimeError as exc:
+        assert exc is business_error
+    else:
+        pytest.fail("business error was not raised")
+
+    [react_span] = _spans_by_operation(
+        span_exporter.get_finished_spans(),
+        "react",
+    )
+    assert react_span.status.status_code == StatusCode.ERROR
+    assert react_span.attributes["error.type"] == "RuntimeError"
+    assert not middleware._reply_states
+
+
 async def test_v2_reply_finish_failure_does_not_replace_business_result(
     instrument,
     span_exporter,
@@ -824,6 +931,7 @@ async def test_v2_acting_aclose_is_normal_across_tasks(
     assert react_span.status.status_code == StatusCode.UNSET
     assert "error.type" not in tool_span.attributes
     assert "error.type" not in react_span.attributes
+    assert react_span.attributes["gen_ai.react.finish_reason"] == "tool_calls"
     assert not any(
         "Context detach failed" in record.getMessage()
         for record in caplog.records
@@ -875,6 +983,7 @@ async def test_v2_acting_aclose_error_preserves_original_exception(
     assert react_span.status.status_code == StatusCode.ERROR
     assert tool_span.attributes["error.type"] == "ValueError"
     assert react_span.attributes["error.type"] == "ValueError"
+    assert "gen_ai.react.finish_reason" not in react_span.attributes
     assert not trace_api.get_current_span().get_span_context().is_valid
 
 
@@ -1023,6 +1132,201 @@ async def test_v2_react_concurrent_tools_share_agent_iteration(
     }
 
 
+async def test_v2_react_step_parents_reasoning_llm_and_concurrent_tools(
+    instrument,
+    span_exporter,
+):
+    agent = Agent(
+        name="react_hierarchy_agent",
+        system_prompt="Use tools.",
+        model=_make_model(stream=False),
+    )
+    middleware = _middleware(agent._reply_middlewares)
+    tool_calls = [
+        ToolCallBlock(
+            id=f"tool-call-{idx}",
+            name=f"tool_{idx}",
+            input=json.dumps({"idx": idx}),
+        )
+        for idx in range(2)
+    ]
+
+    async def model_handler(**kwargs):
+        del kwargs
+        return ChatResponse(content=tool_calls, is_last=True)
+
+    async def reasoning_handler(**kwargs):
+        del kwargs
+        await middleware.on_model_call(
+            agent,
+            {
+                "current_model": agent.model,
+                "messages": [UserMsg(name="user", content="use tools")],
+            },
+            model_handler,
+        )
+        for tool_call in tool_calls:
+            yield SimpleNamespace(type="TOOL_CALL_START")
+            yield SimpleNamespace(type="TOOL_CALL_END")
+        # Some framework versions may emit a completed message after the
+        # individual tool-call events.
+        yield Msg(
+            name="assistant",
+            role="assistant",
+            content=tool_calls,
+        )
+
+    async def call_tool(tool_call):
+        async def tool_handler(**kwargs):
+            del kwargs
+            await asyncio.sleep(0)
+            yield ToolResponse(
+                content=[TextBlock(text=f"result {tool_call.name}")]
+            )
+
+        return [
+            item
+            async for item in middleware.on_acting(
+                agent,
+                {"tool_call": tool_call},
+                tool_handler,
+            )
+        ]
+
+    expected = Msg(
+        name="assistant",
+        role="assistant",
+        content=[TextBlock(text="done")],
+    )
+
+    async def final_model_handler(**kwargs):
+        del kwargs
+        return ChatResponse(
+            content=[TextBlock(text="done")],
+            is_last=True,
+        )
+
+    async def final_reasoning_handler(**kwargs):
+        del kwargs
+        await middleware.on_model_call(
+            agent,
+            {
+                "current_model": agent.model,
+                "messages": [UserMsg(name="user", content="finish")],
+            },
+            final_model_handler,
+        )
+        yield expected
+
+    async def reply_handler(**kwargs):
+        del kwargs
+        async for item in middleware.on_reasoning(
+            agent,
+            {},
+            reasoning_handler,
+        ):
+            yield item
+        assert all(await asyncio.gather(*(call_tool(tc) for tc in tool_calls)))
+        agent.state.cur_iter = 1
+        async for item in middleware.on_reasoning(
+            agent,
+            {},
+            final_reasoning_handler,
+        ):
+            yield item
+
+    stream = middleware.on_reply(agent, {"inputs": []}, reply_handler)
+    while True:
+        try:
+            await _heartbeat_next(stream)
+        except StopAsyncIteration:
+            break
+
+    spans = span_exporter.get_finished_spans()
+    [agent_span] = _spans_by_operation(spans, "invoke_agent")
+    react_spans = _spans_by_operation(spans, "react")
+    llm_spans = _spans_by_operation(spans, "chat")
+    tool_spans = _spans_by_operation(spans, "execute_tool")
+
+    assert len(react_spans) == 2
+    assert len(llm_spans) == 2
+    assert {span.parent.span_id for span in react_spans} == {
+        agent_span.context.span_id
+    }
+    react_by_round = {
+        span.attributes["gen_ai.react.round"]: span for span in react_spans
+    }
+    llm_parent_ids = {span.parent.span_id for span in llm_spans}
+    assert llm_parent_ids == {span.context.span_id for span in react_spans}
+    assert len(tool_spans) == 2
+    assert {span.parent.span_id for span in tool_spans} == {
+        react_by_round[1].context.span_id
+    }
+    assert (
+        react_by_round[1].attributes["gen_ai.react.finish_reason"]
+        == "tool_calls"
+    )
+    assert react_by_round[2].attributes["gen_ai.react.finish_reason"] == "stop"
+
+
+async def test_v2_skill_viewer_tool_captures_skill_metadata(
+    instrument,
+    span_exporter,
+    tmp_path,
+):
+    agent = Agent(
+        name="skill_agent",
+        system_prompt="Load a skill.",
+        model=_make_model(stream=False),
+    )
+    skill_dir = tmp_path / "workspaces" / "demo" / "skills" / "code-review"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\n"
+        "name: code-review\n"
+        "description: Review source code\n"
+        "version: 1.2.3\n"
+        "---\n"
+        "Review the requested source code.\n",
+        encoding="utf-8",
+    )
+    agent.toolkit._qp_skills = {
+        "code-review": {
+            "dir": str(skill_dir),
+        }
+    }
+    middleware = _middleware(agent._acting_middlewares)
+    tool_call = SimpleNamespace(
+        name="Skill",
+        id="skill-tool-call",
+        input='{"skill": "code-review"}',
+    )
+
+    async def tool_handler(**kwargs):
+        del kwargs
+        yield ToolResponse(content=[TextBlock(text="skill markdown")])
+
+    results = [
+        item
+        async for item in middleware.on_acting(
+            agent,
+            {"tool_call": tool_call},
+            tool_handler,
+        )
+    ]
+
+    assert results
+    [tool_span] = _spans_by_operation(
+        span_exporter.get_finished_spans(),
+        "execute_tool",
+    )
+    assert tool_span.attributes["gen_ai.skill.name"] == "code-review"
+    assert (
+        tool_span.attributes["gen_ai.skill.id"] == "workspace:demo:code-review"
+    )
+    assert tool_span.attributes["gen_ai.skill.version"] == "1.2.3"
+
+
 @pytest.mark.vcr()
 async def test_v2_agent_non_streaming_e2e(instrument, span_exporter):
     model = _make_model(stream=False)
@@ -1079,10 +1383,14 @@ async def test_v2_agent_concurrent_e2e(instrument, span_exporter):
     spans = span_exporter.get_finished_spans()
     agent_spans = _spans_by_operation(spans, "invoke_agent")
     llm_spans = _spans_by_operation(spans, "chat")
+    react_spans = _spans_by_operation(spans, "react")
     assert len(agent_spans) == 2
     assert len(llm_spans) == 2
+    assert len(react_spans) == 2
     agent_span_ids = {span.context.span_id for span in agent_spans}
-    assert {span.parent.span_id for span in llm_spans} == agent_span_ids
+    assert {span.parent.span_id for span in react_spans} == agent_span_ids
+    react_span_ids = {span.context.span_id for span in react_spans}
+    assert {span.parent.span_id for span in llm_spans} == react_span_ids
 
 
 def _make_model(stream: bool):
@@ -1101,8 +1409,11 @@ def _make_model(stream: bool):
 
 
 def _assert_agent_and_llm_spans(spans):
-    assert _spans_by_operation(spans, "invoke_agent")
-    assert _spans_by_operation(spans, "chat")
+    [agent_span] = _spans_by_operation(spans, "invoke_agent")
+    [react_span] = _spans_by_operation(spans, "react")
+    [llm_span] = _spans_by_operation(spans, "chat")
+    assert react_span.parent.span_id == agent_span.context.span_id
+    assert llm_span.parent.span_id == react_span.context.span_id
 
 
 def _spans_by_operation(spans, operation_name):

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/test_v2_instrumentation.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/test_v2_instrumentation.py
@@ -269,10 +269,183 @@ async def test_v2_streaming_model_call_starts_llm_span_before_model_handler(
     assert len(spans) == 1
     llm_span_id = spans[0].context.span_id
     assert observed_current_span_ids == [llm_span_id, llm_span_id, llm_span_id]
-    assert consumer_current_span_ids == [llm_span_id, llm_span_id]
+    assert consumer_current_span_ids == [0, 0]
     assert (
         trace_api.get_current_span().get_span_context().span_id != llm_span_id
     )
+
+
+async def test_v2_streaming_model_aclose_is_normal_across_tasks(
+    instrument,
+    span_exporter,
+    caplog,
+):
+    caplog.set_level("DEBUG", logger="opentelemetry.util.genai.handler")
+    agent = Agent(
+        name="stream_close_agent",
+        system_prompt="Reply briefly.",
+        model=_make_model(stream=True),
+    )
+    middleware = _middleware(agent._model_call_middlewares)
+    expected = ChatResponse(
+        content=[TextBlock(text="partial")],
+        is_last=False,
+    )
+    closed = 0
+
+    async def business_stream():
+        nonlocal closed
+        try:
+            yield expected
+            yield ChatResponse(
+                content=[TextBlock(text="unused")],
+                is_last=True,
+            )
+        finally:
+            closed += 1
+
+    async def stream_handler(**kwargs):
+        del kwargs
+        return business_stream()
+
+    stream = await asyncio.create_task(
+        middleware.on_model_call(
+            agent,
+            {
+                "current_model": agent.model,
+                "messages": [UserMsg(name="user", content="hello")],
+            },
+            stream_handler,
+        )
+    )
+    assert not trace_api.get_current_span().get_span_context().is_valid
+    assert await _heartbeat_next(stream) is expected
+    await asyncio.create_task(stream.aclose())
+
+    [span] = _spans_by_operation(
+        span_exporter.get_finished_spans(),
+        "chat",
+    )
+    assert closed == 1
+    assert span.status.status_code == StatusCode.UNSET
+    assert "error.type" not in span.attributes
+    assert "gen_ai.response.finish_reasons" not in span.attributes
+    assert not any(
+        "Context detach failed" in record.getMessage()
+        or "Failed to detach context" in record.getMessage()
+        for record in caplog.records
+    )
+    assert not trace_api.get_current_span().get_span_context().is_valid
+
+
+async def test_v2_streaming_model_aclose_error_preserves_original_exception(
+    instrument,
+    span_exporter,
+):
+    agent = Agent(
+        name="stream_close_error_agent",
+        system_prompt="Reply briefly.",
+        model=_make_model(stream=True),
+    )
+    middleware = _middleware(agent._model_call_middlewares)
+    close_error = ValueError("business close failure")
+
+    async def business_stream():
+        try:
+            yield ChatResponse(
+                content=[TextBlock(text="partial")],
+                is_last=False,
+            )
+        finally:
+            raise close_error
+
+    async def stream_handler(**kwargs):
+        del kwargs
+        return business_stream()
+
+    stream = await asyncio.create_task(
+        middleware.on_model_call(
+            agent,
+            {
+                "current_model": agent.model,
+                "messages": [UserMsg(name="user", content="hello")],
+            },
+            stream_handler,
+        )
+    )
+    await _heartbeat_next(stream)
+    try:
+        await asyncio.create_task(stream.aclose())
+    except ValueError as exc:
+        assert exc is close_error
+    else:
+        pytest.fail("business close error was not raised")
+
+    [span] = _spans_by_operation(
+        span_exporter.get_finished_spans(),
+        "chat",
+    )
+    assert span.status.status_code == StatusCode.ERROR
+    assert span.attributes["error.type"] == "ValueError"
+    assert not trace_api.get_current_span().get_span_context().is_valid
+
+
+async def test_v2_streaming_model_cancellation_cleans_cross_task_context(
+    instrument,
+    span_exporter,
+    caplog,
+):
+    caplog.set_level("DEBUG", logger="opentelemetry.util.genai.handler")
+    agent = Agent(
+        name="stream_cancel_agent",
+        system_prompt="Reply briefly.",
+        model=_make_model(stream=True),
+    )
+    middleware = _middleware(agent._model_call_middlewares)
+    started = asyncio.Event()
+    never = asyncio.Event()
+
+    async def business_stream():
+        started.set()
+        await never.wait()
+        yield ChatResponse(
+            content=[TextBlock(text="unreachable")],
+            is_last=True,
+        )
+
+    async def stream_handler(**kwargs):
+        del kwargs
+        return business_stream()
+
+    stream = await asyncio.create_task(
+        middleware.on_model_call(
+            agent,
+            {
+                "current_model": agent.model,
+                "messages": [UserMsg(name="user", content="hello")],
+            },
+            stream_handler,
+        )
+    )
+    task = asyncio.create_task(stream.__anext__())
+    await started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    [span] = _spans_by_operation(
+        span_exporter.get_finished_spans(),
+        "chat",
+    )
+    assert task.cancelled()
+    assert span.status.status_code == StatusCode.ERROR
+    assert span.attributes["error.type"] == "CancelledError"
+    assert not any(
+        "Context detach failed" in record.getMessage()
+        or "Failed to detach context" in record.getMessage()
+        for record in caplog.records
+    )
+    assert not trace_api.get_current_span().get_span_context().is_valid
 
 
 async def test_v2_streaming_model_call_captures_input_and_output_content(

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/tests/test_runtime_v2.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/tests/test_runtime_v2.py
@@ -541,7 +541,7 @@ async def test_runtime_aclose_preserves_agentscope_tree_and_success_status(
         yield ToolResponse(content=[TextBlock(text="success")])
         yield ToolResponse(content=[TextBlock(text="unused")])
 
-    async def reply_handler(**kwargs):
+    async def reasoning_handler(**kwargs):
         del kwargs
         assert agent_middleware is not None
         await agent_middleware.on_model_call(
@@ -552,6 +552,17 @@ async def test_runtime_aclose_preserves_agentscope_tree_and_success_status(
             },
             model_handler,
         )
+        yield SimpleNamespace(type="tool_call")
+
+    async def reply_handler(**kwargs):
+        del kwargs
+        assert agent_middleware is not None
+        async for _ in agent_middleware.on_reasoning(
+            agent,
+            {},
+            reasoning_handler,
+        ):
+            pass
         acting_stream = agent_middleware.on_acting(
             agent,
             {"tool_call": tool_call},
@@ -621,8 +632,8 @@ async def test_runtime_aclose_preserves_agentscope_tree_and_success_status(
     ]
 
     assert agent_span.parent.span_id == entry.context.span_id
-    assert llm_span.parent.span_id == agent_span.context.span_id
     assert react_span.parent.span_id == agent_span.context.span_id
+    assert llm_span.parent.span_id == react_span.context.span_id
     assert tool_span.parent.span_id == react_span.context.span_id
     for span in (entry, agent_span, llm_span, react_span, tool_span):
         assert span.status.status_code.name == "UNSET"
@@ -675,7 +686,7 @@ async def test_runtime_aclose_preserves_streaming_llm_success_status(
         del kwargs
         return business_model_stream()
 
-    async def reply_handler(**kwargs):
+    async def reasoning_handler(**kwargs):
         del kwargs
         assert agent_middleware is not None
         model_stream = await agent_middleware.on_model_call(
@@ -691,6 +702,21 @@ async def test_runtime_aclose_preserves_streaming_llm_success_status(
                 yield item
         except GeneratorExit:
             await model_stream.aclose()
+            raise
+
+    async def reply_handler(**kwargs):
+        del kwargs
+        assert agent_middleware is not None
+        reasoning_stream = agent_middleware.on_reasoning(
+            agent,
+            {},
+            reasoning_handler,
+        )
+        try:
+            async for item in reasoning_stream:
+                yield item
+        except GeneratorExit:
+            await reasoning_stream.aclose()
             raise
 
     async def fake_run(self, request):
@@ -737,10 +763,16 @@ async def test_runtime_aclose_preserves_streaming_llm_success_status(
         for span in spans
         if span.attributes.get("gen_ai.operation.name") == "chat"
     ]
+    [react_span] = [
+        span
+        for span in spans
+        if span.attributes.get("gen_ai.operation.name") == "react"
+    ]
     assert closed == 1
     assert agent_span.parent.span_id == entry.context.span_id
-    assert llm_span.parent.span_id == agent_span.context.span_id
-    for span in (entry, agent_span, llm_span):
+    assert react_span.parent.span_id == agent_span.context.span_id
+    assert llm_span.parent.span_id == react_span.context.span_id
+    for span in (entry, agent_span, react_span, llm_span):
         assert span.status.status_code.name == "UNSET"
         assert "error.type" not in span.attributes
     assert not any(

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/tests/test_runtime_v2.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/tests/test_runtime_v2.py
@@ -636,6 +636,122 @@ async def test_runtime_aclose_preserves_agentscope_tree_and_success_status(
 
 
 @pytest.mark.asyncio
+async def test_runtime_aclose_preserves_streaming_llm_success_status(
+    runtime_module,
+    tracer_provider,
+    span_exporter,
+    monkeypatch,
+    caplog,
+):
+    caplog.set_level("DEBUG", logger="opentelemetry.util.genai.handler")
+    model = object.__new__(ChatModelBase)
+    model.model = "test-model"
+    model.parameters = None
+    agent = SimpleNamespace(
+        name="streaming-agent",
+        model=model,
+        state=SimpleNamespace(cur_iter=0, session_id="streaming-session"),
+        _system_prompt="Reply briefly.",
+    )
+    first_chunk = ChatResponse(
+        content=[TextBlock(text="partial")],
+        is_last=False,
+    )
+    agent_middleware = None
+    closed = 0
+
+    async def business_model_stream():
+        nonlocal closed
+        try:
+            yield first_chunk
+            yield ChatResponse(
+                content=[TextBlock(text="unused")],
+                is_last=True,
+            )
+        finally:
+            closed += 1
+
+    async def model_handler(**kwargs):
+        del kwargs
+        return business_model_stream()
+
+    async def reply_handler(**kwargs):
+        del kwargs
+        assert agent_middleware is not None
+        model_stream = await agent_middleware.on_model_call(
+            agent,
+            {
+                "current_model": model,
+                "messages": [],
+            },
+            model_handler,
+        )
+        try:
+            async for item in model_stream:
+                yield item
+        except GeneratorExit:
+            await model_stream.aclose()
+            raise
+
+    async def fake_run(self, request):
+        del self, request
+        assert agent_middleware is not None
+        reply_stream = agent_middleware.on_reply(
+            agent,
+            {"inputs": []},
+            reply_handler,
+        )
+        try:
+            async for item in reply_stream:
+                yield item
+        except GeneratorExit:
+            await reply_stream.aclose()
+            raise
+
+    monkeypatch.setattr(runtime_module.Runtime, "run", fake_run)
+    instrumentor = _instrument(tracer_provider)
+    monkeypatch.setattr(
+        instrumentor._handler,
+        "process_multimodal_stop",
+        lambda *args, **kwargs: False,
+    )
+    agent_middleware = AgentScopeV2Middleware(lambda: instrumentor._handler)
+    try:
+        stream = _runtime(runtime_module).run(
+            _request("combined-streaming-close")
+        )
+        assert await asyncio.create_task(stream.__anext__()) is first_chunk
+        await asyncio.create_task(stream.aclose())
+    finally:
+        instrumentor.uninstrument()
+
+    spans = span_exporter.get_finished_spans()
+    [entry] = _entry_spans(span_exporter)
+    [agent_span] = [
+        span
+        for span in spans
+        if span.attributes.get("gen_ai.operation.name") == "invoke_agent"
+    ]
+    [llm_span] = [
+        span
+        for span in spans
+        if span.attributes.get("gen_ai.operation.name") == "chat"
+    ]
+    assert closed == 1
+    assert agent_span.parent.span_id == entry.context.span_id
+    assert llm_span.parent.span_id == agent_span.context.span_id
+    for span in (entry, agent_span, llm_span):
+        assert span.status.status_code.name == "UNSET"
+        assert "error.type" not in span.attributes
+    assert not any(
+        "Context detach failed" in record.getMessage()
+        or "Failed to detach context" in record.getMessage()
+        for record in caplog.records
+    )
+    assert not trace.get_current_span().get_span_context().is_valid
+
+
+@pytest.mark.asyncio
 async def test_runtime_aclose_error_still_finishes_entry(
     runtime_module,
     tracer_provider,


### PR DESCRIPTION
# Description

This PR corrects AgentScope v2 ReAct telemetry when an async agent stream is
advanced or closed by different `asyncio.Task` instances.

It creates each ReAct `STEP` before reasoning so that the planning `LLM` and
the resulting `TOOL` calls share the same per-round parent. It also:

- restores saved OpenTelemetry contexts only while advancing a stream, keeping
  every attach/detach token inside the task that created it;
- preserves normal `GeneratorExit`, cancellation, and business exception
  behavior;
- normalizes AgentScope v2 tool-call event types used by the real runtime;
- records `gen_ai.skill.name`, `gen_ai.skill.id`,
  `gen_ai.skill.description`, and `gen_ai.skill.version` for the built-in
  `Skill` loader while retaining AgentScope v1 compatibility.

The resulting hierarchy is:

```text
ENTRY
└── AGENT
    ├── STEP round=1, finish_reason=tool_calls
    │   ├── LLM
    │   └── TOOL
    └── STEP round=2, finish_reason=stop
        └── LLM
```

Related to #252 and follows up on #255. Duplicate instrumentation warnings are
outside this PR's scope.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] `PRE_COMMIT_HOME="$(mktemp -d)" tox -e precommit`
- [x] `tox -c tox-loongsuite.ini -e py312-test-loongsuite-instrumentation-agentscope-latest,py310-test-loongsuite-instrumentation-agentscope-oldest,py312-test-loongsuite-instrumentation-qwenpaw-latest,py310-test-loongsuite-instrumentation-qwenpaw-v1,py310-test-loongsuite-instrumentation-qwenpaw-legacy,lint-loongsuite-instrumentation-agentscope,lint-loongsuite-instrumentation-qwenpaw -- -q`
- [x] Packaged-wheel QwenPaw 2.0.1 / AgentScope 2.0.4.post1 runtime launched with `loongsuite-instrument qwenpaw app`
- [x] Weaver live-check against the `loongsuite-genai` advice profile

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR:
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated

## Validation Evidence

### Spec and Scope

- Linked issue/spec: #252; follow-up to merged #255.
- Approved spec/comment: the ReAct hierarchy and Skill-load scope was approved
  before implementation and confirmed ready for PR submission.
- Changed surface: AgentScope v2 middleware and Skill metadata helpers,
  AgentScope compatibility tests, and QwenPaw v2 runtime integration tests.

### Local Checks

| Check | Command | Result | Notes |
| --- | --- | --- | --- |
| Static readiness | `python "$PIPELINE_SKILL_DIR/scripts/check_loongsuite_pr_readiness.py" --repo .` | pass | No readiness errors or warnings. |
| Precommit | `PRE_COMMIT_HOME="$(mktemp -d)" tox -e precommit` | pass | Fresh hook cache; worktree remained clean. |
| Focused tests | `tox -c tox-loongsuite.ini -e py312-test-loongsuite-instrumentation-agentscope-latest,py310-test-loongsuite-instrumentation-agentscope-oldest,py312-test-loongsuite-instrumentation-qwenpaw-latest,py310-test-loongsuite-instrumentation-qwenpaw-v1,py310-test-loongsuite-instrumentation-qwenpaw-legacy,lint-loongsuite-instrumentation-agentscope,lint-loongsuite-instrumentation-qwenpaw -- -q` | pass | 176 passed, 6 skipped; both lint environments passed. |
| Qoder review | external correctness and Ponytail simplification reviews | pass | No unresolved blocking finding; optional reductions were deferred or disputed with lifecycle evidence. |
| Privacy scan | branch diff and generated evidence scan | pass | No credentials, private trace IDs, local paths, or private runtime details are published. |

### Business Isolation

| Scenario | Status | Evidence |
| --- | --- | --- |
| prepare/start fault | pass | Fault-injection tests preserve the business result when span/context setup fails. |
| response mapping/stop fault | pass | Mapping and finalization failures remain fail-open and cleanup is idempotent. |
| fail callback fault | pass | The exact original business exception is re-raised. |
| stream chunk/final callback fault | pass | Original chunk identity and order are preserved with one finalization. |
| early close/cancellation/GeneratorExit | pass | Focused tests plus an intentional real SSE disconnect complete without false error status. |
| cross-task or cross-Context stream | pass | Different tasks advance and close the same stream without cross-Context token reset. |
| clean sibling after fault | pass | A request after intentional disconnect produces an independent healthy trace. |

### Real E2E Matrix

| Scenario | Status | Command or Demo | Evidence |
| --- | --- | --- | --- |
| non-streaming | N/A | QwenPaw app exposes an SSE streaming conversation surface | Direct AgentScope non-streaming behavior is covered by focused tests. |
| streaming | pass | `loongsuite-instrument qwenpaw app` | Completed business responses and finalized ENTRY/AGENT/STEP/LLM spans. |
| concurrency | pass | Two simultaneous QwenPaw requests | Independent trace trees and business results with no cross-trace parents. |
| agent/tool/ReAct | pass | Real `get_current_time` tool request | `ENTRY -> AGENT -> STEP -> LLM + TOOL`, followed by the final `STEP -> LLM`. |
| tool-heavy | pass | Bounded tool and Skill scenarios | Two real tool types were exercised; concurrent tools sharing one STEP are covered by the focused regression test. |
| error path | pass | Intentional SSE disconnect followed by a clean request | No cross-Context or `GeneratorExit` application error; the next request remained healthy. |

### Telemetry and Weaver

| Check | Status | Command or Artifact | Notes |
| --- | --- | --- | --- |
| Span tree / span kinds | pass | Packaged QwenPaw runtime and cloud readback | 8 traces and 38 spans; ENTRY=8, AGENT=8, STEP=10, LLM=10, TOOL=2; no parent mismatch. |
| Content capture modes | pass | Focused AgentScope content-capture tests | `NO_CONTENT`, `SPAN_ONLY`, and `SPAN_AND_EVENT` paths are covered; the real run used `SPAN_ONLY`. |
| Concurrency isolation | pass | Two concurrent real QwenPaw requests | No cross-trace parent or content contamination. |
| Weaver live-check | pass | `weaver registry live-check --advice-profile loongsuite-genai ...` | Structural real-runtime sample and focused Skill sample produced zero error/warning findings. |

### CI

- GitHub checks: pending PR creation.
- Known unrelated failures: none known.
- Follow-up needed: inspect branch-specific GitHub Actions results after the PR
  is created.
