### PR TITLE
feat(examples): add Chinese text ecommerce customer service demo

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -50,6 +50,8 @@ LoongSuite Python Agent 同时也是上游 [OTel Python Agent](https://github.co
 - **loongsuite-otel-util-genai** — [https://pypi.org/project/loongsuite-otel-util-genai/](https://pypi.org/project/loongsuite-otel-util-genai/)
 - **loongsuite-site-bootstrap**— [https://pypi.org/project/loongsuite-site-bootstrap/](https://pypi.org/project/loongsuite-site-bootstrap/)。
 
+可运行的端到端示例请参见 [Examples](examples/README.zh-CN.md)。
+
 > **包名迁移：**新的 LoongSuite GenAI 工具库发行包名为
 > **`loongsuite-otel-util-genai`**。旧的 **`loongsuite-util-genai`**
 > 仍可供历史安装使用，但新的 LoongSuite GenAI 工具库更新会发布到新包名下。

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Source tree: [`instrumentation-loongsuite/`](instrumentation-loongsuite).
 - **loongsuite-otel-util-genai** — [https://pypi.org/project/loongsuite-otel-util-genai/](https://pypi.org/project/loongsuite-otel-util-genai/)
 - **loongsuite-site-bootstrap** — [https://pypi.org/project/loongsuite-site-bootstrap/](https://pypi.org/project/loongsuite-site-bootstrap/).
 
+Runnable end-to-end samples are available in [Examples](examples/README.md).
+
 > **Package rename:** LoongSuite GenAI utilities are published as
 > **`loongsuite-otel-util-genai`** in new releases. The previous
 > **`loongsuite-util-genai`** distribution remains available for existing

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,6 +4,6 @@ Runnable examples for LoongSuite Python live in this directory.
 
 | Example | Description |
 | --- | --- |
-| [E-commerce customer service](ecommerce-customer-service/README.md) | A text-only LangGraph workflow that routes questions to separate pre-sales and after-sales ReAct agents, then reviews the answer before returning it. |
+| [Chinese e-commerce customer service](ecommerce-customer-service/README.md) | A text-only Chinese LangGraph workflow that routes questions to separate pre-sales and after-sales ReAct agents, then reviews the answer before returning it. |
 
 See [README.zh-CN.md](README.zh-CN.md) for Chinese documentation.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,9 @@
+# Examples
+
+Runnable examples for LoongSuite Python live in this directory.
+
+| Example | Description |
+| --- | --- |
+| [E-commerce customer service](ecommerce-customer-service/README.md) | A text-only LangGraph workflow that routes questions to separate pre-sales and after-sales ReAct agents, then reviews the answer before returning it. |
+
+See [README.zh-CN.md](README.zh-CN.md) for Chinese documentation.

--- a/examples/README.zh-CN.md
+++ b/examples/README.zh-CN.md
@@ -4,6 +4,6 @@
 
 | 示例 | 说明 |
 | --- | --- |
-| [电商客服](ecommerce-customer-service/README.zh-CN.md) | 一个纯文字 LangGraph 工作流：将问题路由到独立的售前或售后 ReAct Agent，并在回复用户前执行终审。 |
+| [中文电商客服](ecommerce-customer-service/README.zh-CN.md) | 一个纯文字中文 LangGraph 工作流：将问题路由到独立的售前或售后 ReAct Agent，并在回复用户前执行终审。 |
 
 英文文档请参见 [README.md](README.md)。

--- a/examples/README.zh-CN.md
+++ b/examples/README.zh-CN.md
@@ -1,0 +1,9 @@
+# 示例
+
+本目录存放 LoongSuite Python 的可运行示例。
+
+| 示例 | 说明 |
+| --- | --- |
+| [电商客服](ecommerce-customer-service/README.zh-CN.md) | 一个纯文字 LangGraph 工作流：将问题路由到独立的售前或售后 ReAct Agent，并在回复用户前执行终审。 |
+
+英文文档请参见 [README.md](README.md)。

--- a/examples/ecommerce-customer-service/README.md
+++ b/examples/ecommerce-customer-service/README.md
@@ -1,21 +1,24 @@
 # Text-only e-commerce customer service
 
-This example shows a small LangGraph customer-service workflow with LoongSuite
-automatic instrumentation. It accepts text only: there is no image input, file
-upload, browser UI, or multimodal model.
+This example shows a small **Chinese-language** LangGraph customer-service
+workflow with LoongSuite automatic instrumentation. It accepts text only:
+there is no image input, file upload, browser UI, or multimodal model.
 
 The workflow is:
 
 ```text
-question
+Chinese customer question
   -> intent_router
   -> presales_agent | aftersales_agent | clarify
   -> response_review
-  -> final text response
+  -> final Chinese text response
 ```
 
-The two specialist branches use separate prompts and tools. All products,
-orders, policies, and tool results are fictional fixtures in `tools.py`.
+The router, specialist prompts, synthetic data, tool results, CLI, and customer
+responses use Simplified Chinese. Stable Python identifiers and graph node names
+remain in English. The two specialist branches use separate prompts and tools.
+All products, orders, policies, and tool results are fictional fixtures in
+`tools.py`.
 
 ## Install
 
@@ -58,17 +61,20 @@ export OTEL_LOGS_EXPORTER="none"
 export OTEL_SEMCONV_STABILITY_OPT_IN="gen_ai_latest_experimental"
 
 loongsuite-instrument python app.py \
-  --question "Are the CloudStep commuter shoes suitable for walking, and is size 42 available?"
+  --question "云步通勤鞋适合日常步行吗？42 码有货吗？"
 ```
 
 After-sales example:
 
 ```bash
 loongsuite-instrument python app.py \
-  --question "Order DEMO-1001 was delivered yesterday and has a sole defect. What should I do?"
+  --question "订单 DEMO-1001 昨天签收，鞋底有问题，应该怎么处理？"
 ```
 
-Omit `--question` to start a simple interactive text loop.
+Omit `--question` to start a simple interactive Chinese text loop.
+
+For a detailed scenario walkthrough and a ready-to-use training script, see
+[README.zh-CN.md](README.zh-CN.md#培训讲解指南).
 
 With LangChain and LangGraph instrumentation enabled, a specialist request is
 expected to include the router LLM, the selected Agent, ReAct Step, Tool/LLM

--- a/examples/ecommerce-customer-service/README.md
+++ b/examples/ecommerce-customer-service/README.md
@@ -4,6 +4,9 @@ This example shows a small **Chinese-language** LangGraph customer-service
 workflow with LoongSuite automatic instrumentation. It accepts text only:
 there is no image input, file upload, browser UI, or multimodal model.
 
+It targets LangGraph 1.2+ and uses LangChain 1.x `create_agent`, the supported
+LangGraph-backed agent API.
+
 The workflow is:
 
 ```text

--- a/examples/ecommerce-customer-service/README.md
+++ b/examples/ecommerce-customer-service/README.md
@@ -1,0 +1,92 @@
+# Text-only e-commerce customer service
+
+This example shows a small LangGraph customer-service workflow with LoongSuite
+automatic instrumentation. It accepts text only: there is no image input, file
+upload, browser UI, or multimodal model.
+
+The workflow is:
+
+```text
+question
+  -> intent_router
+  -> presales_agent | aftersales_agent | clarify
+  -> response_review
+  -> final text response
+```
+
+The two specialist branches use separate prompts and tools. All products,
+orders, policies, and tool results are fictional fixtures in `tools.py`.
+
+## Install
+
+Python 3.10 or later is required.
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -r requirements.txt
+```
+
+## Configure a model
+
+The default uses the DashScope OpenAI-compatible endpoint and `qwen-plus`:
+
+```bash
+export DASHSCOPE_API_KEY="your-api-key"
+```
+
+Override the compatible endpoint or model when needed:
+
+```bash
+export OPENAI_API_KEY="your-api-key"
+export OPENAI_BASE_URL="https://your-compatible-endpoint/v1"
+export MODEL_NAME="your-model"
+```
+
+`DASHSCOPE_API_KEY` takes precedence over `OPENAI_API_KEY`. Do not commit keys
+to this directory.
+
+## Run with LoongSuite
+
+Console spans are convenient for a local smoke test:
+
+```bash
+export OTEL_SERVICE_NAME="ecommerce-customer-service"
+export OTEL_TRACES_EXPORTER="console"
+export OTEL_METRICS_EXPORTER="none"
+export OTEL_LOGS_EXPORTER="none"
+export OTEL_SEMCONV_STABILITY_OPT_IN="gen_ai_latest_experimental"
+
+loongsuite-instrument python app.py \
+  --question "Are the CloudStep commuter shoes suitable for walking, and is size 42 available?"
+```
+
+After-sales example:
+
+```bash
+loongsuite-instrument python app.py \
+  --question "Order DEMO-1001 was delivered yesterday and has a sole defect. What should I do?"
+```
+
+Omit `--question` to start a simple interactive text loop.
+
+With LangChain and LangGraph instrumentation enabled, a specialist request is
+expected to include the router LLM, the selected Agent, ReAct Step, Tool/LLM
+children, and the final reviewer LLM. Only the chosen specialist branch runs.
+
+## Test
+
+The offline tests do not call an external model:
+
+```bash
+python -m pip install -r requirements-dev.txt
+python -m pytest tests -q
+```
+
+They cover routing, separate specialist branches, synthetic tool results,
+missing orders, fail-open behavior, and concurrent state isolation.
+
+## Privacy boundary
+
+This example is deliberately generic. `P-DEMO-*` products and `DEMO-*` orders
+are synthetic and are not derived from a real store or customer environment.

--- a/examples/ecommerce-customer-service/README.zh-CN.md
+++ b/examples/ecommerce-customer-service/README.zh-CN.md
@@ -1,0 +1,90 @@
+# 纯文字电商客服
+
+本示例展示一个使用 LoongSuite 自动埋点的小型 LangGraph 电商客服工作流。
+示例只接受文字：不包含图片输入、文件上传、浏览器 UI 或多模态模型。
+
+工作流如下：
+
+```text
+用户问题
+  -> intent_router
+  -> presales_agent | aftersales_agent | clarify
+  -> response_review
+  -> 最终文字回复
+```
+
+售前和售后分支具有独立的提示词和工具。`tools.py` 中的商品、订单、政策及
+工具结果全部是虚构数据。
+
+## 安装
+
+需要使用 Python 3.10 或更高版本。
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -r requirements.txt
+```
+
+## 配置模型
+
+默认使用 DashScope OpenAI-compatible 接口和 `qwen-plus`：
+
+```bash
+export DASHSCOPE_API_KEY="your-api-key"
+```
+
+也可以替换为其他兼容接口：
+
+```bash
+export OPENAI_API_KEY="your-api-key"
+export OPENAI_BASE_URL="https://your-compatible-endpoint/v1"
+export MODEL_NAME="your-model"
+```
+
+`DASHSCOPE_API_KEY` 的优先级高于 `OPENAI_API_KEY`。请勿把密钥提交到仓库。
+
+## 使用 LoongSuite 运行
+
+本地验证可先把 Span 输出到控制台：
+
+```bash
+export OTEL_SERVICE_NAME="ecommerce-customer-service"
+export OTEL_TRACES_EXPORTER="console"
+export OTEL_METRICS_EXPORTER="none"
+export OTEL_LOGS_EXPORTER="none"
+export OTEL_SEMCONV_STABILITY_OPT_IN="gen_ai_latest_experimental"
+
+loongsuite-instrument python app.py \
+  --question "CloudStep 通勤鞋适合步行吗？42 码有货吗？"
+```
+
+售后示例：
+
+```bash
+loongsuite-instrument python app.py \
+  --question "订单 DEMO-1001 昨天签收，鞋底有问题，应该怎么处理？"
+```
+
+省略 `--question` 后会进入简单的交互式文字问答。
+
+启用 LangChain 和 LangGraph 埋点后，一次专业客服请求应包含路由 LLM、
+被选中的 Agent、ReAct Step、Tool/LLM 子节点以及最终审查 LLM；未选中的
+专业 Agent 不会执行。
+
+## 测试
+
+离线测试不会请求外部模型：
+
+```bash
+python -m pip install -r requirements-dev.txt
+python -m pytest tests -q
+```
+
+测试覆盖路由、两个独立专业分支、虚构工具结果、订单未命中、fail-open
+行为和并发状态隔离。
+
+## 隐私边界
+
+本示例刻意保持通用。`P-DEMO-*` 商品和 `DEMO-*` 订单均为虚构数据，
+不来源于任何真实店铺或客户环境。

--- a/examples/ecommerce-customer-service/README.zh-CN.md
+++ b/examples/ecommerce-customer-service/README.zh-CN.md
@@ -3,6 +3,9 @@
 本示例展示一个使用 LoongSuite 自动埋点的小型中文 LangGraph 电商客服工作流。
 示例只接受文字：不包含图片输入、文件上传、浏览器 UI 或多模态模型。
 
+示例面向 LangGraph 1.2+，并使用 LangChain 1.x 的 `create_agent`，即当前受支持的
+LangGraph Agent API。
+
 工作流如下：
 
 ```text

--- a/examples/ecommerce-customer-service/README.zh-CN.md
+++ b/examples/ecommerce-customer-service/README.zh-CN.md
@@ -1,6 +1,6 @@
 # 纯文字电商客服
 
-本示例展示一个使用 LoongSuite 自动埋点的小型 LangGraph 电商客服工作流。
+本示例展示一个使用 LoongSuite 自动埋点的小型中文 LangGraph 电商客服工作流。
 示例只接受文字：不包含图片输入、文件上传、浏览器 UI 或多模态模型。
 
 工作流如下：
@@ -15,6 +15,10 @@
 
 售前和售后分支具有独立的提示词和工具。`tools.py` 中的商品、订单、政策及
 工具结果全部是虚构数据。
+
+运行时的意图识别提示词、专业 Agent 提示词、工具说明、虚构数据、异常兜底及
+最终回答均使用简体中文。为了保持代码规范和 Trace 名称稳定，Python 标识符、
+节点名和内部路由值仍使用英文。
 
 ## 安装
 
@@ -56,7 +60,7 @@ export OTEL_LOGS_EXPORTER="none"
 export OTEL_SEMCONV_STABILITY_OPT_IN="gen_ai_latest_experimental"
 
 loongsuite-instrument python app.py \
-  --question "CloudStep 通勤鞋适合步行吗？42 码有货吗？"
+  --question "云步通勤鞋适合日常步行吗？42 码有货吗？"
 ```
 
 售后示例：
@@ -71,6 +75,50 @@ loongsuite-instrument python app.py \
 启用 LangChain 和 LangGraph 埋点后，一次专业客服请求应包含路由 LLM、
 被选中的 Agent、ReAct Step、Tool/LLM 子节点以及最终审查 LLM；未选中的
 专业 Agent 不会执行。
+
+## 培训讲解指南
+
+### 场景故事
+
+把这个 Demo 理解成一家虚构店铺的“客服总台”。总台先判断用户是在买东西前
+咨询，还是已经下单后的问题，再把请求转给有独立职责和工具的专业客服。
+专业客服查到事实并生成草稿后，最后还有一名审核员统一语气并检查是否编造。
+
+### 五步工作流
+
+| 步骤 | 节点 | 作用 | 典型可观测信号 |
+| --- | --- | --- | --- |
+| 1 | `intent_router` | LLM 结构化识别售前、售后或意图不明 | 一次路由 LLM 调用 |
+| 2 | 条件路由 | 只选择一个专业分支；低置信度进入澄清 | LangGraph 节点和边 |
+| 3 | `presales_agent` / `aftersales_agent` | 独立 ReAct Agent 思考并选择工具 | Agent、ReAct Step、LLM |
+| 4 | 虚构工具 | 查询商品/库存，或订单/政策/问题处理建议 | Tool Span 及工具参数、结果 |
+| 5 | `response_review` | LLM 根据草稿和工具证据润色终审 | 最终审查 LLM 调用 |
+
+售前 Agent 可以使用 `search_product_catalog`、`query_product_knowledge` 和
+`check_inventory`；售后 Agent 可以使用 `lookup_order_history`、
+`query_after_sales_policy` 和 `assess_issue`。两个工具集完全隔离，能够直观展示
+“不同 Agent 有不同职责和能力边界”。
+
+### 建议的现场演示
+
+1. 售前问题：`云步通勤鞋适合日常步行吗？42 码有货吗？`
+   讲解路由为什么选择售前，以及 Agent 如何组合商品知识和库存工具。
+2. 售后问题：`订单 DEMO-1001 昨天签收，鞋底有问题，应该怎么处理？`
+   讲解 Agent 为什么必须先查订单，再查询政策或给出人工核验步骤。
+3. 模糊问题：`能帮帮我吗？`
+   展示低置信度请求不会误进专业 Agent，而是先向用户澄清。
+
+在可观测控制台中，可以沿一次请求查看“入口/路由 LLM → 被选中的 Agent →
+ReAct Step → Tool 与专业 LLM → 最终审查 LLM”。培训时重点说明：未选中的
+Agent 不执行；工具证据被传给最终审核员；任何模型或专业 Agent 异常都会返回
+有限的中文兜底回答，而不是影响应用进程。
+
+### 为什么这样设计
+
+- **职责清晰**：售前和售后分别维护提示词与工具，不让一个 Agent 拥有所有权限。
+- **过程可解释**：意图、路由、工具证据和最终回复都能在 Trace 中逐层观察。
+- **事实有边界**：最终审核员只允许保留工具证据支持的信息，降低幻觉风险。
+- **适合演示**：纯文字、虚构数据、单进程即可运行，不依赖真实电商系统。
 
 ## 测试
 

--- a/examples/ecommerce-customer-service/app.py
+++ b/examples/ecommerce-customer-service/app.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run the text-only e-commerce customer service example."""
+"""运行纯文字中文电商客服示例。"""
 
 import argparse
 import os
@@ -10,6 +10,11 @@ from langchain_openai import ChatOpenAI
 from workflow import EcommerceSupportWorkflow
 
 DEFAULT_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+ROUTE_LABELS = {
+    "presales": "售前",
+    "aftersales": "售后",
+    "clarify": "需澄清",
+}
 
 
 def create_model() -> ChatOpenAI:
@@ -17,7 +22,7 @@ def create_model() -> ChatOpenAI:
     api_key = os.getenv("DASHSCOPE_API_KEY") or os.getenv("OPENAI_API_KEY")
     if not api_key:
         raise RuntimeError(
-            "Set DASHSCOPE_API_KEY or OPENAI_API_KEY before running the example."
+            "运行示例前请设置 DASHSCOPE_API_KEY 或 OPENAI_API_KEY。"
         )
 
     return ChatOpenAI(
@@ -36,7 +41,7 @@ def questions(initial_question: str | None) -> Iterator[str]:
         yield initial_question
         return
 
-    print("Enter a question. Submit an empty line to exit.")
+    print("请输入问题，直接回车即可退出。")
     while True:
         try:
             question = input("> ").strip()
@@ -50,11 +55,11 @@ def questions(initial_question: str | None) -> Iterator[str]:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Text-only LangGraph e-commerce customer service example"
+        description="纯文字 LangGraph 中文电商客服示例"
     )
     parser.add_argument(
         "--question",
-        help="Ask one question and exit. Omit it to use the interactive loop.",
+        help="提问一次后退出；不传该参数则进入交互模式。",
     )
     return parser.parse_args()
 
@@ -64,13 +69,17 @@ def main() -> int:
     try:
         support = EcommerceSupportWorkflow(create_model())
     except (RuntimeError, ValueError) as exc:
-        print(f"Configuration error: {exc}", file=sys.stderr)
+        print(f"配置错误：{exc}", file=sys.stderr)
         return 2
 
     for question in questions(args.question):
         try:
             result = support.run(question)
-            print(f"[{result['route']}] {result['final_response']}")
+            route_label = ROUTE_LABELS.get(result["route"], result["route"])
+            print(f"[{route_label}] {result['final_response']}")
+        except ValueError as exc:
+            print(f"请求错误：{exc}", file=sys.stderr)
+            return 2
         except KeyboardInterrupt:
             print()
             return 130

--- a/examples/ecommerce-customer-service/app.py
+++ b/examples/ecommerce-customer-service/app.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Run the text-only e-commerce customer service example."""
+
+import argparse
+import os
+import sys
+from collections.abc import Iterator
+
+from langchain_openai import ChatOpenAI
+from workflow import EcommerceSupportWorkflow
+
+DEFAULT_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+
+
+def create_model() -> ChatOpenAI:
+    """Create an OpenAI-compatible chat model from environment variables."""
+    api_key = os.getenv("DASHSCOPE_API_KEY") or os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "Set DASHSCOPE_API_KEY or OPENAI_API_KEY before running the example."
+        )
+
+    return ChatOpenAI(
+        api_key=api_key,
+        base_url=os.getenv("OPENAI_BASE_URL", DEFAULT_BASE_URL),
+        model=os.getenv("MODEL_NAME", "qwen-plus"),
+        temperature=0,
+        timeout=60,
+        max_retries=2,
+    )
+
+
+def questions(initial_question: str | None) -> Iterator[str]:
+    """Yield one command-line question or questions from an interactive loop."""
+    if initial_question:
+        yield initial_question
+        return
+
+    print("Enter a question. Submit an empty line to exit.")
+    while True:
+        try:
+            question = input("> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return
+        if not question:
+            return
+        yield question
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Text-only LangGraph e-commerce customer service example"
+    )
+    parser.add_argument(
+        "--question",
+        help="Ask one question and exit. Omit it to use the interactive loop.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        support = EcommerceSupportWorkflow(create_model())
+    except (RuntimeError, ValueError) as exc:
+        print(f"Configuration error: {exc}", file=sys.stderr)
+        return 2
+
+    for question in questions(args.question):
+        try:
+            result = support.run(question)
+            print(f"[{result['route']}] {result['final_response']}")
+        except KeyboardInterrupt:
+            print()
+            return 130
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/ecommerce-customer-service/requirements-dev.txt
+++ b/examples/ecommerce-customer-service/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest>=8,<9

--- a/examples/ecommerce-customer-service/requirements.txt
+++ b/examples/ecommerce-customer-service/requirements.txt
@@ -1,0 +1,6 @@
+langchain-openai>=0.3,<2.0
+langgraph>=0.3.1,<2.0
+loongsuite-distro
+loongsuite-instrumentation-langchain
+loongsuite-instrumentation-langgraph
+pydantic>=2,<3

--- a/examples/ecommerce-customer-service/requirements.txt
+++ b/examples/ecommerce-customer-service/requirements.txt
@@ -1,5 +1,6 @@
-langchain-openai>=0.3,<2.0
-langgraph>=0.3.1,<2.0
+langchain>=1.3,<2.0
+langchain-openai>=1.4,<2.0
+langgraph>=1.2,<2.0
 loongsuite-distro
 loongsuite-instrumentation-langchain
 loongsuite-instrumentation-langgraph

--- a/examples/ecommerce-customer-service/tests/conftest.py
+++ b/examples/ecommerce-customer-service/tests/conftest.py
@@ -1,0 +1,7 @@
+"""Make the standalone example modules importable from repository-root tests."""
+
+import sys
+from pathlib import Path
+
+EXAMPLE_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(EXAMPLE_DIR))

--- a/examples/ecommerce-customer-service/tests/test_workflow.py
+++ b/examples/ecommerce-customer-service/tests/test_workflow.py
@@ -1,0 +1,281 @@
+"""Offline tests for the text-only e-commerce support workflow."""
+
+from collections.abc import Sequence
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+import pytest
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import (
+    AIMessage,
+    BaseMessage,
+    SystemMessage,
+    ToolMessage,
+)
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.runnables import Runnable
+from tools import (
+    check_inventory,
+    lookup_order_history,
+    query_after_sales_policy,
+    search_product_catalog,
+)
+from workflow import EcommerceSupportWorkflow, IntentDecision, select_route
+
+
+class KeywordClassifier:
+    def invoke(self, messages: list[Any]) -> IntentDecision:
+        question = messages[-1].content.casefold()
+        if "order" in question or "refund" in question:
+            return IntentDecision(
+                intent="aftersales", confidence=0.95, reason="existing order"
+            )
+        if "shoe" in question or "stock" in question:
+            return IntentDecision(
+                intent="presales", confidence=0.95, reason="product question"
+            )
+        return IntentDecision(
+            intent="other", confidence=0.4, reason="ambiguous"
+        )
+
+
+class FixedClassifier:
+    def __init__(self, intent: str) -> None:
+        self.intent = intent
+
+    def invoke(self, messages: list[Any]) -> IntentDecision:
+        del messages
+        return IntentDecision(
+            intent=self.intent, confidence=0.99, reason="test route"
+        )
+
+
+class DeterministicToolModel(BaseChatModel):
+    """Minimal real LangChain model that drives a LangGraph ReAct tool call."""
+
+    tool_name: str
+    tool_args: dict[str, Any]
+
+    @property
+    def _llm_type(self) -> str:
+        return "deterministic-tool-model"
+
+    def bind_tools(
+        self,
+        tools: Sequence[Any],
+        *,
+        tool_choice: str | None = None,
+        **kwargs: Any,
+    ) -> Runnable[Any, AIMessage]:
+        del tools, tool_choice, kwargs
+        return self
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        del stop, run_manager, kwargs
+        is_review = any(
+            isinstance(message, SystemMessage)
+            and "final response reviewer" in str(message.content)
+            for message in messages
+        )
+        if is_review:
+            response = AIMessage(content="reviewed deterministic answer")
+        elif any(isinstance(message, ToolMessage) for message in messages):
+            response = AIMessage(content="deterministic specialist answer")
+        else:
+            response = AIMessage(
+                content="",
+                tool_calls=[
+                    {
+                        "name": self.tool_name,
+                        "args": self.tool_args,
+                        "id": "deterministic-call",
+                        "type": "tool_call",
+                    }
+                ],
+            )
+        return ChatResult(generations=[ChatGeneration(message=response)])
+
+
+class FakeModel:
+    def __init__(self, *, fail_review: bool = False) -> None:
+        self.fail_review = fail_review
+        self.review_inputs: list[str] = []
+
+    def with_structured_output(self, schema: Any) -> KeywordClassifier:
+        assert schema is IntentDecision
+        return KeywordClassifier()
+
+    def invoke(self, messages: list[Any]) -> AIMessage:
+        if self.fail_review:
+            raise RuntimeError("synthetic reviewer failure")
+        review_input = messages[-1].content
+        self.review_inputs.append(review_input)
+        return AIMessage(content=f"reviewed: {review_input}")
+
+
+class FakeAgent:
+    def __init__(
+        self, name: str, calls: list[str], *, fail: bool = False
+    ) -> None:
+        self.name = name
+        self.calls = calls
+        self.fail = fail
+
+    def invoke(self, input_data: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append(self.name)
+        if self.fail:
+            raise RuntimeError("synthetic specialist failure")
+        question = input_data["messages"][-1].content
+        return {
+            "messages": [
+                ToolMessage(
+                    content=f'{{"source": "{self.name}", "ok": true}}',
+                    tool_call_id=f"call-{self.name}",
+                    name=f"{self.name}_tool",
+                ),
+                AIMessage(content=f"{self.name} draft for {question}"),
+            ]
+        }
+
+
+def make_workflow(
+    *, fail_review: bool = False, fail_agent: str | None = None
+) -> tuple[EcommerceSupportWorkflow, FakeModel, list[str]]:
+    calls: list[str] = []
+    model = FakeModel(fail_review=fail_review)
+
+    def factory(**kwargs: Any) -> FakeAgent:
+        name = kwargs["name"]
+        return FakeAgent(name, calls, fail=name == fail_agent)
+
+    return EcommerceSupportWorkflow(model, agent_factory=factory), model, calls
+
+
+def test_synthetic_tools_return_bounded_results() -> None:
+    assert '"P-DEMO-001"' in search_product_catalog.invoke({"query": "shoes"})
+    inventory = check_inventory.invoke(
+        {"product_id": "P-DEMO-001", "size": "42"}
+    )
+    assert '"available": true' in inventory
+    assert '"quantity": 4' in inventory
+    assert '"window_days": 30' in query_after_sales_policy.invoke(
+        {"issue_type": "quality_issue"}
+    )
+
+
+def test_missing_order_is_a_tool_result_not_an_exception() -> None:
+    result = lookup_order_history.invoke({"order_id": "DEMO-404"})
+    assert '"ok": false' in result
+    assert "order not found" in result
+
+
+def test_route_selection_uses_intent_and_confidence() -> None:
+    assert (
+        select_route({"intent": "presales", "confidence": 0.9}) == "presales"
+    )
+    assert (
+        select_route({"intent": "aftersales", "confidence": 0.9})
+        == "aftersales"
+    )
+    assert select_route({"intent": "presales", "confidence": 0.2}) == "clarify"
+    assert select_route({"intent": "other", "confidence": 1.0}) == "clarify"
+
+
+def test_presales_and_aftersales_use_different_agents() -> None:
+    workflow, model, calls = make_workflow()
+    presales = workflow.run("Are the commuter shoes in stock in size 42?")
+    aftersales = workflow.run(
+        "Order DEMO-1001 has a defect. Can I get a refund?"
+    )
+
+    assert presales["route"] == "presales"
+    assert aftersales["route"] == "aftersales"
+    assert calls == ["presales_agent", "aftersales_agent"]
+    assert "presales_agent_tool" in model.review_inputs[0]
+    assert "aftersales_agent_tool" in model.review_inputs[1]
+
+
+@pytest.mark.parametrize(
+    ("intent", "tool_name", "tool_args", "question", "evidence"),
+    [
+        (
+            "presales",
+            "check_inventory",
+            {"product_id": "P-DEMO-001", "size": "42"},
+            "Are the commuter shoes in stock in size 42?",
+            '"quantity": 4',
+        ),
+        (
+            "aftersales",
+            "lookup_order_history",
+            {"order_id": "DEMO-1001"},
+            "What is the status of order DEMO-1001?",
+            '"status": "delivered"',
+        ),
+    ],
+)
+def test_real_langgraph_react_agent_executes_a_synthetic_tool(
+    intent: str,
+    tool_name: str,
+    tool_args: dict[str, Any],
+    question: str,
+    evidence: str,
+) -> None:
+    model = DeterministicToolModel(
+        tool_name=tool_name,
+        tool_args=tool_args,
+    )
+    workflow = EcommerceSupportWorkflow(
+        model,
+        classifier=FixedClassifier(intent),
+    )
+
+    result = workflow.run(question)
+
+    assert result["route"] == intent
+    assert result["final_response"] == "reviewed deterministic answer"
+    assert any(evidence in item for item in result["tool_evidence"])
+
+
+def test_ambiguous_question_uses_clarification_without_a_specialist() -> None:
+    workflow, _, calls = make_workflow()
+    result = workflow.run("Can you help me?")
+    assert result["route"] == "clarify"
+    assert calls == []
+    assert "clarify" in result["final_response"]
+
+
+def test_specialist_and_reviewer_fail_open() -> None:
+    workflow, _, calls = make_workflow(
+        fail_review=True, fail_agent="presales_agent"
+    )
+    result = workflow.run("Are the commuter shoes in stock?")
+    assert calls == ["presales_agent"]
+    assert result["route"] == "presales"
+    assert result["final_response"].startswith(
+        "The pre-sales specialist is temporarily unavailable."
+    )
+
+
+def test_concurrent_invocations_keep_routes_and_answers_isolated() -> None:
+    workflow, _, _ = make_workflow()
+    questions = [
+        "Are the commuter shoes in stock?",
+        "Where is order DEMO-1002?",
+    ]
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(workflow.run, questions))
+
+    assert [result["route"] for result in results] == [
+        "presales",
+        "aftersales",
+    ]
+    assert questions[0] in results[0]["final_response"]
+    assert questions[1] in results[1]["final_response"]

--- a/examples/ecommerce-customer-service/tests/test_workflow.py
+++ b/examples/ecommerce-customer-service/tests/test_workflow.py
@@ -1,9 +1,12 @@
 """Offline tests for the text-only e-commerce support workflow."""
 
+import argparse
+import json
 from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
+import app
 import pytest
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.chat_models import BaseChatModel
@@ -27,16 +30,16 @@ from workflow import EcommerceSupportWorkflow, IntentDecision, select_route
 class KeywordClassifier:
     def invoke(self, messages: list[Any]) -> IntentDecision:
         question = messages[-1].content.casefold()
-        if "order" in question or "refund" in question:
+        if "订单" in question or "退款" in question:
             return IntentDecision(
-                intent="aftersales", confidence=0.95, reason="existing order"
+                intent="aftersales", confidence=0.95, reason="已有订单"
             )
-        if "shoe" in question or "stock" in question:
+        if "鞋" in question or "库存" in question or "有货" in question:
             return IntentDecision(
-                intent="presales", confidence=0.95, reason="product question"
+                intent="presales", confidence=0.95, reason="商品咨询"
             )
         return IntentDecision(
-            intent="other", confidence=0.4, reason="ambiguous"
+            intent="other", confidence=0.4, reason="意图不明确"
         )
 
 
@@ -47,7 +50,7 @@ class FixedClassifier:
     def invoke(self, messages: list[Any]) -> IntentDecision:
         del messages
         return IntentDecision(
-            intent=self.intent, confidence=0.99, reason="test route"
+            intent=self.intent, confidence=0.99, reason="测试路由"
         )
 
 
@@ -81,13 +84,13 @@ class DeterministicToolModel(BaseChatModel):
         del stop, run_manager, kwargs
         is_review = any(
             isinstance(message, SystemMessage)
-            and "final response reviewer" in str(message.content)
+            and "最终回复审核员" in str(message.content)
             for message in messages
         )
         if is_review:
-            response = AIMessage(content="reviewed deterministic answer")
+            response = AIMessage(content="已审核的确定性回复")
         elif any(isinstance(message, ToolMessage) for message in messages):
-            response = AIMessage(content="deterministic specialist answer")
+            response = AIMessage(content="确定性的专业客服回复")
         else:
             response = AIMessage(
                 content="",
@@ -114,10 +117,10 @@ class FakeModel:
 
     def invoke(self, messages: list[Any]) -> AIMessage:
         if self.fail_review:
-            raise RuntimeError("synthetic reviewer failure")
+            raise RuntimeError("虚构审核员异常")
         review_input = messages[-1].content
         self.review_inputs.append(review_input)
-        return AIMessage(content=f"reviewed: {review_input}")
+        return AIMessage(content=f"已审核：{review_input}")
 
 
 class FakeAgent:
@@ -131,7 +134,7 @@ class FakeAgent:
     def invoke(self, input_data: dict[str, Any]) -> dict[str, Any]:
         self.calls.append(self.name)
         if self.fail:
-            raise RuntimeError("synthetic specialist failure")
+            raise RuntimeError("虚构专业客服异常")
         question = input_data["messages"][-1].content
         return {
             "messages": [
@@ -140,7 +143,7 @@ class FakeAgent:
                     tool_call_id=f"call-{self.name}",
                     name=f"{self.name}_tool",
                 ),
-                AIMessage(content=f"{self.name} draft for {question}"),
+                AIMessage(content=f"{self.name} 针对“{question}”的回复草稿"),
             ]
         }
 
@@ -159,7 +162,7 @@ def make_workflow(
 
 
 def test_synthetic_tools_return_bounded_results() -> None:
-    assert '"P-DEMO-001"' in search_product_catalog.invoke({"query": "shoes"})
+    assert '"P-DEMO-001"' in search_product_catalog.invoke({"query": "通勤鞋"})
     inventory = check_inventory.invoke(
         {"product_id": "P-DEMO-001", "size": "42"}
     )
@@ -172,8 +175,34 @@ def test_synthetic_tools_return_bounded_results() -> None:
 
 def test_missing_order_is_a_tool_result_not_an_exception() -> None:
     result = lookup_order_history.invoke({"order_id": "DEMO-404"})
-    assert '"ok": false' in result
-    assert "order not found" in result
+    assert json.loads(result) == {
+        "error": "未找到订单：DEMO-404",
+        "ok": False,
+    }
+
+
+def test_cli_reports_a_chinese_error_for_a_blank_question(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    class EmptyQuestionWorkflow:
+        def run(self, question: str) -> dict[str, Any]:
+            del question
+            raise ValueError("问题不能为空")
+
+    monkeypatch.setattr(
+        app,
+        "parse_args",
+        lambda: argparse.Namespace(question="  "),
+    )
+    monkeypatch.setattr(app, "create_model", lambda: object())
+    monkeypatch.setattr(
+        app,
+        "EcommerceSupportWorkflow",
+        lambda model: EmptyQuestionWorkflow(),
+    )
+
+    assert app.main() == 2
+    assert capsys.readouterr().err == "请求错误：问题不能为空\n"
 
 
 def test_route_selection_uses_intent_and_confidence() -> None:
@@ -190,10 +219,8 @@ def test_route_selection_uses_intent_and_confidence() -> None:
 
 def test_presales_and_aftersales_use_different_agents() -> None:
     workflow, model, calls = make_workflow()
-    presales = workflow.run("Are the commuter shoes in stock in size 42?")
-    aftersales = workflow.run(
-        "Order DEMO-1001 has a defect. Can I get a refund?"
-    )
+    presales = workflow.run("云步通勤鞋 42 码有货吗？")
+    aftersales = workflow.run("订单 DEMO-1001 的鞋有质量问题，可以退款吗？")
 
     assert presales["route"] == "presales"
     assert aftersales["route"] == "aftersales"
@@ -209,15 +236,15 @@ def test_presales_and_aftersales_use_different_agents() -> None:
             "presales",
             "check_inventory",
             {"product_id": "P-DEMO-001", "size": "42"},
-            "Are the commuter shoes in stock in size 42?",
+            "云步通勤鞋 42 码有货吗？",
             '"quantity": 4',
         ),
         (
             "aftersales",
             "lookup_order_history",
             {"order_id": "DEMO-1001"},
-            "What is the status of order DEMO-1001?",
-            '"status": "delivered"',
+            "订单 DEMO-1001 现在是什么状态？",
+            '"status": "已签收"',
         ),
     ],
 )
@@ -240,35 +267,33 @@ def test_real_langgraph_react_agent_executes_a_synthetic_tool(
     result = workflow.run(question)
 
     assert result["route"] == intent
-    assert result["final_response"] == "reviewed deterministic answer"
+    assert result["final_response"] == "已审核的确定性回复"
     assert any(evidence in item for item in result["tool_evidence"])
 
 
 def test_ambiguous_question_uses_clarification_without_a_specialist() -> None:
     workflow, _, calls = make_workflow()
-    result = workflow.run("Can you help me?")
+    result = workflow.run("能帮帮我吗？")
     assert result["route"] == "clarify"
     assert calls == []
-    assert "clarify" in result["final_response"]
+    assert "请问你想咨询" in result["final_response"]
 
 
 def test_specialist_and_reviewer_fail_open() -> None:
     workflow, _, calls = make_workflow(
         fail_review=True, fail_agent="presales_agent"
     )
-    result = workflow.run("Are the commuter shoes in stock?")
+    result = workflow.run("云步通勤鞋有货吗？")
     assert calls == ["presales_agent"]
     assert result["route"] == "presales"
-    assert result["final_response"].startswith(
-        "The pre-sales specialist is temporarily unavailable."
-    )
+    assert result["final_response"].startswith("售前客服暂时不可用")
 
 
 def test_concurrent_invocations_keep_routes_and_answers_isolated() -> None:
     workflow, _, _ = make_workflow()
     questions = [
-        "Are the commuter shoes in stock?",
-        "Where is order DEMO-1002?",
+        "云步通勤鞋有货吗？",
+        "订单 DEMO-1002 到哪里了？",
     ]
     with ThreadPoolExecutor(max_workers=2) as executor:
         results = list(executor.map(workflow.run, questions))

--- a/examples/ecommerce-customer-service/tools.py
+++ b/examples/ecommerce-customer-service/tools.py
@@ -1,4 +1,4 @@
-"""Synthetic tools for the e-commerce customer service example."""
+"""电商客服示例使用的虚构工具和数据。"""
 
 import json
 from collections.abc import Callable
@@ -8,17 +8,17 @@ from langchain_core.tools import tool
 
 PRODUCTS = {
     "P-DEMO-001": {
-        "name": "CloudStep commuter shoes",
-        "category": "shoes",
-        "material": "water-resistant woven upper and rubber outsole",
-        "use_cases": ["daily commute", "light walking"],
+        "name": "云步通勤鞋",
+        "category": "鞋履",
+        "material": "防泼水织物鞋面和橡胶外底",
+        "use_cases": ["日常通勤", "轻度步行"],
         "sizes": ["39", "40", "41", "42", "43"],
     },
     "P-DEMO-002": {
-        "name": "Breeze insulated bottle",
-        "category": "drinkware",
-        "material": "food-grade stainless steel",
-        "use_cases": ["office", "short trips"],
+        "name": "清风保温杯",
+        "category": "杯具",
+        "material": "食品级不锈钢",
+        "use_cases": ["办公室", "短途出行"],
         "sizes": ["500ml"],
     },
 }
@@ -36,13 +36,13 @@ ORDERS = {
     "DEMO-1001": {
         "product_id": "P-DEMO-001",
         "size": "42",
-        "status": "delivered",
+        "status": "已签收",
         "delivered_days_ago": 1,
     },
     "DEMO-1002": {
         "product_id": "P-DEMO-002",
         "size": "500ml",
-        "status": "in_transit",
+        "status": "运输中",
         "delivered_days_ago": None,
     },
 }
@@ -50,13 +50,13 @@ ORDERS = {
 POLICIES = {
     "quality_issue": {
         "window_days": 30,
-        "resolution": "inspection followed by replacement or refund when confirmed",
-        "required_evidence": "order ID and a text description of the issue",
+        "resolution": "核验属实后可换货或退款",
+        "required_evidence": "订单号和问题文字描述",
     },
     "change_of_mind": {
         "window_days": 7,
-        "resolution": "return when the product is unused and complete",
-        "required_evidence": "order ID and product condition",
+        "resolution": "商品未使用且配件完整时可以退货",
+        "required_evidence": "订单号和商品状态说明",
     },
 }
 
@@ -66,16 +66,19 @@ def _json(data: Any) -> str:
 
 
 def _safe_lookup(operation: Callable[[], Any]) -> str:
-    """Keep synthetic tool failures explainable instead of crashing the agent."""
+    """将虚构工具异常转为可解释的结果，避免中断 Agent。"""
     try:
         return _json({"ok": True, "data": operation()})
     except (KeyError, TypeError, ValueError) as exc:
-        return _json({"ok": False, "error": str(exc)})
+        message = (
+            exc.args[0] if isinstance(exc, KeyError) and exc.args else str(exc)
+        )
+        return _json({"ok": False, "error": str(message)})
 
 
 @tool
 def search_product_catalog(query: str) -> str:
-    """Search the synthetic product catalog by product name, category, or use case."""
+    """按商品名称、分类或使用场景搜索虚构商品目录。"""
 
     def search() -> list[dict[str, Any]]:
         normalized = query.casefold()
@@ -104,11 +107,11 @@ def search_product_catalog(query: str) -> str:
 
 @tool
 def query_product_knowledge(product_id: str) -> str:
-    """Return specifications and suitable use cases for a synthetic product ID."""
+    """按虚构商品编号查询规格和适用场景。"""
 
     def lookup() -> dict[str, Any]:
         if product_id not in PRODUCTS:
-            raise KeyError(f"unknown product: {product_id}")
+            raise KeyError(f"未找到商品：{product_id}")
         return {"product_id": product_id, **PRODUCTS[product_id]}
 
     return _safe_lookup(lookup)
@@ -116,13 +119,13 @@ def query_product_knowledge(product_id: str) -> str:
 
 @tool
 def check_inventory(product_id: str, size: str) -> str:
-    """Check synthetic inventory for one product and size."""
+    """查询指定虚构商品和尺码的库存。"""
 
     def lookup() -> dict[str, Any]:
         if product_id not in PRODUCTS:
-            raise KeyError(f"unknown product: {product_id}")
+            raise KeyError(f"未找到商品：{product_id}")
         if (product_id, size) not in INVENTORY:
-            raise KeyError(f"unknown size {size} for product {product_id}")
+            raise KeyError(f"商品 {product_id} 没有尺码 {size}")
         quantity = INVENTORY[(product_id, size)]
         return {
             "product_id": product_id,
@@ -136,11 +139,11 @@ def check_inventory(product_id: str, size: str) -> str:
 
 @tool
 def lookup_order_history(order_id: str) -> str:
-    """Look up a synthetic order. Only DEMO-prefixed IDs exist in this example."""
+    """查询虚构订单；本示例只包含 DEMO- 前缀的订单号。"""
 
     def lookup() -> dict[str, Any]:
         if order_id not in ORDERS:
-            raise KeyError(f"order not found: {order_id}")
+            raise KeyError(f"未找到订单：{order_id}")
         return {"order_id": order_id, **ORDERS[order_id]}
 
     return _safe_lookup(lookup)
@@ -148,11 +151,11 @@ def lookup_order_history(order_id: str) -> str:
 
 @tool
 def query_after_sales_policy(issue_type: str) -> str:
-    """Return the synthetic policy for quality_issue or change_of_mind."""
+    """查询 quality_issue（质量问题）或 change_of_mind（无理由退货）政策。"""
 
     def lookup() -> dict[str, Any]:
         if issue_type not in POLICIES:
-            raise KeyError(f"unsupported issue type: {issue_type}")
+            raise KeyError(f"不支持的问题类型：{issue_type}")
         return {"issue_type": issue_type, **POLICIES[issue_type]}
 
     return _safe_lookup(lookup)
@@ -160,23 +163,21 @@ def query_after_sales_policy(issue_type: str) -> str:
 
 @tool
 def assess_issue(order_id: str, description: str) -> str:
-    """Provide a bounded next step using a synthetic order and text description."""
+    """根据虚构订单和文字问题描述给出有限的下一步建议。"""
 
     def assess() -> dict[str, Any]:
         if order_id not in ORDERS:
-            raise KeyError(f"order not found: {order_id}")
+            raise KeyError(f"未找到订单：{order_id}")
         if not description.strip():
-            raise ValueError("issue description is required")
+            raise ValueError("必须提供问题描述")
         order = ORDERS[order_id]
-        if order["status"] != "delivered":
-            next_step = "wait for delivery or contact logistics support"
+        if order["status"] != "已签收":
+            next_step = "等待商品送达，或联系物流客服查询"
         else:
-            next_step = (
-                "submit the order ID and issue description for inspection"
-            )
+            next_step = "提交订单号和问题描述，等待人工核验"
         return {
             "order_id": order_id,
-            "assessment": "manual verification required",
+            "assessment": "需要人工核验",
             "next_step": next_step,
         }
 

--- a/examples/ecommerce-customer-service/tools.py
+++ b/examples/ecommerce-customer-service/tools.py
@@ -1,0 +1,196 @@
+"""Synthetic tools for the e-commerce customer service example."""
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+from langchain_core.tools import tool
+
+PRODUCTS = {
+    "P-DEMO-001": {
+        "name": "CloudStep commuter shoes",
+        "category": "shoes",
+        "material": "water-resistant woven upper and rubber outsole",
+        "use_cases": ["daily commute", "light walking"],
+        "sizes": ["39", "40", "41", "42", "43"],
+    },
+    "P-DEMO-002": {
+        "name": "Breeze insulated bottle",
+        "category": "drinkware",
+        "material": "food-grade stainless steel",
+        "use_cases": ["office", "short trips"],
+        "sizes": ["500ml"],
+    },
+}
+
+INVENTORY = {
+    ("P-DEMO-001", "39"): 8,
+    ("P-DEMO-001", "40"): 12,
+    ("P-DEMO-001", "41"): 6,
+    ("P-DEMO-001", "42"): 4,
+    ("P-DEMO-001", "43"): 0,
+    ("P-DEMO-002", "500ml"): 15,
+}
+
+ORDERS = {
+    "DEMO-1001": {
+        "product_id": "P-DEMO-001",
+        "size": "42",
+        "status": "delivered",
+        "delivered_days_ago": 1,
+    },
+    "DEMO-1002": {
+        "product_id": "P-DEMO-002",
+        "size": "500ml",
+        "status": "in_transit",
+        "delivered_days_ago": None,
+    },
+}
+
+POLICIES = {
+    "quality_issue": {
+        "window_days": 30,
+        "resolution": "inspection followed by replacement or refund when confirmed",
+        "required_evidence": "order ID and a text description of the issue",
+    },
+    "change_of_mind": {
+        "window_days": 7,
+        "resolution": "return when the product is unused and complete",
+        "required_evidence": "order ID and product condition",
+    },
+}
+
+
+def _json(data: Any) -> str:
+    return json.dumps(data, ensure_ascii=False, sort_keys=True)
+
+
+def _safe_lookup(operation: Callable[[], Any]) -> str:
+    """Keep synthetic tool failures explainable instead of crashing the agent."""
+    try:
+        return _json({"ok": True, "data": operation()})
+    except (KeyError, TypeError, ValueError) as exc:
+        return _json({"ok": False, "error": str(exc)})
+
+
+@tool
+def search_product_catalog(query: str) -> str:
+    """Search the synthetic product catalog by product name, category, or use case."""
+
+    def search() -> list[dict[str, Any]]:
+        normalized = query.casefold()
+        matches = []
+        for product_id, product in PRODUCTS.items():
+            searchable = " ".join(
+                [
+                    product_id,
+                    product["name"],
+                    product["category"],
+                    *product["use_cases"],
+                ]
+            ).casefold()
+            if not normalized or normalized in searchable:
+                matches.append(
+                    {
+                        "product_id": product_id,
+                        "name": product["name"],
+                        "category": product["category"],
+                    }
+                )
+        return matches
+
+    return _safe_lookup(search)
+
+
+@tool
+def query_product_knowledge(product_id: str) -> str:
+    """Return specifications and suitable use cases for a synthetic product ID."""
+
+    def lookup() -> dict[str, Any]:
+        if product_id not in PRODUCTS:
+            raise KeyError(f"unknown product: {product_id}")
+        return {"product_id": product_id, **PRODUCTS[product_id]}
+
+    return _safe_lookup(lookup)
+
+
+@tool
+def check_inventory(product_id: str, size: str) -> str:
+    """Check synthetic inventory for one product and size."""
+
+    def lookup() -> dict[str, Any]:
+        if product_id not in PRODUCTS:
+            raise KeyError(f"unknown product: {product_id}")
+        if (product_id, size) not in INVENTORY:
+            raise KeyError(f"unknown size {size} for product {product_id}")
+        quantity = INVENTORY[(product_id, size)]
+        return {
+            "product_id": product_id,
+            "size": size,
+            "available": quantity > 0,
+            "quantity": quantity,
+        }
+
+    return _safe_lookup(lookup)
+
+
+@tool
+def lookup_order_history(order_id: str) -> str:
+    """Look up a synthetic order. Only DEMO-prefixed IDs exist in this example."""
+
+    def lookup() -> dict[str, Any]:
+        if order_id not in ORDERS:
+            raise KeyError(f"order not found: {order_id}")
+        return {"order_id": order_id, **ORDERS[order_id]}
+
+    return _safe_lookup(lookup)
+
+
+@tool
+def query_after_sales_policy(issue_type: str) -> str:
+    """Return the synthetic policy for quality_issue or change_of_mind."""
+
+    def lookup() -> dict[str, Any]:
+        if issue_type not in POLICIES:
+            raise KeyError(f"unsupported issue type: {issue_type}")
+        return {"issue_type": issue_type, **POLICIES[issue_type]}
+
+    return _safe_lookup(lookup)
+
+
+@tool
+def assess_issue(order_id: str, description: str) -> str:
+    """Provide a bounded next step using a synthetic order and text description."""
+
+    def assess() -> dict[str, Any]:
+        if order_id not in ORDERS:
+            raise KeyError(f"order not found: {order_id}")
+        if not description.strip():
+            raise ValueError("issue description is required")
+        order = ORDERS[order_id]
+        if order["status"] != "delivered":
+            next_step = "wait for delivery or contact logistics support"
+        else:
+            next_step = (
+                "submit the order ID and issue description for inspection"
+            )
+        return {
+            "order_id": order_id,
+            "assessment": "manual verification required",
+            "next_step": next_step,
+        }
+
+    return _safe_lookup(assess)
+
+
+PRESALES_TOOLS = [
+    search_product_catalog,
+    query_product_knowledge,
+    check_inventory,
+]
+
+AFTERSALES_TOOLS = [
+    lookup_order_history,
+    query_after_sales_policy,
+    assess_issue,
+]

--- a/examples/ecommerce-customer-service/workflow.py
+++ b/examples/ecommerce-customer-service/workflow.py
@@ -1,0 +1,284 @@
+"""LangGraph workflow for a text-only e-commerce support example."""
+
+import json
+from collections.abc import Callable, Sequence
+from typing import Any, Literal, Protocol, TypedDict
+
+from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
+from langchain_core.tools import BaseTool
+from langgraph.graph import END, START, StateGraph
+from langgraph.prebuilt import create_react_agent
+from pydantic import BaseModel, Field
+from tools import AFTERSALES_TOOLS, PRESALES_TOOLS
+
+Route = Literal["presales", "aftersales", "clarify"]
+
+PRESALES_PROMPT = """You are the pre-sales specialist for a fictional store.
+Use only the supplied synthetic catalog, product knowledge, and inventory tools.
+Call at least one tool before answering. If a requested fact is unavailable, say so.
+Never invent prices, promotions, delivery promises, or product capabilities.
+"""
+
+AFTERSALES_PROMPT = """You are the after-sales specialist for a fictional store.
+Use only the supplied synthetic order, policy, and issue-assessment tools.
+Call the order tool before discussing an order. Never promise a refund or replacement;
+describe the policy and the next verification step instead.
+"""
+
+REVIEW_PROMPT = """You are the final response reviewer for a fictional store.
+Rewrite the draft as a concise, helpful customer reply. Preserve only facts supported
+by the tool evidence. Do not add prices, stock, policy, order status, guarantees, or
+actions that are absent from the evidence. If evidence is missing, keep the uncertainty.
+Return only the final customer-facing answer.
+"""
+
+
+class IntentDecision(BaseModel):
+    """Structured result produced by the intent router."""
+
+    intent: Literal["presales", "aftersales", "other"]
+    confidence: float = Field(ge=0, le=1)
+    reason: str
+
+
+class SupportState(TypedDict, total=False):
+    """State shared by the outer customer-service graph."""
+
+    question: str
+    intent: str
+    confidence: float
+    route: Route
+    draft_response: str
+    tool_evidence: list[str]
+    final_response: str
+
+
+class StructuredClassifier(Protocol):
+    def invoke(self, input_data: Any) -> IntentDecision | dict[str, Any]: ...
+
+
+class ChatModel(Protocol):
+    def with_structured_output(
+        self, schema: type[BaseModel]
+    ) -> StructuredClassifier: ...
+
+    def invoke(self, input_data: Any) -> BaseMessage: ...
+
+
+class AgentRunner(Protocol):
+    def invoke(self, input_data: dict[str, Any]) -> dict[str, Any]: ...
+
+
+AgentFactory = Callable[..., AgentRunner]
+
+
+def default_agent_factory(
+    *, name: str, model: ChatModel, tools: Sequence[BaseTool], prompt: str
+) -> AgentRunner:
+    """Build a LangGraph ReAct agent while keeping construction injectable for tests."""
+    del name  # The outer graph node supplies the observable specialist name.
+    return create_react_agent(model=model, tools=list(tools), prompt=prompt)
+
+
+def select_route(
+    state: SupportState, confidence_threshold: float = 0.6
+) -> Route:
+    """Map the structured decision to an explicit graph branch."""
+    if state.get("confidence", 0) < confidence_threshold:
+        return "clarify"
+    intent = state.get("intent")
+    if intent == "presales":
+        return "presales"
+    if intent == "aftersales":
+        return "aftersales"
+    return "clarify"
+
+
+def _content_to_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict) and isinstance(item.get("text"), str):
+                parts.append(item["text"])
+        return "\n".join(parts)
+    return str(content)
+
+
+def extract_agent_result(result: dict[str, Any]) -> tuple[str, list[str]]:
+    """Extract the final assistant text and tool evidence from an agent result."""
+    messages = result.get("messages", [])
+    answer = ""
+    evidence = []
+    for message in messages:
+        message_type = getattr(message, "type", "")
+        content = _content_to_text(getattr(message, "content", ""))
+        if message_type == "tool":
+            name = getattr(message, "name", None) or "tool"
+            evidence.append(f"{name}: {content}")
+        elif message_type == "ai" and content.strip():
+            answer = content.strip()
+    if not answer:
+        raise ValueError("specialist agent returned no final answer")
+    return answer, evidence
+
+
+def build_review_input(state: SupportState) -> str:
+    """Build a bounded review request from the draft and observed tool results."""
+    payload = {
+        "route": state.get("route", "clarify"),
+        "customer_question": state["question"],
+        "draft_response": state.get("draft_response", ""),
+        "tool_evidence": state.get("tool_evidence", []),
+    }
+    return json.dumps(payload, ensure_ascii=False, sort_keys=True)
+
+
+class EcommerceSupportWorkflow:
+    """Route a text question to a specialist and review its response."""
+
+    def __init__(
+        self,
+        model: ChatModel,
+        *,
+        classifier: StructuredClassifier | None = None,
+        agent_factory: AgentFactory = default_agent_factory,
+        confidence_threshold: float = 0.6,
+    ) -> None:
+        self.model = model
+        self.classifier = classifier or model.with_structured_output(
+            IntentDecision
+        )
+        self.confidence_threshold = confidence_threshold
+        self.presales_agent = agent_factory(
+            name="presales_agent",
+            model=model,
+            tools=PRESALES_TOOLS,
+            prompt=PRESALES_PROMPT,
+        )
+        self.aftersales_agent = agent_factory(
+            name="aftersales_agent",
+            model=model,
+            tools=AFTERSALES_TOOLS,
+            prompt=AFTERSALES_PROMPT,
+        )
+        self.graph = self._build_graph()
+
+    def _build_graph(self) -> Any:
+        graph = StateGraph(SupportState)
+        graph.add_node("intent_router", self._route_intent)
+        graph.add_node("presales_agent", self._run_presales)
+        graph.add_node("aftersales_agent", self._run_aftersales)
+        graph.add_node("clarify", self._clarify)
+        graph.add_node("response_review", self._review_response)
+        graph.add_edge(START, "intent_router")
+        graph.add_conditional_edges(
+            "intent_router",
+            lambda state: select_route(state, self.confidence_threshold),
+            {
+                "presales": "presales_agent",
+                "aftersales": "aftersales_agent",
+                "clarify": "clarify",
+            },
+        )
+        graph.add_edge("presales_agent", "response_review")
+        graph.add_edge("aftersales_agent", "response_review")
+        graph.add_edge("clarify", "response_review")
+        graph.add_edge("response_review", END)
+        return graph.compile()
+
+    def _route_intent(self, state: SupportState) -> SupportState:
+        question = state["question"]
+        try:
+            raw_decision = self.classifier.invoke(
+                [
+                    SystemMessage(
+                        content=(
+                            "Classify this e-commerce question as presales, aftersales, "
+                            "or other. Presales covers product selection, specifications, "
+                            "and stock. Aftersales covers an existing order, delivery, "
+                            "returns, warranty, or a product issue."
+                        )
+                    ),
+                    HumanMessage(content=question),
+                ]
+            )
+            decision = (
+                raw_decision
+                if isinstance(raw_decision, IntentDecision)
+                else IntentDecision.model_validate(raw_decision)
+            )
+        except Exception:  # noqa: BLE001 - an unavailable model must fail open
+            decision = IntentDecision(
+                intent="other",
+                confidence=0,
+                reason="intent classification was unavailable",
+            )
+        route = select_route(
+            {"intent": decision.intent, "confidence": decision.confidence},
+            self.confidence_threshold,
+        )
+        return {
+            "intent": decision.intent,
+            "confidence": decision.confidence,
+            "route": route,
+        }
+
+    def _run_specialist(
+        self, state: SupportState, agent: AgentRunner, label: str
+    ) -> SupportState:
+        try:
+            result = agent.invoke(
+                {"messages": [HumanMessage(content=state["question"])]}
+            )
+            draft, evidence = extract_agent_result(result)
+            return {"draft_response": draft, "tool_evidence": evidence}
+        except Exception:  # noqa: BLE001 - an unavailable agent must fail open
+            return {
+                "draft_response": (
+                    f"The {label} specialist is temporarily unavailable. "
+                    "Please try again or provide more details."
+                ),
+                "tool_evidence": [],
+            }
+
+    def _run_presales(self, state: SupportState) -> SupportState:
+        return self._run_specialist(state, self.presales_agent, "pre-sales")
+
+    def _run_aftersales(self, state: SupportState) -> SupportState:
+        return self._run_specialist(
+            state, self.aftersales_agent, "after-sales"
+        )
+
+    def _clarify(self, state: SupportState) -> SupportState:
+        return {
+            "draft_response": (
+                "Could you clarify whether you are asking about choosing a product "
+                "or about an existing order?"
+            ),
+            "tool_evidence": [],
+        }
+
+    def _review_response(self, state: SupportState) -> SupportState:
+        try:
+            response = self.model.invoke(
+                [
+                    SystemMessage(content=REVIEW_PROMPT),
+                    HumanMessage(content=build_review_input(state)),
+                ]
+            )
+            final_response = _content_to_text(response.content).strip()
+            if not final_response:
+                raise ValueError("reviewer returned an empty response")
+        except Exception:  # noqa: BLE001 - review failure returns the safe draft
+            final_response = state["draft_response"]
+        return {"final_response": final_response}
+
+    def run(self, question: str) -> SupportState:
+        normalized = question.strip()
+        if not normalized:
+            raise ValueError("question must not be empty")
+        return self.graph.invoke({"question": normalized})

--- a/examples/ecommerce-customer-service/workflow.py
+++ b/examples/ecommerce-customer-service/workflow.py
@@ -4,10 +4,10 @@ import json
 from collections.abc import Callable, Sequence
 from typing import Any, Literal, Protocol, TypedDict
 
+from langchain.agents import create_agent
 from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
 from langchain_core.tools import BaseTool
 from langgraph.graph import END, START, StateGraph
-from langgraph.prebuilt import create_react_agent
 from pydantic import BaseModel, Field
 from tools import AFTERSALES_TOOLS, PRESALES_TOOLS
 
@@ -76,9 +76,13 @@ AgentFactory = Callable[..., AgentRunner]
 def default_agent_factory(
     *, name: str, model: ChatModel, tools: Sequence[BaseTool], prompt: str
 ) -> AgentRunner:
-    """Build a LangGraph ReAct agent while keeping construction injectable for tests."""
-    del name  # The outer graph node supplies the observable specialist name.
-    return create_react_agent(model=model, tools=list(tools), prompt=prompt)
+    """Build a LangGraph-backed agent while keeping construction injectable."""
+    return create_agent(
+        model=model,
+        tools=list(tools),
+        system_prompt=prompt,
+        name=name,
+    )
 
 
 def select_route(

--- a/examples/ecommerce-customer-service/workflow.py
+++ b/examples/ecommerce-customer-service/workflow.py
@@ -1,4 +1,4 @@
-"""LangGraph workflow for a text-only e-commerce support example."""
+"""纯文字电商客服 LangGraph 工作流。"""
 
 import json
 from collections.abc import Callable, Sequence
@@ -13,23 +13,24 @@ from tools import AFTERSALES_TOOLS, PRESALES_TOOLS
 
 Route = Literal["presales", "aftersales", "clarify"]
 
-PRESALES_PROMPT = """You are the pre-sales specialist for a fictional store.
-Use only the supplied synthetic catalog, product knowledge, and inventory tools.
-Call at least one tool before answering. If a requested fact is unavailable, say so.
-Never invent prices, promotions, delivery promises, or product capabilities.
+PRESALES_PROMPT = """你是虚构电商店铺的售前客服。
+只能使用提供的虚构商品目录、商品知识和库存工具。
+回答前至少调用一个工具；工具未提供的信息要明确说明不知道。
+不得编造价格、促销、到货承诺或商品能力。
+请始终使用简体中文回复。
 """
 
-AFTERSALES_PROMPT = """You are the after-sales specialist for a fictional store.
-Use only the supplied synthetic order, policy, and issue-assessment tools.
-Call the order tool before discussing an order. Never promise a refund or replacement;
-describe the policy and the next verification step instead.
+AFTERSALES_PROMPT = """你是虚构电商店铺的售后客服。
+只能使用提供的虚构订单、售后政策和问题评估工具。
+讨论订单前必须先调用订单查询工具。不得直接承诺退款或换货，
+只能说明政策依据和下一步核验流程。
+请始终使用简体中文回复。
 """
 
-REVIEW_PROMPT = """You are the final response reviewer for a fictional store.
-Rewrite the draft as a concise, helpful customer reply. Preserve only facts supported
-by the tool evidence. Do not add prices, stock, policy, order status, guarantees, or
-actions that are absent from the evidence. If evidence is missing, keep the uncertainty.
-Return only the final customer-facing answer.
+REVIEW_PROMPT = """你是虚构电商店铺的最终回复审核员。
+请把草稿润色成简洁、友善的中文客服回复，只保留工具证据支持的事实。
+不得补充证据中没有的价格、库存、政策、订单状态、保证或处理动作。
+证据不足时必须保留不确定性。只输出最终给客户看的中文回复。
 """
 
 
@@ -122,7 +123,7 @@ def extract_agent_result(result: dict[str, Any]) -> tuple[str, list[str]]:
         elif message_type == "ai" and content.strip():
             answer = content.strip()
     if not answer:
-        raise ValueError("specialist agent returned no final answer")
+        raise ValueError("专业客服 Agent 未返回最终答案")
     return answer, evidence
 
 
@@ -197,10 +198,10 @@ class EcommerceSupportWorkflow:
                 [
                     SystemMessage(
                         content=(
-                            "Classify this e-commerce question as presales, aftersales, "
-                            "or other. Presales covers product selection, specifications, "
-                            "and stock. Aftersales covers an existing order, delivery, "
-                            "returns, warranty, or a product issue."
+                            "请将这个电商问题分类为 presales、aftersales 或 other。"
+                            "presales（售前）包括商品选择、规格和库存；"
+                            "aftersales（售后）包括已有订单、物流、退换、质保或"
+                            "商品问题。只判断意图，不要回答用户问题。"
                         )
                     ),
                     HumanMessage(content=question),
@@ -215,7 +216,7 @@ class EcommerceSupportWorkflow:
             decision = IntentDecision(
                 intent="other",
                 confidence=0,
-                reason="intent classification was unavailable",
+                reason="意图识别暂时不可用",
             )
         route = select_route(
             {"intent": decision.intent, "confidence": decision.confidence},
@@ -239,25 +240,22 @@ class EcommerceSupportWorkflow:
         except Exception:  # noqa: BLE001 - an unavailable agent must fail open
             return {
                 "draft_response": (
-                    f"The {label} specialist is temporarily unavailable. "
-                    "Please try again or provide more details."
+                    f"{label}客服暂时不可用，请稍后重试或补充更多信息。"
                 ),
                 "tool_evidence": [],
             }
 
     def _run_presales(self, state: SupportState) -> SupportState:
-        return self._run_specialist(state, self.presales_agent, "pre-sales")
+        return self._run_specialist(state, self.presales_agent, "售前")
 
     def _run_aftersales(self, state: SupportState) -> SupportState:
-        return self._run_specialist(
-            state, self.aftersales_agent, "after-sales"
-        )
+        return self._run_specialist(state, self.aftersales_agent, "售后")
 
     def _clarify(self, state: SupportState) -> SupportState:
         return {
             "draft_response": (
-                "Could you clarify whether you are asking about choosing a product "
-                "or about an existing order?"
+                "请问你想咨询商品选择、规格或库存，还是想查询已有订单、"
+                "物流或退换货问题？"
             ),
             "tool_evidence": [],
         }
@@ -272,13 +270,15 @@ class EcommerceSupportWorkflow:
             )
             final_response = _content_to_text(response.content).strip()
             if not final_response:
-                raise ValueError("reviewer returned an empty response")
+                raise ValueError("回复审核员返回了空内容")
         except Exception:  # noqa: BLE001 - review failure returns the safe draft
-            final_response = state["draft_response"]
+            final_response = state.get("draft_response") or (
+                "暂时无法生成回复，请稍后重试。"
+            )
         return {"final_response": final_response}
 
     def run(self, question: str) -> SupportState:
         normalized = question.strip()
         if not normalized:
-            raise ValueError("question must not be empty")
+            raise ValueError("问题不能为空")
         return self.graph.invoke({"question": normalized})


### PR DESCRIPTION
# Description

This PR adds a text-only **Chinese-language** LangGraph e-commerce customer-service example. It targets LangGraph 1.2+ and uses the supported LangChain 1.x `create_agent` API. An LLM intent router selects a presales or aftersales ReAct agent, each specialist uses a separate synthetic tool set, and a final LLM reviews the response before it is returned.

All customer-facing runtime content is Simplified Chinese, including prompts, fictional product/order/policy values, tool descriptions and errors, CLI output, example questions, and fail-open responses. Stable Python identifiers, graph node names, route enum values, and JSON schema keys remain in English. The Chinese README includes a ready-to-use training walkthrough for the scenario and trace structure.

The example is CLI-only and contains no image input, file upload, browser UI, customer data, or production commerce integration. All products, orders, policies, and tool results are fictional fixtures.

Fixes # (N/A)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] `cd examples/ecommerce-customer-service && uv run --isolated --no-project --with-requirements requirements-dev.txt pytest tests -q`
- [x] `cd examples/ecommerce-customer-service && uv run --isolated --no-project --with-requirements requirements-dev.txt --with 'langgraph==1.2.10' --with 'langchain==1.3.14' --with 'langchain-openai==1.4.1' pytest tests -q`
- [x] `tox -e precommit`
- [x] `python3 .github/scripts/detect_loongsuite_changes.py` with the pull-request changed-file set

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR:
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated (not required for an example-only change; use `Skip Changelog`)
- [x] Unit tests have been added
- [x] Documentation has been updated

## Validation Evidence

### Spec and Scope

- Linked issue/spec: direct feature request; no public issue
- Approved spec/comment: implement a text-only Chinese e-commerce support example without customer data
- Changed surface: bilingual example documentation, Chinese CLI/runtime content, LangGraph workflow, synthetic tools, training walkthrough, and offline tests under `examples/ecommerce-customer-service`

### Local Checks

| Check | Command | Result | Notes |
| --- | --- | --- | --- |
| Static readiness | pipeline readiness checker and changed-file detector | pass | Example-only diff; detector reports no LoongSuite package changes |
| Precommit | `tox -e precommit` | pass | Fresh pre-commit cache; clean worktree afterward |
| Focused tests | commands listed above | pass | 10 tests pass with the declared LangGraph 1.2+ requirements and the pinned current stable 1.2.10 stack |
| Test-first red | N/A | N/A | No instrumentation behavior or bug fix is introduced |
| VCR replay-only | N/A | N/A | Offline tests use deterministic injected model responses and synthetic tools; no cassette is committed |
| External review | earlier two-round diff review plus LangGraph v1 migration review | partial | The Chinese localization diff passed two-round review. The v1 delta was checked against the official migration contract and full tests; the external reviewer could not run because its login had expired. |
| Privacy scan | changed example files | pass | No customer identifiers, credentials, private endpoints, or local paths |

### Business Isolation

| Scenario | Status | Evidence |
| --- | --- | --- |
| prepare/start fault | N/A | No instrumentation wrapper or callback lifecycle changed |
| response mapping/stop fault | pass | Specialist and final-review failures return bounded Chinese fallback responses |
| fail callback fault | N/A | No instrumentation callback changed |
| stream chunk/final callback fault | N/A | The example uses non-streaming invocation |
| early close/cancellation/GeneratorExit | N/A | The example does not expose a stream API |
| cross-task or cross-Context stream | N/A | The example does not expose a stream API |
| clean sibling after fault | pass | Concurrent workflow test proves route and answer state remains isolated |

### Real E2E Matrix

| Scenario | Status | Command or Demo | Evidence |
| --- | --- | --- | --- |
| non-streaming | pass | Chinese text-only deployed smoke on LangGraph 1.2.10 / LangChain 1.3.14 | Eight real Chinese questions returned HTTP 200: presales 3, aftersales 3, clarify 2 |
| streaming | N/A | N/A | The example intentionally exposes a text question/answer invocation only |
| concurrency | pass | `test_concurrent_invocations_keep_routes_and_answers_isolated` | Concurrent states retain separate routes and answers |
| agent/tool/ReAct | pass | Chinese presales and aftersales deployed smoke | Presales and aftersales questions selected different named agents, executed LangGraph v1 model/tool loops, and reached the final reviewer |
| tool-heavy | pass | Chinese product/inventory/knowledge flow | Product search, product knowledge, and inventory tools returned synthetic Chinese evidence before the reviewed answer |
| error path | pass | `test_specialist_and_reviewer_fail_open` and `test_cli_reports_a_chinese_error_for_a_blank_question` | Specialist/reviewer and invalid-input failures return stable Chinese responses without escaping |

### Telemetry and Weaver

| Check | Status | Command or Artifact | Notes |
| --- | --- | --- | --- |
| Span tree / span kinds | pass | Cloud trace readback from the final LangGraph 1.2.10 Pod | Eight fresh business traces were attributed to the final Pod; presales and aftersales samples contain router LLM, selected named AGENT, repeated LLM/TOOL children, and response-review LLM spans |
| Content capture modes | N/A | N/A | This example does not change instrumentation or content-capture behavior |
| Concurrency isolation | N/A | N/A | No instrumentation concurrency behavior changed |
| Weaver live-check | blocked | Registry live-check | The current registry advisor reports a pre-existing duplicated local-variable definition |

### CI

- GitHub checks: the previous revision passed all executable CodeQL, LoongSuite, docs, precommit, typecheck, and CLA checks
- Known unrelated failures: one stale changelog event was created before the `Skip Changelog` label; subsequent PR events see the label
- Follow-up needed: inspect the new revision checks after push
